### PR TITLE
[codex] CI 워크플로를 codingbuddy 스타일로 재구성

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "feat"
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "fix"
+      - "bug"
+      - "bugfix"
+  - title: "Documentation"
+    labels:
+      - "docs"
+      - "documentation"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "ci"
+      - "build"
+      - "refactor"
+      - "test"
+  - title: "Dependencies"
+    labels:
+      - "dependencies"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,142 @@
+name: maximus-dev
+
+on:
+  push:
+    paths:
+      - "bin/**"
+      - "src/**"
+      - "test/**"
+      - ".github/workflows/dev.yml"
+      - ".github/workflows/release-drafter.yml"
+      - ".github/release-drafter.yml"
+      - "package.json"
+      - "README*.md"
+      - "LICENSE"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+  pull_request:
+    paths:
+      - "bin/**"
+      - "src/**"
+      - "test/**"
+      - ".github/workflows/dev.yml"
+      - ".github/workflows/release-drafter.yml"
+      - ".github/release-drafter.yml"
+      - "package.json"
+      - "README*.md"
+      - "LICENSE"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  node-compatibility:
+    name: Node compatibility (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Run unit tests
+        run: npm test
+
+  cli-smoke-check:
+    name: CLI smoke checks (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Smoke test audit
+        run: node ./bin/maximus.js audit ./test/fixtures/clean-project
+
+      - name: Smoke test doctor
+        run: node ./bin/maximus.js doctor ./test/fixtures/clean-project
+
+      - name: Smoke test fix
+        run: node ./bin/maximus.js fix ./test/fixtures/clean-project --dry-run
+
+  readme-consistency-check:
+    name: README consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify multilingual README files and language links
+        run: |
+          files=(
+            README.md
+            README.en.md
+            README.zh-CN.md
+            README.es.md
+            README.ja.md
+          )
+
+          for file in "${files[@]}"; do
+            test -f "$file"
+            grep -q 'README.md' "$file"
+            grep -q 'README.en.md' "$file"
+            grep -q 'README.zh-CN.md' "$file"
+            grep -q 'README.es.md' "$file"
+            grep -q 'README.ja.md' "$file"
+          done
+
+  package-check:
+    name: Package dry run
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Pack package
+        run: |
+          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm pack --json > pack.json
+          node -e "const fs=require('node:fs'); const pack=JSON.parse(fs.readFileSync('pack.json','utf8')); console.log(pack[0].filename);" > tarball.txt
+
+      - name: Smoke test packaged CLI entrypoint
+        run: |
+          tarball="$(cat tarball.txt)"
+          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus audit ./test/fixtures/clean-project
+          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus doctor ./test/fixtures/clean-project
+          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus fix ./test/fixtures/clean-project --dry-run

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: release-drafter.yml

--- a/test/fixtures/clean-project/package.json
+++ b/test/fixtures/clean-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "clean-project",
+  "private": true
+}


### PR DESCRIPTION
# 배경

`Maximus`의 CI를 단일 테스트 워크플로에서 역할 분리형 구조로 재정비했습니다. [codingbuddy](https://github.com/JeremyDev87/codingbuddy)의 운영 방식을 롤모델로 삼되, 현재 `Maximus`의 규모와 배포 준비도에 맞게 `dev` 검증과 `release drafter`만 우선 도입했습니다.

# 변경 사항

- `release-drafter`용 GitHub Actions workflow를 추가했습니다.
- 릴리스 노트 분류 규칙을 `.github/release-drafter.yml`로 분리했습니다.
- 개발 검증용 `dev` workflow를 추가했습니다.
- Node 20, 22, 24에서 테스트와 CLI smoke check를 수행하도록 구성했습니다.
- 패키징 결과물을 `npm pack`으로 만든 뒤, tarball 기준으로 설치 가능한 CLI 엔트리포인트를 검증하도록 구성했습니다.
- 다국어 README 링크 일관성을 확인하는 체크를 추가했습니다.
- repo 자체 상태에 흔들리지 않도록 `test/fixtures/clean-project/package.json` fixture를 추가했습니다.

# 검증

- `npm test`
- `node ./bin/maximus.js audit ./test/fixtures/clean-project`
- `node ./bin/maximus.js doctor ./test/fixtures/clean-project`
- `node ./bin/maximus.js fix ./test/fixtures/clean-project --dry-run`
- `npm pack --json`
- `npm exec --yes --package ./maximus-0.1.0.tgz -- maximus audit ./test/fixtures/clean-project`
- `npm exec --yes --package ./maximus-0.1.0.tgz -- maximus doctor ./test/fixtures/clean-project`
- `npm exec --yes --package ./maximus-0.1.0.tgz -- maximus fix ./test/fixtures/clean-project --dry-run`
- README 언어 링크 일관성 shell check

# 리스크 또는 후속 확인 포인트

- 원격 GitHub 저장소의 실제 default branch가 `master`인지 GitHub 상에서 한 번 더 확인이 필요합니다.
- `codingbuddy`처럼 release 발행 자동화 workflow까지는 아직 넣지 않았습니다. npm 배포 전략과 secret 운영 방식이 정해지면 다음 단계로 추가하는 편이 안전합니다.
