### PR TITLE
[codex] Rust 전환 방향 문서 정리

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Thanks for helping improve Maximus.
 
 This project aims to make config-heavy repositories easier to understand, safer to change, and faster to onboard into. Good contributions usually improve one of those three outcomes.
 
+## Runtime Direction
+
+Maximus is currently in a runtime transition period.
+
+- The executable code in this repository still runs as a Node.js CLI today.
+- The canonical runtime direction is a Rust rewrite.
+- Until the Rust cutover lands, the JS implementation remains the reference implementation for behavior and golden output generation.
+- `docs/plan/001` through `012` should be read as Rust v1 feature specs, not as instructions to extend the JS codebase directly.
+- `docs/plan/013+` and the older JS backlog are deferred until the Rust cutover is complete.
+
+Read [docs/runtime-transition.md](docs/runtime-transition.md) before starting any roadmap-sized work.
+
 ## Ways to Contribute
 
 - Report bugs or false positives in existing checks
@@ -16,6 +28,13 @@ This project aims to make config-heavy repositories easier to understand, safer 
 For larger features or behavior changes, open an issue first so we can agree on scope and expected behavior before code is written.
 
 For small fixes, feel free to open a pull request directly.
+
+If you are working from the local planning docs, use the following rule set:
+
+- Treat `docs/plan/001` through `012` as the source of truth for Rust v1 objectives, target outcomes, public interface changes, tests and acceptance, and done criteria.
+- Do not reuse the JS file lists inside those plan docs as ownership guidance for new implementation work.
+- Do not start `docs/plan/013+` implementation work before the Rust cutover phases are complete.
+- Follow the transition families in order: `062` for direction, `063` for bootstrap/core, `064` for current MVP parity, `065` for backlog `001~012`, `066` for wrapper/cutover/distribution.
 
 ## Development Setup
 
@@ -37,6 +56,8 @@ src/lib/          parsing and filesystem helpers
 test/             regression tests
 ```
 
+Current repository layout reflects the Node.js reference runtime. Rust crates and workspace files will be introduced as the transition proceeds; until then, changes should avoid implying that JS backlog expansion is the default roadmap.
+
 ## Contribution Guidelines
 
 - Keep changes focused. One behavior change per pull request is ideal.
@@ -44,6 +65,7 @@ test/             regression tests
 - Add or update tests when changing detection or fix behavior.
 - Update `README.md` if the user-facing behavior or supported checks change.
 - Avoid destructive fixes unless the user can clearly preview and understand them.
+- If the change belongs to the rewrite roadmap, make sure the wording in README, contributing docs, and transition docs stays aligned.
 
 ## Testing
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,13 +1,13 @@
 # Maximus
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)
 
 <p align="center">
-  <a href="README.md">한국어</a> |
-  <a href="README.en.md">English</a> |
-  <a href="README.zh-CN.md">中文</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.ja.md">日本語</a>
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.md">한국어</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.en.md">English</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.zh-CN.md">中文</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.es.md">Español</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.ja.md">日本語</a>
 </p>
 
 Bring order to chaotic configs.
@@ -15,6 +15,18 @@ Bring order to chaotic configs.
 Maximus is a CLI that audits scattered project configuration files, untangles conflicts and duplication, and helps teams keep their development environment organized.
 
 Modern projects stand on top of countless config layers like `tsconfig`, `eslint`, `prettier`, `vite`, `jest`, `next.config`, and `.env`. Maximus restores order when that setup starts to drift.
+
+## Runtime Transition
+
+Maximus is now prioritizing a Rust rewrite as its canonical runtime direction instead of continuing the JS backlog as the primary implementation path.
+
+- The currently shipped CLI and the executable code in this repository still run on Node.js today.
+- The user-facing command surface stays the same: `npx maximus audit`, `npx maximus doctor`, `npx maximus fix`
+- Until the cutover lands, the current JS runtime stays as the reference implementation.
+- `docs/plan/001` through `012` are no longer treated as direct JS implementation tickets; they are Rust v1 spec inputs.
+- `docs/plan/013+` and the older JS backlog stay deferred until the Rust cutover is complete.
+
+See the [runtime transition document](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) for the transition boundary, phase map, and contributor rules.
 
 ## What It Does
 
@@ -81,6 +93,8 @@ node ./bin/maximus.js audit
 node ./bin/maximus.js fix --dry-run
 ```
 
+These local commands continue to validate the current Node.js reference implementation. Even after the Rust bootstrap starts, user-facing command examples stay in the `npx maximus ...` form.
+
 ## Recommended For
 
 - Teams running monorepos or multi-package repositories
@@ -89,11 +103,11 @@ node ./bin/maximus.js fix --dry-run
 
 ## Contributing
 
-Contributions are welcome. If you want to add a new check, improve fix safety, or reduce false positives, start with [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/main/CONTRIBUTING.md).
+Contributions are welcome. If you want to add a new check, improve fix safety, or reduce false positives, start with [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) and the [runtime transition document](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) first, because the active priority is the Rust rewrite family rather than direct JS backlog expansion.
 
 ## Security
 
-If you believe you found a security issue, please do not open a public issue first. Use [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/main/SECURITY.md) for the private reporting path.
+If you believe you found a security issue, please do not open a public issue first. Use [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/master/SECURITY.md) for the private reporting path.
 
 ## Sponsor
 
@@ -101,4 +115,4 @@ If Maximus helps your team keep config chaos under control, you can support ongo
 
 ## License
 
-Maximus is released under the [MIT License](https://github.com/JeremyDev87/maximus/blob/main/LICENSE).
+Maximus is released under the [MIT License](https://github.com/JeremyDev87/maximus/blob/master/LICENSE).

--- a/README.es.md
+++ b/README.es.md
@@ -1,13 +1,13 @@
 # Maximus
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)
 
 <p align="center">
-  <a href="README.md">한국어</a> |
-  <a href="README.en.md">English</a> |
-  <a href="README.zh-CN.md">中文</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.ja.md">日本語</a>
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.md">한국어</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.en.md">English</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.zh-CN.md">中文</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.es.md">Español</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.ja.md">日本語</a>
 </p>
 
 Pon orden en configuraciones caóticas.
@@ -15,6 +15,18 @@ Pon orden en configuraciones caóticas.
 Maximus es una CLI que audita archivos de configuración dispersos por todo un proyecto, ordena conflictos y duplicaciones, y ayuda a los equipos a mantener un entorno de desarrollo limpio y coherente.
 
 Los proyectos modernos se apoyan en muchas capas de configuración como `tsconfig`, `eslint`, `prettier`, `vite`, `jest`, `next.config` y `.env`. Maximus restaura el orden cuando esa configuración empieza a desviarse.
+
+## Transición de Runtime
+
+Maximus ahora prioriza una reescritura en Rust como su dirección de runtime canónico, en lugar de seguir ampliando el backlog de JS como ruta principal de implementación.
+
+- La CLI publicada actualmente y el código ejecutable de este repositorio todavía funcionan sobre Node.js.
+- La superficie de comandos para usuarios se mantiene igual: `npx maximus audit`, `npx maximus doctor`, `npx maximus fix`
+- Hasta que llegue el cutover, el runtime actual en JS se mantiene como reference implementation.
+- `docs/plan/001` hasta `012` ya no deben leerse como tareas directas para ampliar el código JS; ahora son spec inputs para Rust v1.
+- `docs/plan/013+` y el backlog JS anterior permanecen en estado deferred hasta que termine el Rust cutover.
+
+Consulta el [documento de runtime transition](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) para ver el límite de la transición, las fases y las reglas para contribuir.
 
 ## Qué Hace
 
@@ -81,6 +93,8 @@ node ./bin/maximus.js audit
 node ./bin/maximus.js fix --dry-run
 ```
 
+Estos comandos locales siguen validando la reference implementation actual en Node.js. Incluso después de iniciar el Rust bootstrap, los ejemplos para usuarios se mantienen con la forma `npx maximus ...`.
+
 ## Recomendado Para
 
 - Equipos que operan monorepos o repositorios con múltiples paquetes
@@ -89,11 +103,11 @@ node ./bin/maximus.js fix --dry-run
 
 ## Contribuir
 
-Las contribuciones son bienvenidas. Si quieres añadir una nueva verificación, mejorar la seguridad de las correcciones automáticas o reducir falsos positivos, empieza por [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/main/CONTRIBUTING.md).
+Las contribuciones son bienvenidas. Si quieres añadir una nueva verificación, mejorar la seguridad de las correcciones automáticas o reducir falsos positivos, empieza por [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) y por el [documento de runtime transition](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md), porque la prioridad activa es la familia de reescritura en Rust y no la expansión directa del backlog JS.
 
 ## Seguridad
 
-Si crees que encontraste un problema de seguridad, no abras primero un issue público. Usa [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/main/SECURITY.md) para el proceso de reporte privado.
+Si crees que encontraste un problema de seguridad, no abras primero un issue público. Usa [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/master/SECURITY.md) para el proceso de reporte privado.
 
 ## Sponsor
 
@@ -101,4 +115,4 @@ Si Maximus ayuda a tu equipo a mantener bajo control el caos de configuración, 
 
 ## Licencia
 
-Maximus se distribuye bajo la [MIT License](https://github.com/JeremyDev87/maximus/blob/main/LICENSE).
+Maximus se distribuye bajo la [MIT License](https://github.com/JeremyDev87/maximus/blob/master/LICENSE).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,13 +1,13 @@
 # Maximus
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)
 
 <p align="center">
-  <a href="README.md">한국어</a> |
-  <a href="README.en.md">English</a> |
-  <a href="README.zh-CN.md">中文</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.ja.md">日本語</a>
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.md">한국어</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.en.md">English</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.zh-CN.md">中文</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.es.md">Español</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.ja.md">日本語</a>
 </p>
 
 混沌とした設定に秩序を。
@@ -15,6 +15,18 @@
 Maximus は、プロジェクトのあちこちに散らばった設定ファイルを監査し、競合や重複を整理して、整った開発環境を作るための CLI です。
 
 現代のプロジェクトは `tsconfig`、`eslint`、`prettier`、`vite`、`jest`、`next.config`、`.env` など数多くの設定の上に成り立っています。Maximus は、その構成が崩れ始めたときに秩序を取り戻します。
+
+## ランタイム移行
+
+Maximus は現在、JS backlog の拡張を主な実装経路として続けるのではなく、Rust への再実装を canonical runtime の方向として優先しています。
+
+- 現在公開されている CLI と、このリポジトリ内の実行コードはまだ Node.js 上で動作しています。
+- ユーザー向けコマンドの表面は維持されます: `npx maximus audit`、`npx maximus doctor`、`npx maximus fix`
+- cutover が完了するまでは、現在の JS runtime は reference implementation として残ります。
+- `docs/plan/001` から `012` は、もはや JS 実装を直接拡張するためのチケットではなく、Rust v1 の spec input として扱います。
+- `docs/plan/013+` と既存の JS backlog は、Rust cutover が完了するまで deferred のままです。
+
+移行境界、フェーズ構成、コントリビューター向けルールは [runtime transition ドキュメント](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) を参照してください。
 
 ## 主な機能
 
@@ -81,6 +93,8 @@ node ./bin/maximus.js audit
 node ./bin/maximus.js fix --dry-run
 ```
 
+これらのローカルコマンドは、引き続き現在の Node.js reference implementation を検証します。Rust bootstrap が始まった後も、ユーザー向けのコマンド例は `npx maximus ...` の形を保ちます。
+
 ## こんなチームにおすすめ
 
 - モノレポ / マルチパッケージを運用するチーム
@@ -89,11 +103,11 @@ node ./bin/maximus.js fix --dry-run
 
 ## コントリビュート
 
-新しいチェックの追加、自動修正の安全性向上、false positive の削減などの貢献を歓迎します。まずは [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/main/CONTRIBUTING.md) を確認してください。
+新しいチェックの追加、自動修正の安全性向上、false positive の削減などの貢献を歓迎します。まずは [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) と [runtime transition ドキュメント](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) を確認してください。現在の優先順位は JS backlog の直接拡張ではなく、Rust rewrite family です。
 
 ## セキュリティ
 
-セキュリティ上の問題を見つけた可能性がある場合は、まず公開 issue を作成しないでください。非公開の報告手順は [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/main/SECURITY.md) を参照してください。
+セキュリティ上の問題を見つけた可能性がある場合は、まず公開 issue を作成しないでください。非公開の報告手順は [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/master/SECURITY.md) を参照してください。
 
 ## スポンサー
 
@@ -101,4 +115,4 @@ Maximus がチームの設定混乱を減らすのに役立っているなら、
 
 ## ライセンス
 
-Maximus は [MIT License](https://github.com/JeremyDev87/maximus/blob/main/LICENSE) のもとで公開されています。
+Maximus は [MIT License](https://github.com/JeremyDev87/maximus/blob/master/LICENSE) のもとで公開されています。

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Maximus
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)
 
 <p align="center">
-  <a href="README.md">한국어</a> |
-  <a href="README.en.md">English</a> |
-  <a href="README.zh-CN.md">中文</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.ja.md">日本語</a>
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.md">한국어</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.en.md">English</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.zh-CN.md">中文</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.es.md">Español</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.ja.md">日本語</a>
 </p>
 
 혼란스러운 설정에 질서를.
@@ -15,6 +15,18 @@
 Maximus는 프로젝트 곳곳에 흩어진 설정 파일을 점검하고, 충돌과 중복을 정리하며 질서 있는 개발환경을 만드는 CLI입니다.
 
 현대 프로젝트는 `tsconfig`, `eslint`, `prettier`, `vite`, `jest`, `next.config`, `.env` 등 수많은 설정 위에 서 있습니다. Maximus는 무너진 질서를 다시 세웁니다.
+
+## 런타임 전환 방향
+
+Maximus의 canonical runtime 방향은 이제 Node.js 확장이 아니라 Rust 재작성입니다.
+
+- 현재 배포된 CLI와 이 저장소의 실행 구현은 아직 Node.js 기준입니다.
+- 사용자 명령 표면은 유지합니다: `npx maximus audit`, `npx maximus doctor`, `npx maximus fix`
+- Rust cutover 전까지 현재 JS 코드는 reference implementation으로 유지됩니다.
+- `docs/plan/001`~`012`는 더 이상 JS 구현 TODO가 아니라 Rust v1 spec input으로 사용합니다.
+- `docs/plan/013+`와 기존 JS backlog는 Rust cutover가 끝날 때까지 defer 상태입니다.
+
+전환 범위와 단계별 역할은 [runtime transition 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)에서 확인할 수 있습니다.
 
 ## 주요 기능
 
@@ -81,6 +93,8 @@ node ./bin/maximus.js audit
 node ./bin/maximus.js fix --dry-run
 ```
 
+현재 로컬 개발 명령은 Node.js reference 구현을 기준으로 유지됩니다. Rust bootstrap 이후에도 사용자-facing 명령 예시는 계속 `npx maximus ...` 형태를 유지합니다.
+
 ## 이런 팀에 추천
 
 - 모노레포 / 멀티패키지 운영 팀
@@ -89,11 +103,11 @@ node ./bin/maximus.js fix --dry-run
 
 ## 기여하기
 
-새로운 점검기 추가, 자동 수정 안전성 개선, false positive 감소 같은 기여를 환영합니다. 시작점은 [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/main/CONTRIBUTING.md)에서 확인할 수 있습니다.
+새로운 점검기 추가, 자동 수정 안전성 개선, false positive 감소 같은 기여를 환영합니다. 다만 현재 우선순위는 JS backlog 직접 확장이 아니라 Rust rewrite family입니다. 기여 시작 전에는 [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md)와 [runtime transition 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)를 먼저 확인해 주세요.
 
 ## 보안
 
-보안 이슈가 의심된다면 공개 이슈부터 열지 말고 [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/main/SECURITY.md)의 비공개 신고 절차를 따라 주세요.
+보안 이슈가 의심된다면 공개 이슈부터 열지 말고 [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/master/SECURITY.md)의 비공개 신고 절차를 따라 주세요.
 
 ## 스폰서
 
@@ -101,4 +115,4 @@ Maximus가 팀의 설정 혼란을 줄이는 데 도움이 된다면 [GitHub Spo
 
 ## 라이선스
 
-Maximus는 [MIT License](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)로 배포됩니다.
+Maximus는 [MIT License](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)로 배포됩니다.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,13 +1,13 @@
 # Maximus
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/JeremyDev87/maximus/blob/master/LICENSE)
 
 <p align="center">
-  <a href="README.md">한국어</a> |
-  <a href="README.en.md">English</a> |
-  <a href="README.zh-CN.md">中文</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.ja.md">日本語</a>
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.md">한국어</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.en.md">English</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.zh-CN.md">中文</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.es.md">Español</a> |
+  <a href="https://github.com/JeremyDev87/maximus/blob/master/README.ja.md">日本語</a>
 </p>
 
 为混乱的配置重建秩序。
@@ -15,6 +15,18 @@
 Maximus 是一个 CLI，用来检查散落在项目各处的配置文件，整理冲突与重复项，并帮助团队维持有序的开发环境。
 
 现代项目建立在大量配置之上，例如 `tsconfig`、`eslint`、`prettier`、`vite`、`jest`、`next.config`、`.env` 等。Maximus 可以在这些配置开始失控时重新建立秩序。
+
+## 运行时迁移方向
+
+Maximus 现在优先推进 Rust 重写，并将其作为 canonical runtime 方向，而不是继续把 JS backlog 扩展当作默认实现路径。
+
+- 当前发布的 CLI 和此仓库中的可执行实现今天仍然运行在 Node.js 上。
+- 面向用户的命令入口保持不变：`npx maximus audit`、`npx maximus doctor`、`npx maximus fix`
+- 在 cutover 完成之前，当前 JS runtime 仍作为 reference implementation 保留。
+- `docs/plan/001` 到 `012` 不再被视为直接扩展 JS 的任务，而是 Rust v1 的 spec input。
+- `docs/plan/013+` 和旧的 JS backlog 会在 Rust cutover 完成前保持 defer 状态。
+
+迁移边界、阶段划分和贡献规则可见 [runtime transition 文档](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)。
 
 ## 功能
 
@@ -81,6 +93,8 @@ node ./bin/maximus.js audit
 node ./bin/maximus.js fix --dry-run
 ```
 
+这些本地命令目前仍用于验证 Node.js reference implementation。即使 Rust bootstrap 开始后，面向用户的命令示例也继续保持 `npx maximus ...` 形式。
+
 ## 适合这些团队
 
 - 维护 monorepo / 多包仓库的团队
@@ -89,11 +103,11 @@ node ./bin/maximus.js fix --dry-run
 
 ## 贡献
 
-欢迎贡献。如果你想添加新的检查项、提升自动修复的安全性，或者减少误报，请先阅读 [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/main/CONTRIBUTING.md)。
+欢迎贡献。如果你想添加新的检查项、提升自动修复的安全性，或者减少误报，请先阅读 [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) 和 [runtime transition 文档](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)，因为当前优先级是 Rust rewrite family，而不是直接扩展 JS backlog。
 
 ## 安全
 
-如果你怀疑发现了安全问题，请不要先公开提 issue。请按照 [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/main/SECURITY.md) 中的私密报告流程进行报告。
+如果你怀疑发现了安全问题，请不要先公开提 issue。请按照 [SECURITY.md](https://github.com/JeremyDev87/maximus/blob/master/SECURITY.md) 中的私密报告流程进行报告。
 
 ## 赞助
 
@@ -101,4 +115,4 @@ node ./bin/maximus.js fix --dry-run
 
 ## 许可证
 
-Maximus 基于 [MIT License](https://github.com/JeremyDev87/maximus/blob/main/LICENSE) 发布。
+Maximus 基于 [MIT License](https://github.com/JeremyDev87/maximus/blob/master/LICENSE) 发布。

--- a/docs/runtime-transition.md
+++ b/docs/runtime-transition.md
@@ -1,0 +1,78 @@
+# Runtime Transition
+
+Maximus is moving from a Node.js runtime implementation to a Rust runtime implementation.
+
+This document defines the transition boundary so roadmap work, contributor expectations, and user-facing docs all point at the same direction.
+
+## Current State
+
+- The published CLI behavior is currently implemented by the Node.js runtime in `bin/maximus.js` and `src/**/*.js`.
+- Local development and regression commands still validate that Node.js implementation today.
+- The user-facing command surface must remain stable during the transition:
+  - `npx maximus audit`
+  - `npx maximus doctor`
+  - `npx maximus fix`
+
+## Canonical Runtime Direction
+
+- The canonical runtime direction for Maximus is Rust.
+- The current JS runtime is kept as a reference implementation until the cutover is complete.
+- The cutover does not change the primary command surface; it changes the implementation behind that surface.
+
+## Scope Freeze
+
+The local planning docs are split into two groups during the rewrite:
+
+- `docs/plan/001` through `docs/plan/012`
+  - These remain active inputs for Rust v1.
+  - Their authoritative sections are:
+    - `Objective`
+    - `Target Outcome`
+    - `Public Interface Changes`
+    - `Tests And Acceptance`
+    - `Done Criteria`
+  - Their JS file lists, PR units, and Node verification commands are legacy reference only.
+- `docs/plan/013+`
+  - These are post-cutover backlog items.
+  - They stay deferred until the Rust cutover is complete.
+
+This means contributors should not directly resume the older JS backlog as the default execution path.
+
+## Transition Families
+
+The rewrite is organized into five roadmap families:
+
+1. `062` Rust rewrite master roadmap
+   - Declares the runtime direction and freezes the older JS backlog as the default implementation lane.
+2. `063` Rust bootstrap and core
+   - Adds the toolchain, Cargo workspace, JS golden reference harness, and Rust pure-library foundations.
+3. `064` Rust current MVP parity
+   - Rebuilds the currently shipped `audit`, `doctor`, `fix`, `--json`, and env fix behavior in Rust.
+4. `065` Rust v1 backlog `001~012`
+   - Ports the accepted v1 feature contracts that go beyond today's shipped MVP.
+5. `066` Rust npm wrapper, cutover, and distribution
+   - Connects the Rust binary to the npm wrapper, GitHub Action, release flow, and final runtime cutover.
+
+## Distribution Surface
+
+The long-term distribution contract stays familiar for users:
+
+- `npx maximus ...` remains the main invocation path.
+- The root npm package name and `bin.maximus` entry stay stable.
+- After cutover, the npm package becomes a thin launcher for platform-specific Rust binaries.
+
+## Contributor Rules
+
+- Do not treat `001~012` as approval to expand the JS codebase first.
+- Do not start `013+` roadmap work before the Rust cutover phases are done.
+- Keep README, contributing docs, CI, wrapper plans, and roadmap terminology aligned when transition wording changes.
+- When in doubt, prefer preserving the user-facing CLI contract while moving implementation responsibility into Rust.
+
+## Exit Condition
+
+The transition is complete when all of the following are true:
+
+- Rust reproduces the currently shipped MVP behavior.
+- Rust implements the accepted `001~012` feature contracts.
+- The npm wrapper and GitHub Action run the Rust runtime.
+- Maximus documentation treats Rust as the canonical runtime and the JS runtime as frozen reference code.


### PR DESCRIPTION
# 배경

`TODO.md` 기준 우선순위인 `P062-A`를 먼저 반영했습니다. 이번 PR은 Maximus의 canonical runtime 방향을 Rust 재작성으로 고정하고, 기존 JS backlog를 기본 실행 경로로 보지 않도록 공개 문서에 기준을 세우는 작업입니다.

# 변경 사항

- 한국어/영문 README에 Rust runtime transition 방향과 JS backlog freeze 정책을 추가했습니다.
- 새 문서 `docs/runtime-transition.md`를 추가해 cut line, transition family, distribution surface를 한곳에 정리했습니다.
- `CONTRIBUTING.md`에 Rust v1 spec 해석 규칙과 기여 시 참고해야 할 transition 기준을 추가했습니다.
- 중국어/스페인어/일본어 README도 같은 전환 정책과 `master` 브랜치 링크 기준으로 동기화했습니다.
- npm README 렌더링에서도 안전하도록 README 언어 전환 링크를 GitHub 절대 링크로 정리했습니다.

# 검증

- `npm test`
- `env npm_config_cache=/tmp/maximus-npm-cache npm pack --dry-run`

# 리스크 또는 후속 확인 포인트

- 이번 PR은 문서 단계인 `P062-A`까지만 다룹니다. Cargo workspace 생성이나 Rust 코드 포팅은 다음 단계인 `P063-A`부터 진행됩니다.
- `docs/plan/` 문서는 local-only 계획 자산으로 계속 운영되므로, 실제 공개 계약은 README / CONTRIBUTING / `docs/runtime-transition.md` 기준으로 보는 편이 안전합니다.
