### PR TITLE
[codex] JS reference golden harness 추가

### DIFF
--- a/test/fixtures/reference-env/.env
+++ b/test/fixtures/reference-env/.env
@@ -1,0 +1,2 @@
+API_URL=http://localhost:3000
+AUTH_TOKEN=supersecretvalue12345

--- a/test/fixtures/reference-tsconfig/package.json
+++ b/test/fixtures/reference-tsconfig/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "reference-tsconfig",
+  "private": true
+}

--- a/test/fixtures/reference-tsconfig/tsconfig.json
+++ b/test/fixtures/reference-tsconfig/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@missing/*": ["ghost/*"]
+    }
+  }
+}

--- a/test/golden-rust/clean-project.audit.txt
+++ b/test/golden-rust/clean-project.audit.txt
@@ -1,0 +1,13 @@
+Maximus audit
+Target: <TARGET>
+
+Status: clean
+Findings: 0 error, 0 warnings, 0 info
+Fixes available: 0
+
+Structure: single package, 1 package(s), 1 config file(s), 0 env folder(s)
+
+No config drift detected.
+
+Recommendations
+- Current config surface looks healthy. Keep shared rules centralized as the repo grows.

--- a/test/golden-rust/clean-project.doctor.txt
+++ b/test/golden-rust/clean-project.doctor.txt
@@ -1,0 +1,14 @@
+Maximus doctor
+Target: <TARGET>
+
+Diagnosis: clean
+Project shape: single package, 1 package(s), 1 config file(s), 0 env folder(s)
+
+Prescription
+- No automatic fixes are currently available.
+- No manual follow-up is required right now.
+
+No config drift detected.
+
+Recommended structure
+- Current config surface looks healthy. Keep shared rules centralized as the repo grows.

--- a/test/golden-rust/env-missing-example.audit.txt
+++ b/test/golden-rust/env-missing-example.audit.txt
@@ -1,0 +1,14 @@
+Maximus audit
+Target: <TARGET>
+
+Status: attention needed
+Findings: 0 error, 1 warnings, 0 info
+Fixes available: 1
+
+Structure: single package, 0 package(s), 1 config file(s), 1 env folder(s)
+
+Findings
+- [warn] Missing .env.example contract
+  file: .env
+  detail: Runtime env files exist, but .env.example is missing.
+  hint: Run "maximus fix" to create a blank contract file.

--- a/test/golden-rust/env-missing-example.fix-dry-run.txt
+++ b/test/golden-rust/env-missing-example.fix-dry-run.txt
@@ -1,0 +1,12 @@
+Maximus fix
+Target: <TARGET>
+
+Dry run: 1 safe fix(es) available.
+
+Post-check: 0 error, 1 warnings, 0 info
+
+Remaining findings
+- [warn] Missing .env.example contract
+  file: .env
+  detail: Runtime env files exist, but .env.example is missing.
+  hint: Run "maximus fix" to create a blank contract file.

--- a/test/golden-rust/tsconfig-missing-alias.audit.txt
+++ b/test/golden-rust/tsconfig-missing-alias.audit.txt
@@ -1,0 +1,14 @@
+Maximus audit
+Target: <TARGET>
+
+Status: blocking issues
+Findings: 1 error, 0 warnings, 0 info
+Fixes available: 0
+
+Structure: single package, 1 package(s), 2 config file(s), 0 env folder(s)
+
+Findings
+- [error] Path alias target does not exist
+  file: tsconfig.json
+  detail: @missing/* points to ghost/*, but the resolved path was not found.
+  hint: Update or remove stale aliases before they break editor and build resolution.

--- a/test/reference-parity.test.js
+++ b/test/reference-parity.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "..");
+
+const scenarios = [
+  {
+    name: "clean-project audit output stays stable",
+    args: ["audit", "./test/fixtures/clean-project"],
+    goldenFile: "clean-project.audit.txt",
+    expectedStatus: 0,
+    targetDir: path.join(repoRoot, "test", "fixtures", "clean-project"),
+  },
+  {
+    name: "clean-project doctor output stays stable",
+    args: ["doctor", "./test/fixtures/clean-project"],
+    goldenFile: "clean-project.doctor.txt",
+    expectedStatus: 0,
+    targetDir: path.join(repoRoot, "test", "fixtures", "clean-project"),
+  },
+  {
+    name: "reference env audit output stays stable",
+    args: ["audit", "./test/fixtures/reference-env"],
+    goldenFile: "env-missing-example.audit.txt",
+    expectedStatus: 1,
+    targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
+  },
+  {
+    name: "reference env fix dry-run output stays stable",
+    args: ["fix", "./test/fixtures/reference-env", "--dry-run"],
+    goldenFile: "env-missing-example.fix-dry-run.txt",
+    expectedStatus: 1,
+    targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
+  },
+  {
+    name: "reference tsconfig audit output stays stable",
+    args: ["audit", "./test/fixtures/reference-tsconfig"],
+    goldenFile: "tsconfig-missing-alias.audit.txt",
+    expectedStatus: 1,
+    targetDir: path.join(repoRoot, "test", "fixtures", "reference-tsconfig"),
+  },
+];
+
+for (const scenario of scenarios) {
+  test(scenario.name, async () => {
+    const result = spawnSync(process.execPath, ["./bin/maximus.js", ...scenario.args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, scenario.expectedStatus, result.stderr);
+
+    const actual = normalizeOutput(result.stdout, scenario.targetDir);
+    const golden = normalizeOutput(
+      await readFile(path.join(repoRoot, "test", "golden-rust", scenario.goldenFile), "utf8"),
+      scenario.targetDir,
+    );
+
+    assert.equal(actual, golden);
+  });
+}
+
+function normalizeOutput(output, targetDir) {
+  return output.replaceAll("\r\n", "\n").replaceAll(targetDir, "<TARGET>").trimEnd();
+}


### PR DESCRIPTION
# 배경

`TODO.md`의 Rust rewrite 우선순위에 따라 `P063-B`를 진행했습니다. 이번 PR은 현재 JS CLI 출력 결과를 reference golden artifact로 고정해서, 이후 Rust parity 구현이 무엇과 같아야 하는지 테스트 자산으로 명확히 만드는 작업입니다.

# 변경 사항

- `test/golden-rust/` 아래에 현재 JS CLI 기준 golden 출력 5개를 추가했습니다.
- `test/reference-parity.test.js`를 추가해 golden 파일과 실제 CLI 출력이 계속 일치하는지 검증하도록 했습니다.
- `reference-env`, `reference-tsconfig` fixture를 추가해 env missing example / tsconfig missing alias 시나리오를 고정했습니다.
- parity 비교 시 절대 경로는 `<TARGET>`으로 정규화해 로컬/CI 경로 차이 때문에 golden이 깨지지 않도록 했습니다.

# 검증

- `node --test test/reference-parity.test.js`
- `npm test`

# 리스크 또는 후속 확인 포인트

- 이번 PR은 text output golden만 고정합니다. `--json` parity와 stderr 동작은 아직 범위 밖입니다.
- 다음 단계인 `P063-C`에서 Rust core pure library 계층을 옮기면서 이 golden 자산을 참조 기준으로 사용하게 됩니다.
