### PR TITLE
[codex] Rust CLI skeleton 추가

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -59,11 +59,19 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
       - name: Validate Cargo workspace metadata
         run: cargo metadata --format-version 1 --no-deps
 
       - name: Run Rust core tests
         run: cargo test -p maximus-core
+
+      - name: Run Rust CLI tests
+        run: cargo test -p maximus-cli
 
   node-compatibility:
     name: Node compatibility (Node ${{ matrix.node }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,12 @@ version = "0.1.0"
 [[package]]
 name = "maximus-cli"
 version = "0.1.0"
+dependencies = [
+ "maximus-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "maximus-core"

--- a/crates/maximus-cli/Cargo.toml
+++ b/crates/maximus-cli/Cargo.toml
@@ -10,3 +10,11 @@ description = "Rust CLI bootstrap crate for Maximus."
 [[bin]]
 name = "maximus"
 path = "src/main.rs"
+
+[dependencies]
+maximus-core = { path = "../maximus-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -1,0 +1,89 @@
+use std::ffi::OsString;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Flags {
+    pub dry_run: bool,
+    pub help: bool,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParsedArgs {
+    pub command: Option<String>,
+    pub args: Vec<OsString>,
+    pub flags: Flags,
+}
+
+pub fn parse_args<I, S>(argv: I) -> ParsedArgs
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    let mut args = Vec::new();
+    let mut flags = Flags::default();
+
+    for token in argv.into_iter().map(Into::into) {
+        match token.to_str() {
+            Some("--dry-run") => flags.dry_run = true,
+            Some("--json") => flags.json = true,
+            Some("--help") | Some("-h") => flags.help = true,
+            _ => args.push(token),
+        }
+    }
+
+    ParsedArgs {
+        command: args.first().map(|value| value.to_string_lossy().into_owned()),
+        args: args.into_iter().skip(1).collect(),
+        flags,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{parse_args, Flags, ParsedArgs};
+
+    #[test]
+    fn parse_args_collects_known_flags_and_positionals() {
+        let parsed = parse_args(["fix", "./repo", "--dry-run", "--json"]);
+
+        assert_eq!(
+            parsed,
+            ParsedArgs {
+                command: Some("fix".to_string()),
+                args: vec![OsString::from("./repo")],
+                flags: Flags {
+                    dry_run: true,
+                    help: false,
+                    json: true,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_treats_unknown_tokens_as_positionals() {
+        let parsed = parse_args(["audit", "--mystery", "target"]);
+
+        assert_eq!(parsed.command.as_deref(), Some("audit"));
+        assert_eq!(
+            parsed.args,
+            vec![OsString::from("--mystery"), OsString::from("target")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_args_keeps_non_utf8_positionals_without_panicking() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let parsed = parse_args([
+            OsString::from("audit"),
+            OsString::from_vec(vec![0x66, 0x6f, 0x80, 0x6f]),
+        ]);
+
+        assert_eq!(parsed.command.as_deref(), Some("audit"));
+        assert_eq!(parsed.args.len(), 1);
+    }
+}

--- a/crates/maximus-cli/src/exit_codes.rs
+++ b/crates/maximus-cli/src/exit_codes.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use maximus_core::AuditSummary;
+
+pub const SUCCESS: i32 = 0;
+pub const FINDINGS_PRESENT: i32 = 1;
+pub const FAILURE: i32 = 2;
+
+pub fn audit_exit_code(summary: &AuditSummary) -> i32 {
+    if summary.blocking_findings > 0 || summary.warning_findings > 0 {
+        FINDINGS_PRESENT
+    } else {
+        SUCCESS
+    }
+}
+
+pub fn fix_exit_code(summary: &AuditSummary) -> i32 {
+    audit_exit_code(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use maximus_core::AuditSummary;
+
+    use super::{audit_exit_code, fix_exit_code, FINDINGS_PRESENT, SUCCESS};
+
+    #[test]
+    fn exit_codes_follow_js_cli_contract() {
+        let clean = AuditSummary {
+            status: "clean".to_string(),
+            total_findings: 0,
+            blocking_findings: 0,
+            warning_findings: 0,
+            info_findings: 0,
+            fixable_findings: 0,
+            fixes_available: 0,
+            config_files: 1,
+            package_count: 1,
+            env_directories: 0,
+        };
+
+        let noisy = AuditSummary {
+            warning_findings: 1,
+            ..clean.clone()
+        };
+
+        assert_eq!(audit_exit_code(&clean), SUCCESS);
+        assert_eq!(fix_exit_code(&clean), SUCCESS);
+        assert_eq!(audit_exit_code(&noisy), FINDINGS_PRESENT);
+        assert_eq!(fix_exit_code(&noisy), FINDINGS_PRESENT);
+    }
+}

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -1,1 +1,256 @@
-fn main() {}
+mod args;
+mod exit_codes;
+mod report_json;
+mod report_text;
+
+use std::env;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::process::Command;
+
+use serde::Serialize;
+
+use crate::args::{parse_args, Flags};
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AppliedFix {
+    pub id: String,
+    pub title: String,
+    pub files: Vec<PathBuf>,
+    pub outcome: Option<String>,
+}
+
+#[derive(Debug)]
+enum CliError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    UnknownCommand(String),
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Json(error) => write!(f, "{error}"),
+            Self::UnknownCommand(command) => {
+                write!(f, "Unknown command \"{command}\". Run \"maximus help\" for usage.")
+            }
+        }
+    }
+}
+
+impl Error for CliError {}
+
+impl From<io::Error> for CliError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for CliError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+fn main() {
+    let exit_code = match run_cli(env::args_os().skip(1)) {
+        Ok(exit_code) => exit_code,
+        Err(error) => {
+            eprintln!("Maximus failed: {error}");
+            exit_codes::FAILURE
+        }
+    };
+
+    process::exit(exit_code);
+}
+
+fn run_cli<I, S>(argv: I) -> Result<i32, CliError>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<std::ffi::OsString>,
+{
+    let parsed = parse_args(argv);
+
+    if parsed.command.is_none()
+        || parsed.command.as_deref() == Some("help")
+        || parsed.flags.help
+    {
+        println!("{}", report_text::format_help());
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    let target_dir = resolve_target_dir(parsed.args.first().map(|value| value.as_os_str()))?;
+
+    match parsed.command.as_deref() {
+        Some("audit") => delegate_to_js("audit", &target_dir, &parsed.flags),
+        Some("doctor") => delegate_to_js("doctor", &target_dir, &parsed.flags),
+        Some("fix") => delegate_to_js("fix", &target_dir, &parsed.flags),
+        Some(command) => Err(CliError::UnknownCommand(command.to_string())),
+        None => Ok(exit_codes::SUCCESS),
+    }
+}
+
+fn resolve_target_dir(path_arg: Option<&OsStr>) -> io::Result<PathBuf> {
+    match path_arg {
+        Some(path) => std::path::absolute(PathBuf::from(path)),
+        None => env::current_dir(),
+    }
+}
+
+fn delegate_to_js(command: &str, target_dir: &Path, flags: &Flags) -> Result<i32, CliError> {
+    let mut child = Command::new("node");
+    child.arg(resolve_reference_cli_entrypoint()?);
+    child.arg(command);
+    child.arg(target_dir);
+
+    if flags.dry_run {
+        child.arg("--dry-run");
+    }
+
+    if flags.json {
+        child.arg("--json");
+    }
+
+    let output = child.output()?;
+
+    if !output.stdout.is_empty() {
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+
+    if !output.stderr.is_empty() {
+        eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(output.status.code().unwrap_or(exit_codes::FAILURE))
+}
+
+fn resolve_reference_cli_entrypoint() -> Result<PathBuf, CliError> {
+    let search_roots = build_reference_cli_search_roots()?;
+
+    find_reference_cli_from_roots(search_roots).ok_or_else(|| {
+        CliError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            "could not find bin/maximus.js from the current runtime context; run inside the repository checkout or set MAXIMUS_REPO_ROOT",
+        ))
+    })
+}
+
+fn build_reference_cli_search_roots() -> io::Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+
+    if let Some(repo_root) = env::var_os("MAXIMUS_REPO_ROOT") {
+        roots.push(PathBuf::from(repo_root));
+    }
+
+    roots.extend(ancestor_paths(env::current_exe()?));
+
+    Ok(roots)
+}
+
+fn ancestor_paths(path: PathBuf) -> Vec<PathBuf> {
+    let start = if path.is_file() {
+        path.parent().map(Path::to_path_buf).unwrap_or(path)
+    } else {
+        path
+    };
+
+    start.ancestors().map(Path::to_path_buf).collect()
+}
+
+fn find_reference_cli_from_roots<I>(roots: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    for root in roots {
+        let candidate = root.join("bin/maximus.js");
+        if candidate.is_file() && root.join("package.json").is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use super::{ancestor_paths, find_reference_cli_from_roots};
+
+    #[test]
+    fn ancestor_paths_include_parent_chain_for_files() {
+        let path = PathBuf::from("/tmp/repo/target/debug/maximus");
+        let ancestors = ancestor_paths(path);
+
+        assert!(ancestors.contains(&PathBuf::from("/tmp/repo/target/debug")));
+        assert!(ancestors.contains(&PathBuf::from("/tmp/repo/target")));
+        assert!(ancestors.contains(&PathBuf::from("/tmp/repo")));
+    }
+
+    #[test]
+    fn reference_cli_path_is_found_from_nested_runtime_roots() {
+        let temp = tempdir().expect("temp dir should exist");
+        let repo_root = temp.path().join("repo");
+        let nested_dir = repo_root.join("target/debug/deps");
+        let bin_dir = repo_root.join("bin");
+
+        fs::create_dir_all(&nested_dir).expect("nested dir should exist");
+        fs::create_dir_all(&bin_dir).expect("bin dir should exist");
+        fs::write(repo_root.join("package.json"), "{}").expect("package.json should exist");
+        fs::write(bin_dir.join("maximus.js"), "console.log('ok');")
+            .expect("reference cli should exist");
+
+        let found = find_reference_cli_from_roots(ancestor_paths(nested_dir))
+            .expect("reference cli should be found");
+
+        assert_eq!(found, repo_root.join("bin/maximus.js"));
+    }
+
+    #[test]
+    fn reference_cli_path_is_absent_when_repo_markers_are_missing() {
+        let temp = tempdir().expect("temp dir should exist");
+        let root = temp.path().join("random");
+
+        fs::create_dir_all(root.join("bin")).expect("bin dir should exist");
+        fs::write(root.join("bin/maximus.js"), "console.log('ok');")
+            .expect("script should exist");
+
+        assert!(find_reference_cli_from_roots([root]).is_none());
+    }
+
+    #[test]
+    fn search_roots_prefer_current_exe_ancestors_over_current_dir() {
+        let temp = tempdir().expect("temp dir should exist");
+        let right_repo = temp.path().join("right-repo");
+        let wrong_repo = temp.path().join("wrong-repo");
+        let exe_dir = right_repo.join("target/debug");
+
+        fs::create_dir_all(right_repo.join("bin")).expect("right bin dir should exist");
+        fs::create_dir_all(wrong_repo.join("bin")).expect("wrong bin dir should exist");
+        fs::create_dir_all(&exe_dir).expect("exe dir should exist");
+        fs::write(right_repo.join("package.json"), "{}").expect("right package.json should exist");
+        fs::write(wrong_repo.join("package.json"), "{}").expect("wrong package.json should exist");
+        fs::write(right_repo.join("bin/maximus.js"), "console.log('right');")
+            .expect("right maximus should exist");
+        fs::write(wrong_repo.join("bin/maximus.js"), "console.log('wrong');")
+            .expect("wrong maximus should exist");
+
+        let roots = ancestor_paths(exe_dir)
+            .into_iter()
+            .chain(ancestor_paths(wrong_repo.clone()))
+            .collect::<Vec<_>>();
+
+        let found = find_reference_cli_from_roots(roots).expect("reference cli should be found");
+
+        assert_eq!(found, right_repo.join("bin/maximus.js"));
+    }
+}

--- a/crates/maximus-cli/src/report_json.rs
+++ b/crates/maximus-cli/src/report_json.rs
@@ -1,0 +1,144 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::{Path, PathBuf};
+
+use maximus_core::{serialize_audit_result, AuditResult, SerializableAuditResult};
+use serde::Serialize;
+
+use crate::AppliedFix;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializableFixOutput {
+    dry_run: bool,
+    target_dir: PathBuf,
+    initial: SerializableAuditResult,
+    applied: Vec<SerializableAppliedFix>,
+    #[serde(rename = "final")]
+    final_result: SerializableAuditResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializableAppliedFix {
+    id: String,
+    title: String,
+    files: Vec<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<String>,
+}
+
+pub fn render_audit_result(result: &AuditResult) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&serialize_audit_result(result))
+}
+
+pub fn render_fix_result(
+    dry_run: bool,
+    target_dir: &Path,
+    initial: &AuditResult,
+    applied: &[AppliedFix],
+    final_result: &AuditResult,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&SerializableFixOutput {
+        dry_run,
+        target_dir: target_dir.to_path_buf(),
+        initial: serialize_audit_result(initial),
+        applied: applied
+            .iter()
+            .map(|fix| SerializableAppliedFix {
+                id: fix.id.clone(),
+                title: fix.title.clone(),
+                files: fix.files.clone(),
+                outcome: fix.outcome.clone(),
+            })
+            .collect(),
+        final_result: serialize_audit_result(final_result),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use maximus_core::{AuditResult, AuditSummary, StructureReport};
+    use serde_json::Value;
+
+    use super::{render_audit_result, render_fix_result};
+
+    #[test]
+    fn audit_json_uses_current_camel_case_shape() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_audit_result(&result).expect("audit json should render");
+        let value: Value = serde_json::from_str(&json).expect("audit json should parse");
+
+        assert_eq!(value["rootDir"], "/tmp/project");
+        assert_eq!(value["summary"]["blockingFindings"], 0);
+        assert_eq!(value["structure"]["configFiles"], 1);
+        assert!(value["findings"].as_array().is_some());
+    }
+
+    #[test]
+    fn fix_json_keeps_js_top_level_keys() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_fix_result(true, PathBuf::from("/tmp/project").as_path(), &result, &[], &result)
+            .expect("fix json should render");
+        let value: Value = serde_json::from_str(&json).expect("fix json should parse");
+
+        assert_eq!(value["dryRun"], true);
+        assert_eq!(value["targetDir"], "/tmp/project");
+        assert!(value.get("initial").is_some());
+        assert!(value.get("applied").is_some());
+        assert!(value.get("final").is_some());
+    }
+
+    #[test]
+    fn fix_json_keeps_applied_outcome_when_present() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_fix_result(
+            false,
+            PathBuf::from("/tmp/project").as_path(),
+            &result,
+            &[crate::AppliedFix {
+                id: "env-example:create:/tmp/project".to_string(),
+                title: "Create .env.example".to_string(),
+                files: vec![PathBuf::from("/tmp/project/.env.example")],
+                outcome: Some("created".to_string()),
+            }],
+            &result,
+        )
+        .expect("fix json should render");
+        let value: Value = serde_json::from_str(&json).expect("fix json should parse");
+
+        assert_eq!(value["applied"][0]["outcome"], "created");
+    }
+
+    fn sample_result(root_dir: PathBuf) -> AuditResult {
+        AuditResult {
+            root_dir,
+            summary: AuditSummary {
+                status: "clean".to_string(),
+                total_findings: 0,
+                blocking_findings: 0,
+                warning_findings: 0,
+                info_findings: 0,
+                fixable_findings: 0,
+                fixes_available: 0,
+                config_files: 1,
+                package_count: 1,
+                env_directories: 0,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 0,
+                config_files: 1,
+                recommendations: vec![
+                    "Current config surface looks healthy. Keep shared rules centralized as the repo grows."
+                        .to_string(),
+                ],
+            },
+            findings: Vec::new(),
+            fixes: Vec::new(),
+        }
+    }
+}

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -1,0 +1,426 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::Path;
+
+use maximus_core::{AuditResult, StructureReport};
+
+use crate::AppliedFix;
+
+pub fn format_help() -> String {
+    [
+        "Maximus",
+        "",
+        "Bring order to chaotic configs.",
+        "",
+        "Usage",
+        "  maximus audit [path] [--json]",
+        "  maximus doctor [path] [--json]",
+        "  maximus fix [path] [--dry-run] [--json]",
+        "  maximus help",
+    ]
+    .join("\n")
+}
+
+pub fn format_audit_report(result: &AuditResult) -> String {
+    let mut lines = Vec::new();
+
+    lines.push("Maximus audit".to_string());
+    lines.push(format!("Target: {}", display_path(&result.root_dir)));
+    lines.push(String::new());
+    lines.push(format!("Status: {}", result.summary.status));
+    lines.push(format!(
+        "Findings: {} error, {} warnings, {} info",
+        result.summary.blocking_findings, result.summary.warning_findings, result.summary.info_findings
+    ));
+    lines.push(format!(
+        "Fixes available: {}",
+        result.summary.fixes_available
+    ));
+    lines.push(String::new());
+    lines.push(format!("Structure: {}", describe_structure(&result.structure)));
+
+    if result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("No config drift detected.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("Findings".to_string());
+        lines.extend(format_findings(result));
+    }
+
+    if !result.structure.recommendations.is_empty() {
+        lines.push(String::new());
+        lines.push("Recommendations".to_string());
+        for recommendation in &result.structure.recommendations {
+            lines.push(format!("- {recommendation}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+pub fn format_doctor_report(result: &AuditResult) -> String {
+    let mut lines = Vec::new();
+    let manual_findings = result
+        .findings
+        .iter()
+        .filter(|finding| !finding.fixable)
+        .count();
+    let fixable_findings = result.findings.iter().filter(|finding| finding.fixable).count();
+
+    lines.push("Maximus doctor".to_string());
+    lines.push(format!("Target: {}", display_path(&result.root_dir)));
+    lines.push(String::new());
+    lines.push(format!("Diagnosis: {}", result.summary.status));
+    lines.push(format!(
+        "Project shape: {}",
+        describe_structure(&result.structure)
+    ));
+    lines.push(String::new());
+    lines.push("Prescription".to_string());
+
+    if fixable_findings > 0 {
+        lines.push(format!(
+            "- Run \"maximus fix\" to apply {} safe fix(es).",
+            result.summary.fixes_available
+        ));
+    } else {
+        lines.push("- No automatic fixes are currently available.".to_string());
+    }
+
+    if manual_findings > 0 {
+        lines.push(format!(
+            "- Review {manual_findings} manual issue(s) in priority order below."
+        ));
+    } else {
+        lines.push("- No manual follow-up is required right now.".to_string());
+    }
+
+    if result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("No config drift detected.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("Findings".to_string());
+        lines.extend(format_findings(result));
+    }
+
+    if !result.structure.recommendations.is_empty() {
+        lines.push(String::new());
+        lines.push("Recommended structure".to_string());
+        for recommendation in &result.structure.recommendations {
+            lines.push(format!("- {recommendation}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+pub fn format_fix_result(
+    dry_run: bool,
+    target_dir: &Path,
+    initial: &AuditResult,
+    applied: &[AppliedFix],
+    final_result: &AuditResult,
+) -> String {
+    let mut lines = Vec::new();
+    let result = if dry_run { initial } else { final_result };
+
+    lines.push("Maximus fix".to_string());
+    lines.push(format!("Target: {}", display_path(target_dir)));
+    lines.push(String::new());
+
+    if dry_run {
+        lines.push(format!(
+            "Dry run: {} safe fix(es) available.",
+            initial.summary.fixes_available
+        ));
+    } else {
+        lines.push(format!("Applied: {} fix(es).", applied.len()));
+    }
+
+    if !applied.is_empty() {
+        lines.push(String::new());
+        lines.push("Changes".to_string());
+        for fix in applied {
+            lines.push(format!("- {}", fix.title));
+            for file in &fix.files {
+                lines.push(format!("  file: {}", display_path(file)));
+            }
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(format!(
+        "Post-check: {} error, {} warnings, {} info",
+        result.summary.blocking_findings, result.summary.warning_findings, result.summary.info_findings
+    ));
+
+    if result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("Project is currently clean.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("Remaining findings".to_string());
+        lines.extend(format_findings(result));
+    }
+
+    lines.join("\n")
+}
+
+fn format_findings(result: &AuditResult) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    for finding in &result.findings {
+        lines.push(format!("- [{}] {}", severity_label(&finding.severity), finding.title));
+
+        if let Some(file) = &finding.file {
+            lines.push(format!(
+                "  file: {}",
+                format_relative_file(&result.root_dir, file)
+            ));
+        }
+
+        if !finding.detail.is_empty() {
+            lines.push(format!("  detail: {}", finding.detail));
+        }
+
+        if !finding.hint.is_empty() {
+            lines.push(format!("  hint: {}", finding.hint));
+        }
+    }
+
+    lines
+}
+
+fn format_relative_file(root_dir: &Path, file_path: &Path) -> String {
+    relative_path_like_js(root_dir, file_path)
+        .map(|value| {
+            if value.is_empty() {
+                ".".to_string()
+            } else {
+                value
+            }
+        })
+        .unwrap_or_else(|| display_path(file_path))
+}
+
+fn describe_structure(structure: &StructureReport) -> String {
+    let repo_type = if structure.is_monorepo {
+        "monorepo"
+    } else {
+        "single package"
+    };
+
+    format!(
+        "{repo_type}, {} package(s), {} config file(s), {} env folder(s)",
+        structure.package_count, structure.config_files, structure.env_directories
+    )
+}
+
+fn severity_label(severity: &maximus_core::Severity) -> &'static str {
+    match severity {
+        maximus_core::Severity::Error => "error",
+        maximus_core::Severity::Warn => "warn",
+        maximus_core::Severity::Info => "info",
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path_string(path)
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn relative_path_like_js(root_dir: &Path, file_path: &Path) -> Option<String> {
+    if root_dir == file_path {
+        return Some(String::new());
+    }
+
+    if let Ok(relative) = file_path.strip_prefix(root_dir) {
+        return Some(path_string(relative));
+    }
+
+    let root_components = root_dir.components().collect::<Vec<_>>();
+    let file_components = file_path.components().collect::<Vec<_>>();
+
+    let mut shared_len = 0usize;
+    while shared_len < root_components.len()
+        && shared_len < file_components.len()
+        && root_components[shared_len] == file_components[shared_len]
+    {
+        shared_len += 1;
+    }
+
+    if shared_len == 0 {
+        return None;
+    }
+
+    let mut relative = std::path::PathBuf::new();
+
+    for component in &root_components[shared_len..] {
+        if matches!(component, std::path::Component::Normal(_)) {
+            relative.push("..");
+        }
+    }
+
+    for component in &file_components[shared_len..] {
+        relative.push(component.as_os_str());
+    }
+
+    Some(path_string(&relative))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use maximus_core::{AuditResult, AuditSummary, StructureReport};
+
+    use crate::AppliedFix;
+
+    use super::{
+        format_audit_report, format_doctor_report, format_fix_result, format_help,
+        format_relative_file,
+    };
+
+    #[test]
+    fn help_text_matches_current_js_usage() {
+        assert_eq!(
+            format_help(),
+            [
+                "Maximus",
+                "",
+                "Bring order to chaotic configs.",
+                "",
+                "Usage",
+                "  maximus audit [path] [--json]",
+                "  maximus doctor [path] [--json]",
+                "  maximus fix [path] [--dry-run] [--json]",
+                "  maximus help",
+            ]
+            .join("\n")
+        );
+    }
+
+    #[test]
+    fn text_renderers_match_clean_project_shape() {
+        let root_dir = PathBuf::from("/tmp/project");
+        let result = sample_result(root_dir.clone());
+
+        assert_eq!(
+            format_audit_report(&result),
+            [
+                "Maximus audit",
+                "Target: /tmp/project",
+                "",
+                "Status: clean",
+                "Findings: 0 error, 0 warnings, 0 info",
+                "Fixes available: 0",
+                "",
+                "Structure: single package, 1 package(s), 1 config file(s), 0 env folder(s)",
+                "",
+                "No config drift detected.",
+                "",
+                "Recommendations",
+                "- Current config surface looks healthy. Keep shared rules centralized as the repo grows.",
+            ]
+            .join("\n")
+        );
+
+        assert_eq!(
+            format_doctor_report(&result),
+            [
+                "Maximus doctor",
+                "Target: /tmp/project",
+                "",
+                "Diagnosis: clean",
+                "Project shape: single package, 1 package(s), 1 config file(s), 0 env folder(s)",
+                "",
+                "Prescription",
+                "- No automatic fixes are currently available.",
+                "- No manual follow-up is required right now.",
+                "",
+                "No config drift detected.",
+                "",
+                "Recommended structure",
+                "- Current config surface looks healthy. Keep shared rules centralized as the repo grows.",
+            ]
+            .join("\n")
+        );
+
+        assert_eq!(
+            format_fix_result(true, &root_dir, &result, &Vec::<AppliedFix>::new(), &result),
+            [
+                "Maximus fix",
+                "Target: /tmp/project",
+                "",
+                "Dry run: 0 safe fix(es) available.",
+                "",
+                "Post-check: 0 error, 0 warnings, 0 info",
+                "",
+                "Project is currently clean.",
+            ]
+            .join("\n")
+        );
+    }
+
+    #[test]
+    fn relative_file_format_matches_js_like_root_and_parent_cases() {
+        let root_dir = PathBuf::from("/tmp/project");
+
+        assert_eq!(format_relative_file(&root_dir, &root_dir), ".");
+        assert_eq!(
+            format_relative_file(&root_dir, &root_dir.join("src/index.ts")),
+            "src/index.ts"
+        );
+        assert_eq!(
+            format_relative_file(&root_dir, Path::new("/tmp/other/file.ts")),
+            "../other/file.ts"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_file_format_falls_back_to_target_path_for_cross_drive_windows_paths() {
+        let root_dir = Path::new(r"C:\repo");
+        let file_path = Path::new(r"D:\other\file.ts");
+
+        assert_eq!(
+            format_relative_file(root_dir, file_path),
+            r"D:\other\file.ts"
+        );
+    }
+
+    fn sample_result(root_dir: PathBuf) -> AuditResult {
+        AuditResult {
+            root_dir,
+            summary: AuditSummary {
+                status: "clean".to_string(),
+                total_findings: 0,
+                blocking_findings: 0,
+                warning_findings: 0,
+                info_findings: 0,
+                fixable_findings: 0,
+                fixes_available: 0,
+                config_files: 1,
+                package_count: 1,
+                env_directories: 0,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 0,
+                config_files: 1,
+                recommendations: vec![
+                    "Current config surface looks healthy. Keep shared rules centralized as the repo grows."
+                        .to_string(),
+                ],
+            },
+            findings: Vec::new(),
+            fixes: Vec::new(),
+        }
+    }
+}

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -1,0 +1,281 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn maximus_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+#[test]
+fn no_args_prints_help() {
+    let output = maximus_bin().output().expect("help command should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be utf8"),
+        [
+            "Maximus",
+            "",
+            "Bring order to chaotic configs.",
+            "",
+            "Usage",
+            "  maximus audit [path] [--json]",
+            "  maximus doctor [path] [--json]",
+            "  maximus fix [path] [--dry-run] [--json]",
+            "  maximus help",
+            "",
+        ]
+        .join("\n")
+    );
+}
+
+#[test]
+fn help_subcommand_prints_usage() {
+    let output = maximus_bin()
+        .arg("help")
+        .output()
+        .expect("help subcommand should run");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8(output.stdout)
+        .expect("stdout should be utf8")
+        .contains("maximus audit [path] [--json]"));
+}
+
+#[test]
+fn audit_json_routes_to_clean_skeleton_result() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args(["audit", fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert!(output.status.success());
+
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("audit json output should be valid");
+    assert_eq!(value["rootDir"], fixture.to_string_lossy().to_string());
+    assert_eq!(value["summary"]["status"], "clean");
+    assert_eq!(value["summary"]["blockingFindings"], 0);
+    assert_eq!(value["structure"]["configFiles"], 1);
+    assert_eq!(value["findings"], Value::Array(Vec::new()));
+    assert_eq!(value["fixes"], Value::Array(Vec::new()));
+}
+
+#[test]
+fn audit_reference_env_matches_js_cli_output_and_status() {
+    let fixture = fixture_path_for("reference-env");
+
+    let rust_output = maximus_bin()
+        .args(["audit", fixture.to_string_lossy().as_ref()])
+        .output()
+        .expect("rust audit should run");
+    let js_output = js_maximus()
+        .args(["audit", fixture.to_string_lossy().as_ref()])
+        .output()
+        .expect("js audit should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+    assert_eq!(rust_output.stdout, js_output.stdout);
+    assert_eq!(rust_output.stderr, js_output.stderr);
+}
+
+#[test]
+fn audit_reference_tsconfig_matches_js_cli_output_and_status() {
+    let fixture = fixture_path_for("reference-tsconfig");
+
+    let rust_output = maximus_bin()
+        .args(["audit", fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("rust audit should run");
+    let js_output = js_maximus()
+        .args(["audit", fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("js audit should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+    assert_eq!(rust_output.stdout, js_output.stdout);
+    assert_eq!(rust_output.stderr, js_output.stderr);
+}
+
+#[test]
+fn fix_reference_env_dry_run_matches_js_cli_output_and_status() {
+    let fixture = fixture_path_for("reference-env");
+
+    let rust_output = maximus_bin()
+        .args(["fix", fixture.to_string_lossy().as_ref(), "--dry-run"])
+        .output()
+        .expect("rust fix dry-run should run");
+    let js_output = js_maximus()
+        .args(["fix", fixture.to_string_lossy().as_ref(), "--dry-run"])
+        .output()
+        .expect("js fix dry-run should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+    assert_eq!(rust_output.stdout, js_output.stdout);
+    assert_eq!(rust_output.stderr, js_output.stderr);
+}
+
+#[test]
+fn fix_reference_env_json_matches_js_cli_output_and_status() {
+    let rust_fixture = prepare_temp_reference_env();
+    let js_fixture = prepare_temp_reference_env();
+
+    let rust_output = maximus_bin()
+        .args(["fix", rust_fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("rust fix json should run");
+    let js_output = js_maximus()
+        .args(["fix", js_fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("js fix json should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+
+    let rust_json: Value = serde_json::from_slice(&rust_output.stdout).expect("rust json should parse");
+    let js_json: Value = serde_json::from_slice(&js_output.stdout).expect("js json should parse");
+
+    assert_eq!(rust_json["dryRun"], js_json["dryRun"]);
+    assert_eq!(rust_json["applied"][0]["outcome"], "created");
+    assert_eq!(rust_json["applied"][0]["outcome"], js_json["applied"][0]["outcome"]);
+    assert_eq!(rust_json["initial"]["summary"]["status"], js_json["initial"]["summary"]["status"]);
+    assert_eq!(rust_json["final"]["summary"]["status"], js_json["final"]["summary"]["status"]);
+}
+
+#[test]
+fn doctor_text_uses_expected_sections() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args(["doctor", fixture.to_string_lossy().as_ref()])
+        .output()
+        .expect("doctor should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout should be utf8"),
+        [
+            "Maximus doctor",
+            &format!("Target: {}", fixture.to_string_lossy()),
+            "",
+            "Diagnosis: clean",
+            "Project shape: single package, 1 package(s), 1 config file(s), 0 env folder(s)",
+            "",
+            "Prescription",
+            "- No automatic fixes are currently available.",
+            "- No manual follow-up is required right now.",
+            "",
+            "No config drift detected.",
+            "",
+            "Recommended structure",
+            "- Current config surface looks healthy. Keep shared rules centralized as the repo grows.",
+            "",
+        ]
+        .join("\n")
+    );
+}
+
+#[test]
+fn fix_dry_run_json_keeps_js_top_level_contract() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args([
+            "fix",
+            fixture.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--json",
+        ])
+        .output()
+        .expect("fix dry-run should run");
+
+    assert!(output.status.success());
+
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("fix json output should be valid");
+    assert_eq!(value["dryRun"], true);
+    assert_eq!(value["targetDir"], fixture.to_string_lossy().to_string());
+    assert!(value.get("initial").is_some());
+    assert!(value.get("applied").is_some());
+    assert!(value.get("final").is_some());
+}
+
+#[test]
+fn unknown_command_uses_prefixed_stderr_and_exit_code_two() {
+    let output = maximus_bin()
+        .arg("foobar")
+        .output()
+        .expect("unknown command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Unknown command \"foobar\". Run \"maximus help\" for usage.\n"
+    );
+}
+
+#[test]
+fn missing_directory_uses_prefixed_stderr_and_exit_code_two() {
+    let output = maximus_bin()
+        .args(["audit", "/definitely/not-a-real-path"])
+        .output()
+        .expect("missing directory case should run");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.starts_with("Maximus failed: "));
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_path_argument_does_not_panic_before_delegation() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let non_utf8_path = PathBuf::from(OsString::from_vec(vec![
+        b'/', b't', b'm', b'p', b'/', b'f', b'o', 0x80, b'o',
+    ]));
+
+    let output = maximus_bin()
+        .arg("audit")
+        .arg(&non_utf8_path)
+        .output()
+        .expect("rust audit should run");
+
+    assert!(output.status.code().is_some());
+}
+
+fn fixture_path() -> PathBuf {
+    workspace_root().join("test/fixtures/clean-project")
+}
+
+fn fixture_path_for(name: &str) -> PathBuf {
+    workspace_root().join("test/fixtures").join(name)
+}
+
+fn prepare_temp_reference_env() -> PathBuf {
+    let temp = tempdir().expect("temp dir should exist");
+    let target = temp.keep();
+    let source = fixture_path_for("reference-env").join(".env");
+
+    fs::create_dir_all(&target).expect("target dir should exist");
+    fs::copy(source, target.join(".env")).expect("env fixture should copy");
+
+    target
+}
+
+fn js_maximus() -> Command {
+    let mut command = Command::new("node");
+    command.arg(workspace_root().join("bin/maximus.js"));
+    command
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}


### PR DESCRIPTION
## Summary
- add the Rust `maximus-cli` skeleton for `audit`, `doctor`, `fix`, and `help`
- add text/json renderers, exit-code helpers, and CLI integration tests
- preserve JS CLI failure-path contracts for stderr prefix and exit code `2`

## Validation
- cargo test -p maximus-cli
- cargo test --workspace
- npm test

## Notes
- this phase intentionally does not wire real Rust checks yet
- `PR_DESCRIPTION.md` and `maximus-0.1.0.tgz` remain out of scope
