### PR TITLE
[codex] Rust base checks parity 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "maximus-checks"
 version = "0.1.0"
+dependencies = [
+ "maximus-core",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "maximus-cli"

--- a/crates/maximus-checks/Cargo.toml
+++ b/crates/maximus-checks/Cargo.toml
@@ -9,3 +9,10 @@ description = "Rust checks bootstrap crate for Maximus."
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+maximus-core = { path = "../maximus-core" }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/maximus-checks/src/config_duplicates.rs
+++ b/crates/maximus-checks/src/config_duplicates.rs
@@ -46,7 +46,7 @@ pub fn run_config_duplicate_check(project: &ProjectSnapshot) -> std::io::Result<
                 category: Some("duplicates".to_string()),
                 detail: Some(format!(
                     "Found {total_sources} {label} config sources in {}.",
-                    directory.relative_dir
+                    js_detail_directory(&directory.relative_dir)
                 )),
                 file,
                 fix_ids: Vec::new(),
@@ -95,4 +95,12 @@ pub fn run_config_duplicate_check(project: &ProjectSnapshot) -> std::io::Result<
         findings,
         fixes: Vec::new(),
     })
+}
+
+fn js_detail_directory(relative_dir: &str) -> String {
+    if cfg!(windows) {
+        relative_dir.replace('/', "\\")
+    } else {
+        relative_dir.to_string()
+    }
 }

--- a/crates/maximus-checks/src/config_duplicates.rs
+++ b/crates/maximus-checks/src/config_duplicates.rs
@@ -1,0 +1,98 @@
+use maximus_core::{make_finding, FileKind, FindingInput, ProjectSnapshot, Severity};
+
+use crate::registry::{
+    has_object_key, package_file_for_directory, read_package_json, CheckOutcome,
+};
+
+pub fn run_config_duplicate_check(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for directory in &project.directories {
+        let package_file = package_file_for_directory(directory).cloned();
+        let package_json = package_file
+            .as_ref()
+            .and_then(|file| read_package_json(&file.path));
+
+        for (label, file_kind, package_field) in [
+            ("ESLint", FileKind::Eslint, "eslintConfig"),
+            ("Prettier", FileKind::Prettier, "prettier"),
+            ("Jest", FileKind::Jest, "jest"),
+        ] {
+            let family_files = directory.files_by_kind.get(&file_kind);
+            let family_file_count = family_files.map(|files| files.len()).unwrap_or(0);
+            let has_package_field = package_json
+                .as_ref()
+                .map(|value| has_object_key(value, package_field))
+                .unwrap_or(false);
+            let total_sources = family_file_count + usize::from(has_package_field);
+
+            if total_sources <= 1 {
+                continue;
+            }
+
+            let severity = if label == "ESLint" {
+                Severity::Error
+            } else {
+                Severity::Warn
+            };
+            let file = package_file
+                .as_ref()
+                .map(|value| value.path.clone())
+                .or_else(|| family_files.and_then(|files| files.first().map(|file| file.path.clone())));
+
+            findings.push(make_finding(FindingInput {
+                id: format!("duplicate-config:{label}:{}", directory.dir.to_string_lossy()),
+                title: format!("{label} config is declared in multiple places"),
+                category: Some("duplicates".to_string()),
+                detail: Some(format!(
+                    "Found {total_sources} {label} config sources in {}.",
+                    directory.relative_dir
+                )),
+                file,
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(format!(
+                    "Keep a single {label} entry point per directory to avoid drift."
+                )),
+                severity: Some(severity),
+            }));
+        }
+
+        let eslint_files = directory
+            .files_by_kind
+            .get(&FileKind::Eslint)
+            .cloned()
+            .unwrap_or_default();
+        let has_legacy_eslint = eslint_files
+            .iter()
+            .any(|file| file.name.starts_with(".eslintrc"));
+        let has_flat_eslint = eslint_files
+            .iter()
+            .any(|file| file.name.starts_with("eslint.config."));
+
+        if has_legacy_eslint && has_flat_eslint {
+            findings.push(make_finding(FindingInput {
+                id: format!("eslint-mixed-modes:{}", directory.dir.to_string_lossy()),
+                title: "Legacy and flat ESLint configs coexist".to_string(),
+                category: Some("duplicates".to_string()),
+                detail: Some(
+                    "ESLint may resolve different config systems depending on invocation and toolchain."
+                        .to_string(),
+                ),
+                file: eslint_files.first().map(|file| file.path.clone()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Pick either flat config (eslint.config.*) or legacy .eslintrc.* in the same directory."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Error),
+            }));
+        }
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+    })
+}

--- a/crates/maximus-checks/src/eslint_prettier.rs
+++ b/crates/maximus-checks/src/eslint_prettier.rs
@@ -1,0 +1,173 @@
+use maximus_core::{make_finding, FileKind, FindingInput, ProjectSnapshot, Severity, read_text_if_exists};
+
+use crate::registry::{
+    has_object_key, package_file_for_directory, read_package_json, CheckOutcome,
+};
+
+const FORMATTING_RULES: &[&str] = &[
+    "array-bracket-spacing",
+    "comma-dangle",
+    "indent",
+    "max-len",
+    "object-curly-spacing",
+    "quotes",
+    "semi",
+];
+
+pub fn run_eslint_prettier_check(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for directory in &project.directories {
+        let eslint_files = directory
+            .files_by_kind
+            .get(&FileKind::Eslint)
+            .cloned()
+            .unwrap_or_default();
+        let prettier_files = directory
+            .files_by_kind
+            .get(&FileKind::Prettier)
+            .cloned()
+            .unwrap_or_default();
+        let package_file = package_file_for_directory(directory).cloned();
+        let package_json = package_file
+            .as_ref()
+            .and_then(|file| read_package_json(&file.path));
+
+        let mut eslint_sources = Vec::new();
+        let mut prettier_sources = Vec::new();
+
+        for file in &eslint_files {
+            if let Some(text) = read_text_if_exists(&file.path)? {
+                eslint_sources.push(text);
+            }
+        }
+
+        for file in &prettier_files {
+            if let Some(text) = read_text_if_exists(&file.path)? {
+                prettier_sources.push(text);
+            }
+        }
+
+        if let Some(package_json) = package_json.as_ref() {
+            if has_object_key(package_json, "eslintConfig") {
+                if let Some(value) = package_json.get("eslintConfig") {
+                    eslint_sources.push(
+                        serde_json::to_string_pretty(value)
+                            .unwrap_or_else(|_| value.to_string()),
+                    );
+                }
+            }
+
+            if has_object_key(package_json, "prettier") {
+                if let Some(value) = package_json.get("prettier") {
+                    prettier_sources.push(
+                        serde_json::to_string_pretty(value)
+                            .unwrap_or_else(|_| value.to_string()),
+                    );
+                }
+            }
+        }
+
+        if eslint_sources.is_empty() || prettier_sources.is_empty() {
+            continue;
+        }
+
+        let eslint_text = eslint_sources.join("\n");
+        let has_formatting_rules = FORMATTING_RULES
+            .iter()
+            .any(|rule| contains_property_name(&eslint_text, rule));
+        let has_prettier_integration = contains_word(&eslint_text, "prettier");
+        let file = eslint_files
+            .first()
+            .map(|file| file.path.clone())
+            .or_else(|| package_file.as_ref().map(|file| file.path.clone()));
+
+        if has_formatting_rules && !has_prettier_integration {
+            findings.push(make_finding(FindingInput {
+                id: format!("eslint-prettier-conflict:{}", directory.dir.to_string_lossy()),
+                title: "ESLint formatting rules may conflict with Prettier".to_string(),
+                category: Some("conflict".to_string()),
+                detail: Some(
+                    "Formatting-oriented ESLint rules were found, but no explicit Prettier bridge was detected."
+                        .to_string(),
+                ),
+                file,
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Consider eslint-config-prettier or plugin:prettier/recommended to reduce formatter churn."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        } else if !has_prettier_integration {
+            findings.push(make_finding(FindingInput {
+                id: format!("eslint-prettier-separate:{}", directory.dir.to_string_lossy()),
+                title: "ESLint and Prettier are configured separately".to_string(),
+                category: Some("conflict".to_string()),
+                detail: Some(
+                    "That can be fine, but teams often prefer an explicit integration strategy."
+                        .to_string(),
+                ),
+                file,
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Document which tool owns formatting and which tool owns code-quality rules."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Info),
+            }));
+        }
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+    })
+}
+
+fn contains_property_name(text: &str, property: &str) -> bool {
+    ['"', '\''].into_iter().any(|quote| {
+        let needle = format!("{quote}{property}{quote}");
+        let mut remainder = text;
+
+        while let Some(index) = remainder.find(&needle) {
+            let after_match = &remainder[index + needle.len()..];
+            let next_non_whitespace = after_match.chars().find(|character| !character.is_whitespace());
+
+            if next_non_whitespace == Some(':') {
+                return true;
+            }
+
+            remainder = after_match;
+        }
+
+        false
+    })
+}
+
+fn contains_word(text: &str, needle: &str) -> bool {
+    let mut search_start = 0usize;
+
+    while let Some(relative_index) = text[search_start..].find(needle) {
+        let start = search_start + relative_index;
+        let end = start + needle.len();
+        let previous = text[..start].chars().next_back();
+        let next = text[end..].chars().next();
+
+        if !is_word_char(previous) && !is_word_char(next) {
+            return true;
+        }
+
+        search_start = end;
+    }
+
+    false
+}
+
+fn is_word_char(character: Option<char>) -> bool {
+    character
+        .map(|character| character.is_alphanumeric() || character == '_')
+        .unwrap_or(false)
+}

--- a/crates/maximus-checks/src/eslint_prettier.rs
+++ b/crates/maximus-checks/src/eslint_prettier.rs
@@ -1,8 +1,6 @@
 use maximus_core::{make_finding, FileKind, FindingInput, ProjectSnapshot, Severity, read_text_if_exists};
 
-use crate::registry::{
-    has_object_key, package_file_for_directory, read_package_json, CheckOutcome,
-};
+use crate::registry::{package_file_for_directory, read_package_json, CheckOutcome};
 
 const FORMATTING_RULES: &[&str] = &[
     "array-bracket-spacing",
@@ -49,22 +47,22 @@ pub fn run_eslint_prettier_check(project: &ProjectSnapshot) -> std::io::Result<C
         }
 
         if let Some(package_json) = package_json.as_ref() {
-            if has_object_key(package_json, "eslintConfig") {
-                if let Some(value) = package_json.get("eslintConfig") {
-                    eslint_sources.push(
-                        serde_json::to_string_pretty(value)
-                            .unwrap_or_else(|_| value.to_string()),
-                    );
-                }
+            if let Some(value) = package_json
+                .get("eslintConfig")
+                .filter(|value| is_js_truthy_json_value(value))
+            {
+                eslint_sources.push(
+                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()),
+                );
             }
 
-            if has_object_key(package_json, "prettier") {
-                if let Some(value) = package_json.get("prettier") {
-                    prettier_sources.push(
-                        serde_json::to_string_pretty(value)
-                            .unwrap_or_else(|_| value.to_string()),
-                    );
-                }
+            if let Some(value) = package_json
+                .get("prettier")
+                .filter(|value| is_js_truthy_json_value(value))
+            {
+                prettier_sources.push(
+                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()),
+                );
             }
         }
 
@@ -170,4 +168,21 @@ fn is_word_char(character: Option<char>) -> bool {
     character
         .map(|character| character.is_alphanumeric() || character == '_')
         .unwrap_or(false)
+}
+
+fn is_js_truthy_json_value(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(value) => *value,
+        serde_json::Value::Number(value) => {
+            value.as_i64().map(|value| value != 0).unwrap_or_else(|| {
+                value
+                    .as_u64()
+                    .map(|value| value != 0)
+                    .unwrap_or_else(|| value.as_f64().map(|value| value != 0.0).unwrap_or(true))
+            })
+        }
+        serde_json::Value::String(value) => !value.is_empty(),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => true,
+    }
 }

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -1,1 +1,9 @@
-//! Bootstrap crate for the Maximus Rust checks layer.
+//! Base check implementations for the Maximus Rust rewrite.
+
+mod config_duplicates;
+mod eslint_prettier;
+pub mod registry;
+
+pub use config_duplicates::run_config_duplicate_check;
+pub use eslint_prettier::run_eslint_prettier_check;
+pub use registry::{run_registered_checks, CheckOutcome};

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use maximus_core::{
+    parse_jsonc, sort_findings, unique_fixes, FixPlan, Finding, ProjectDirectory, ProjectFile,
+    ProjectSnapshot, read_text_if_exists,
+};
+
+use crate::{run_config_duplicate_check, run_eslint_prettier_check};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CheckOutcome {
+    pub findings: Vec<Finding>,
+    pub fixes: Vec<FixPlan>,
+}
+
+impl CheckOutcome {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+pub fn run_registered_checks(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
+    let outcomes = [
+        run_config_duplicate_check(project)?,
+        run_eslint_prettier_check(project)?,
+    ];
+
+    Ok(merge_outcomes(outcomes))
+}
+
+pub(crate) fn merge_outcomes<I>(outcomes: I) -> CheckOutcome
+where
+    I: IntoIterator<Item = CheckOutcome>,
+{
+    let mut findings = Vec::new();
+    let mut fixes = Vec::new();
+
+    for outcome in outcomes {
+        findings.extend(outcome.findings);
+        fixes.extend(outcome.fixes);
+    }
+
+    CheckOutcome {
+        findings: sort_findings(&findings),
+        fixes: unique_fixes(&fixes),
+    }
+}
+
+pub(crate) fn package_file_for_directory(directory: &ProjectDirectory) -> Option<&ProjectFile> {
+    directory.files.iter().find(|file| file.kind == maximus_core::FileKind::Package)
+}
+
+pub(crate) fn read_package_json(file_path: &Path) -> Option<serde_json::Value> {
+    let text = read_text_if_exists(file_path).ok().flatten()?;
+    parse_jsonc::<serde_json::Value>(&text, &file_path.to_string_lossy()).ok()
+}
+
+pub(crate) fn has_object_key(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .as_object()
+        .map(|object| object.contains_key(key))
+        .unwrap_or(false)
+}

--- a/crates/maximus-checks/tests/basic_checks.rs
+++ b/crates/maximus-checks/tests/basic_checks.rs
@@ -113,6 +113,51 @@ fn eslint_prettier_check_reports_separate_info_when_no_bridge_is_declared() {
 }
 
 #[test]
+fn eslint_prettier_check_ignores_falsy_package_json_entries_like_js() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "eslintConfig": false, "prettier": { "semi": true } }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_eslint_prettier_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn duplicate_config_detail_uses_js_style_relative_path_rendering() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("packages/app/package.json"),
+        r#"{ "prettier": { "semi": true } }"#,
+    );
+    write(fixture.path().join("packages/app/.prettierrc.json"), "{}");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_config_duplicate_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "duplicate-config:Prettier:{}",
+            fixture.path().join("packages/app").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Prettier config is declared in multiple places",
+        &format!(
+            "Found 2 Prettier config sources in {}.",
+            expected_js_relative_dir("packages/app")
+        ),
+        "Keep a single Prettier entry point per directory to avoid drift.",
+        Some(fixture.path().join("packages/app/package.json")),
+    );
+}
+
+#[test]
 fn registered_checks_aggregate_duplicate_and_conflict_findings() {
     let fixture = TempDir::new().expect("temp dir should exist");
 
@@ -154,6 +199,14 @@ fn write(path: impl AsRef<Path>, content: &str) {
     }
 
     fs::write(path, content).expect("fixture file should write");
+}
+
+fn expected_js_relative_dir(path: &str) -> String {
+    if cfg!(windows) {
+        path.replace('/', "\\")
+    } else {
+        path.to_string()
+    }
 }
 
 fn assert_has_finding(

--- a/crates/maximus-checks/tests/basic_checks.rs
+++ b/crates/maximus-checks/tests/basic_checks.rs
@@ -1,0 +1,180 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::{
+    run_config_duplicate_check, run_eslint_prettier_check, run_registered_checks,
+};
+use maximus_core::{discover_project, Severity};
+use tempfile::TempDir;
+
+#[test]
+fn config_duplicate_check_matches_js_duplicate_and_mixed_mode_contracts() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"
+        {
+          "eslintConfig": { "root": true },
+          "prettier": { "semi": true },
+          "jest": { "testEnvironment": "node" }
+        }
+        "#,
+    );
+    write(fixture.path().join(".eslintrc.json"), "{}");
+    write(fixture.path().join("eslint.config.js"), "export default [];\n");
+    write(fixture.path().join(".prettierrc.json"), "{}");
+    write(fixture.path().join("jest.config.js"), "export default {};\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_config_duplicate_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("duplicate-config:ESLint:{}", fixture.path().to_string_lossy()),
+        Severity::Error,
+        "ESLint config is declared in multiple places",
+        "Found 3 ESLint config sources in ..",
+        "Keep a single ESLint entry point per directory to avoid drift.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!("duplicate-config:Prettier:{}", fixture.path().to_string_lossy()),
+        Severity::Warn,
+        "Prettier config is declared in multiple places",
+        "Found 2 Prettier config sources in ..",
+        "Keep a single Prettier entry point per directory to avoid drift.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!("duplicate-config:Jest:{}", fixture.path().to_string_lossy()),
+        Severity::Warn,
+        "Jest config is declared in multiple places",
+        "Found 2 Jest config sources in ..",
+        "Keep a single Jest entry point per directory to avoid drift.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!("eslint-mixed-modes:{}", fixture.path().to_string_lossy()),
+        Severity::Error,
+        "Legacy and flat ESLint configs coexist",
+        "ESLint may resolve different config systems depending on invocation and toolchain.",
+        "Pick either flat config (eslint.config.*) or legacy .eslintrc.* in the same directory.",
+        Some(fixture.path().join(".eslintrc.json")),
+    );
+}
+
+#[test]
+fn eslint_prettier_check_reports_conflict_when_formatting_rules_lack_bridge() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("eslint.config.js"),
+        r#"export default [{ rules: { "quotes": ["error", "single"], "semi": "error" } }];"#,
+    );
+    write(fixture.path().join(".prettierrc.json"), "{ \"semi\": true }\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_eslint_prettier_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("eslint-prettier-conflict:{}", fixture.path().to_string_lossy()),
+        Severity::Warn,
+        "ESLint formatting rules may conflict with Prettier",
+        "Formatting-oriented ESLint rules were found, but no explicit Prettier bridge was detected.",
+        "Consider eslint-config-prettier or plugin:prettier/recommended to reduce formatter churn.",
+        Some(fixture.path().join("eslint.config.js")),
+    );
+}
+
+#[test]
+fn eslint_prettier_check_reports_separate_info_when_no_bridge_is_declared() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(fixture.path().join("eslint.config.js"), "export default [];\n");
+    write(fixture.path().join(".prettierrc.json"), "{ \"semi\": true }\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_eslint_prettier_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("eslint-prettier-separate:{}", fixture.path().to_string_lossy()),
+        Severity::Info,
+        "ESLint and Prettier are configured separately",
+        "That can be fine, but teams often prefer an explicit integration strategy.",
+        "Document which tool owns formatting and which tool owns code-quality rules.",
+        Some(fixture.path().join("eslint.config.js")),
+    );
+}
+
+#[test]
+fn registered_checks_aggregate_duplicate_and_conflict_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "eslintConfig": { "root": true }, "prettier": { "semi": true } }"#,
+    );
+    write(fixture.path().join(".eslintrc.json"), "{}");
+    write(
+        fixture.path().join("eslint.config.js"),
+        r#"export default [{ rules: { "quotes": ["error", "single"] } }];"#,
+    );
+    write(fixture.path().join(".prettierrc.json"), "{}");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_registered_checks(&project).expect("registry should run");
+
+    let finding_ids = outcome
+        .findings
+        .iter()
+        .map(|finding| finding.id.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        finding_ids,
+        vec![
+            format!("eslint-mixed-modes:{}", fixture.path().to_string_lossy()),
+            format!("duplicate-config:ESLint:{}", fixture.path().to_string_lossy()),
+            format!("eslint-prettier-conflict:{}", fixture.path().to_string_lossy()),
+            format!("duplicate-config:Prettier:{}", fixture.path().to_string_lossy()),
+        ]
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    detail: &str,
+    hint: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.detail, detail);
+    assert_eq!(finding.hint, hint);
+    assert_eq!(finding.file, file);
+    assert!(!finding.fixable);
+    assert!(finding.fix_ids.is_empty());
+}


### PR DESCRIPTION
# 배경

`TODO.md`의 Rust rewrite 우선순위에 따라 `P064-B`를 진행했습니다. 이번 PR은 현재 JS 구현을 기준으로 `duplicate-config`와 `eslint/prettier` 관련 base checks를 Rust로 옮기고, 독립 리뷰에서 나온 parity 이슈까지 함께 정리하는 작업입니다.

# 변경 사항

- `crates/maximus-checks`에 Rust base checks 레이어를 추가했습니다.
- `config_duplicates.rs`에서 ESLint / Prettier / Jest 중복 config와 mixed ESLint mode를 JS 계약에 맞춰 구현했습니다.
- `eslint_prettier.rs`에서 formatter conflict / separate 전략 finding을 JS wording과 severity에 맞춰 구현했습니다.
- `registry.rs`를 추가해 check 결과 병합과 finding 정렬을 공통 경로로 묶었습니다.
- `basic_checks.rs`에 crate-level regression test를 추가해 id, severity, detail, hint, file, 정렬 결과를 고정했습니다.
- review follow-up으로 `package.json`의 falsy `eslintConfig` / `prettier` 값을 JS truthiness와 맞춰 처리했고, duplicate detail의 Windows path rendering도 JS와 맞췄습니다.

# 검증

- `cargo test -p maximus-checks`
- `cargo test --workspace`
- `npm test`

# 리스크 또는 후속 확인 포인트

- 이번 PR은 Rust checks layer 추가까지가 범위이고, 실제 shipped runtime wiring은 다음 단계인 `P064-C`에서 이어집니다.
- 현재는 duplicate-config / eslint-prettier parity만 포함하며, env / tsconfig / structure / env fix parity는 후속 PR에서 연결됩니다.
