### PR TITLE
[codex] Rust MVP integration 연결

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
 name = "maximus-cli"
 version = "0.1.0"
 dependencies = [
+ "maximus-checks",
  "maximus-core",
  "serde",
  "serde_json",

--- a/crates/maximus-checks/src/check_outcome.rs
+++ b/crates/maximus-checks/src/check_outcome.rs
@@ -1,0 +1,8 @@
+use maximus_core::{Finding, FixPlan, PlannedFix};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CheckOutcome {
+    pub findings: Vec<Finding>,
+    pub fixes: Vec<FixPlan>,
+    pub planned_fixes: Vec<PlannedFix>,
+}

--- a/crates/maximus-checks/src/config_duplicates.rs
+++ b/crates/maximus-checks/src/config_duplicates.rs
@@ -1,8 +1,7 @@
 use maximus_core::{make_finding, FileKind, FindingInput, ProjectSnapshot, Severity};
 
-use crate::registry::{
-    has_object_key, package_file_for_directory, read_package_json, CheckOutcome,
-};
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{has_object_key, package_file_for_directory, read_package_json};
 
 pub fn run_config_duplicate_check(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
     let mut findings = Vec::new();
@@ -94,6 +93,7 @@ pub fn run_config_duplicate_check(project: &ProjectSnapshot) -> std::io::Result<
     Ok(CheckOutcome {
         findings,
         fixes: Vec::new(),
+        planned_fixes: Vec::new(),
     })
 }
 

--- a/crates/maximus-checks/src/env.rs
+++ b/crates/maximus-checks/src/env.rs
@@ -4,19 +4,17 @@ use std::path::Path;
 
 use maximus_core::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, make_finding,
-    parse_env, read_text_if_exists, render_env_template, sort_findings, unique_fixes, FileKind,
-    Finding, FindingInput, FixPlan, ProjectFile, ProjectSnapshot, Severity,
+    parse_env, plan_create_env_example, plan_sync_env_example, read_text_if_exists,
+    render_env_template, sort_findings, unique_fixes, FileKind, FindingInput, FixPlan,
+    ProjectFile, ProjectSnapshot, Severity,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CheckOutcome {
-    pub findings: Vec<Finding>,
-    pub fixes: Vec<FixPlan>,
-}
+use crate::check_outcome::CheckOutcome;
 
 pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
     let mut findings = Vec::new();
     let mut fixes = Vec::new();
+    let mut planned_fixes = Vec::new();
 
     for directory in &project.directories {
         let env_files = directory
@@ -35,7 +33,11 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
             };
 
             let parsed = parse_env(&text, Some(&file.name));
-            parsed_records.push(ParsedEnvRecord { file, parsed });
+            parsed_records.push(ParsedEnvRecord {
+                file,
+                parsed_source_text: text,
+                parsed,
+            });
         }
 
         if parsed_records.is_empty() {
@@ -136,6 +138,11 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                 ),
                 files: vec![output_path],
             });
+            planned_fixes.push(plan_create_env_example(
+                &project.root_dir,
+                &directory.dir,
+                &contract_keys,
+            ));
         }
 
         if let Some(example_record) = example_record {
@@ -178,6 +185,12 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                     ),
                     files: vec![example_record.file.path.clone()],
                 });
+                planned_fixes.push(plan_sync_env_example(
+                    &project.root_dir,
+                    &example_record.file.path,
+                    &example_record.parsed_source_text,
+                    &missing_keys,
+                ));
             }
 
             for contract_record in &contract_records {
@@ -291,6 +304,7 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
     Ok(CheckOutcome {
         findings: sort_findings(&findings),
         fixes: unique_fixes(&fixes),
+        planned_fixes,
     })
 }
 
@@ -316,6 +330,7 @@ pub fn render_synced_env_example(existing_text: &str, missing_keys: &[String]) -
 #[derive(Debug, Clone)]
 struct ParsedEnvRecord {
     file: ProjectFile,
+    parsed_source_text: String,
     parsed: maximus_core::ParsedEnv,
 }
 

--- a/crates/maximus-checks/src/eslint_prettier.rs
+++ b/crates/maximus-checks/src/eslint_prettier.rs
@@ -1,6 +1,7 @@
 use maximus_core::{make_finding, FileKind, FindingInput, ProjectSnapshot, Severity, read_text_if_exists};
 
-use crate::registry::{package_file_for_directory, read_package_json, CheckOutcome};
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{package_file_for_directory, read_package_json};
 
 const FORMATTING_RULES: &[&str] = &[
     "array-bracket-spacing",
@@ -122,6 +123,7 @@ pub fn run_eslint_prettier_check(project: &ProjectSnapshot) -> std::io::Result<C
     Ok(CheckOutcome {
         findings,
         fixes: Vec::new(),
+        planned_fixes: Vec::new(),
     })
 }
 

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -1,9 +1,17 @@
 //! Base check implementations for the Maximus Rust rewrite.
 
+mod check_outcome;
 mod config_duplicates;
+mod env;
 mod eslint_prettier;
+pub mod structure;
+mod tsconfig;
 pub mod registry;
 
+pub use check_outcome::CheckOutcome;
 pub use config_duplicates::run_config_duplicate_check;
+pub use env::{render_created_env_example, render_synced_env_example, run_env_check};
 pub use eslint_prettier::run_eslint_prettier_check;
-pub use registry::{run_registered_checks, CheckOutcome};
+pub use registry::{audit_project, run_registered_checks, AuditedProject};
+pub use structure::build_structure_report;
+pub use tsconfig::run_tsconfig_check;

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -1,31 +1,53 @@
+use std::io;
 use std::path::Path;
 
 use maximus_core::{
-    parse_jsonc, sort_findings, unique_fixes, FixPlan, Finding, ProjectDirectory, ProjectFile,
-    ProjectSnapshot, read_text_if_exists,
+    discover_project, parse_jsonc, sort_findings, summarize_findings, unique_fixes, AuditResult,
+    PlannedFix, ProjectDirectory, ProjectFile, ProjectSnapshot, read_text_if_exists,
 };
 
-use crate::{run_config_duplicate_check, run_eslint_prettier_check};
+use crate::check_outcome::CheckOutcome;
+use crate::{
+    build_structure_report, run_config_duplicate_check, run_env_check, run_eslint_prettier_check,
+    run_tsconfig_check,
+};
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CheckOutcome {
-    pub findings: Vec<Finding>,
-    pub fixes: Vec<FixPlan>,
-}
-
-impl CheckOutcome {
-    pub fn empty() -> Self {
-        Self::default()
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditedProject {
+    pub project: ProjectSnapshot,
+    pub result: AuditResult,
+    pub planned_fixes: Vec<PlannedFix>,
 }
 
 pub fn run_registered_checks(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
     let outcomes = [
         run_config_duplicate_check(project)?,
+        run_env_check(project)?,
         run_eslint_prettier_check(project)?,
+        run_tsconfig_check(project)?,
     ];
 
     Ok(merge_outcomes(outcomes))
+}
+
+pub fn audit_project(root_dir: &Path) -> io::Result<AuditedProject> {
+    let project = discover_project(root_dir)?;
+    let outcome = run_registered_checks(&project)?;
+    let structure = build_structure_report(&project, &outcome.findings);
+    let summary = summarize_findings(&outcome.findings, &outcome.fixes, &structure);
+    let result = AuditResult {
+        root_dir: project.root_dir.clone(),
+        summary,
+        structure,
+        findings: outcome.findings,
+        fixes: outcome.fixes,
+    };
+
+    Ok(AuditedProject {
+        project,
+        result,
+        planned_fixes: outcome.planned_fixes,
+    })
 }
 
 pub(crate) fn merge_outcomes<I>(outcomes: I) -> CheckOutcome
@@ -34,16 +56,32 @@ where
 {
     let mut findings = Vec::new();
     let mut fixes = Vec::new();
+    let mut planned_fixes = Vec::new();
 
     for outcome in outcomes {
         findings.extend(outcome.findings);
         fixes.extend(outcome.fixes);
+        planned_fixes.extend(outcome.planned_fixes);
     }
 
     CheckOutcome {
         findings: sort_findings(&findings),
         fixes: unique_fixes(&fixes),
+        planned_fixes: unique_planned_fixes(&planned_fixes),
     }
+}
+
+fn unique_planned_fixes(fixes: &[PlannedFix]) -> Vec<PlannedFix> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut unique = Vec::new();
+
+    for fix in fixes {
+        if seen.insert(fix.public.id.clone()) {
+            unique.push(fix.clone());
+        }
+    }
+
+    unique
 }
 
 pub(crate) fn package_file_for_directory(directory: &ProjectDirectory) -> Option<&ProjectFile> {

--- a/crates/maximus-checks/src/tsconfig.rs
+++ b/crates/maximus-checks/src/tsconfig.rs
@@ -4,9 +4,11 @@ use std::path::{Component, Path, PathBuf};
 
 use maximus_core::{
     find_nearest_package_file, get_files, make_finding, parse_jsonc, path_exists,
-    read_text_if_exists, FileKind, Finding, FindingInput, FixPlan, ProjectSnapshot, Severity,
+    read_text_if_exists, FileKind, Finding, FindingInput, ProjectSnapshot, Severity,
 };
 use serde_json::{Map, Value};
+
+use crate::check_outcome::CheckOutcome;
 
 const DEPRECATED_COMPILER_OPTIONS: &[(&str, &str)] = &[
     (
@@ -44,12 +46,6 @@ const CHECKABLE_EXTENSIONS: &[&str] = &[
     ".cjs", ".cts", ".js", ".json", ".jsx", ".mjs", ".mts", ".ts", ".tsx",
 ];
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CheckOutcome {
-    pub findings: Vec<Finding>,
-    pub fixes: Vec<FixPlan>,
-}
-
 pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
     let mut findings = Vec::new();
 
@@ -85,6 +81,10 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
         let Some(paths_config) = compiler_options.and_then(|options| options.get("paths")) else {
             continue;
         };
+
+        if paths_config.is_null() {
+            continue;
+        }
 
         let Some(paths_config) = paths_config.as_object() else {
             findings.push(make_finding(FindingInput {
@@ -140,6 +140,7 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
     Ok(CheckOutcome {
         findings,
         fixes: Vec::new(),
+        planned_fixes: Vec::new(),
     })
 }
 

--- a/crates/maximus-checks/tests/env_checks.rs
+++ b/crates/maximus-checks/tests/env_checks.rs
@@ -3,9 +3,11 @@ use std::path::{Path, PathBuf};
 
 #[path = "../src/env.rs"]
 mod env;
+#[path = "../src/check_outcome.rs"]
+mod check_outcome;
 
 use env::{render_created_env_example, render_synced_env_example, run_env_check};
-use maximus_core::{discover_project, FixPlan, Severity};
+use maximus_core::{apply_fix, discover_project, FixOperation, FixPlan, Severity};
 use tempfile::TempDir;
 
 #[test]
@@ -143,6 +145,43 @@ fn env_check_plans_example_creation_when_runtime_env_files_exist_without_contrac
         "Create apps/web/.env.example",
         &[dir.join(".env.example")],
     );
+    assert_eq!(outcome.planned_fixes.len(), 1);
+}
+
+#[test]
+fn env_sync_planned_fix_uses_audited_snapshot_text() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let example_path = fixture.path().join(".env.example");
+
+    write(fixture.path().join(".env"), "PRIMARY=1\nSECONDARY=2\n");
+    write(&example_path, "PRIMARY=\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_env_check(&project).expect("check should run");
+    let planned = outcome
+        .planned_fixes
+        .iter()
+        .find(|fix| fix.public.id == format!("env-example:sync:{}", fixture.path().to_string_lossy()))
+        .expect("planned sync fix should exist")
+        .clone();
+
+    match &planned.operation {
+        FixOperation::SyncEnvExample {
+            existing_text,
+            missing_keys,
+            ..
+        } => {
+            assert_eq!(existing_text, "PRIMARY=\n");
+            assert_eq!(missing_keys, &vec!["SECONDARY".to_string()]);
+        }
+        _ => panic!("expected sync env example operation"),
+    }
+
+    fs::write(&example_path, "MUTATED=\n").expect("mutated example file should write");
+    apply_fix(&planned).expect("planned fix should apply");
+
+    let output = fs::read_to_string(&example_path).expect("example file should exist");
+    assert_eq!(output, "PRIMARY=\nSECONDARY=\n");
 }
 
 #[test]

--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -6,6 +6,8 @@ use tempfile::TempDir;
 
 #[path = "../src/tsconfig.rs"]
 mod tsconfig;
+#[path = "../src/check_outcome.rs"]
+mod check_outcome;
 
 use tsconfig::run_tsconfig_check;
 
@@ -227,6 +229,26 @@ fn tsconfig_check_reports_paths_shape_type_empty_wildcard_and_missing_findings()
         }),
         "scoped package targets should bypass file existence checks"
     );
+}
+
+#[test]
+fn tsconfig_check_treats_null_paths_like_missing_paths() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "paths": null } }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "null paths should be ignored like the JS reference implementation"
+    );
+    assert!(outcome.fixes.is_empty());
+    assert!(outcome.planned_fixes.is_empty());
 }
 
 #[test]

--- a/crates/maximus-cli/Cargo.toml
+++ b/crates/maximus-cli/Cargo.toml
@@ -12,6 +12,7 @@ name = "maximus"
 path = "src/main.rs"
 
 [dependencies]
+maximus-checks = { path = "../maximus-checks" }
 maximus-core = { path = "../maximus-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -8,22 +8,12 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::{Display, Formatter};
 use std::io;
-use std::path::{Path, PathBuf};
 use std::process;
-use std::process::Command;
 
-use serde::Serialize;
+use maximus_checks::audit_project;
+use maximus_core::apply_fixes;
 
 use crate::args::{parse_args, Flags};
-
-#[cfg_attr(not(test), allow(dead_code))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct AppliedFix {
-    pub id: String,
-    pub title: String,
-    pub files: Vec<PathBuf>,
-    pub outcome: Option<String>,
-}
 
 #[derive(Debug)]
 enum CliError {
@@ -88,169 +78,114 @@ where
     let target_dir = resolve_target_dir(parsed.args.first().map(|value| value.as_os_str()))?;
 
     match parsed.command.as_deref() {
-        Some("audit") => delegate_to_js("audit", &target_dir, &parsed.flags),
-        Some("doctor") => delegate_to_js("doctor", &target_dir, &parsed.flags),
-        Some("fix") => delegate_to_js("fix", &target_dir, &parsed.flags),
+        Some("audit") => run_audit_command(&target_dir, &parsed.flags),
+        Some("doctor") => run_doctor_command(&target_dir, &parsed.flags),
+        Some("fix") => run_fix_command(&target_dir, &parsed.flags),
         Some(command) => Err(CliError::UnknownCommand(command.to_string())),
         None => Ok(exit_codes::SUCCESS),
     }
 }
 
-fn resolve_target_dir(path_arg: Option<&OsStr>) -> io::Result<PathBuf> {
+fn run_audit_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
+    let audited = audit_project(target_dir)?;
+
+    if flags.json {
+        println!("{}", report_json::render_audit_result(&audited.result)?);
+    } else {
+        println!("{}", report_text::format_audit_report(&audited.result));
+    }
+
+    Ok(exit_codes::audit_exit_code(&audited.result.summary))
+}
+
+fn run_doctor_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
+    let audited = audit_project(target_dir)?;
+
+    if flags.json {
+        println!("{}", report_json::render_audit_result(&audited.result)?);
+    } else {
+        println!("{}", report_text::format_doctor_report(&audited.result));
+    }
+
+    Ok(exit_codes::audit_exit_code(&audited.result.summary))
+}
+
+fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
+    let initial = audit_project(target_dir)?;
+    if initial.planned_fixes.len() != initial.result.fixes.len() {
+        return Err(CliError::Io(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "one or more fixes are not executable from the Rust runtime yet",
+        )));
+    }
+    let planned = initial.planned_fixes.clone();
+    let applied = if flags.dry_run {
+        Vec::new()
+    } else {
+        apply_fixes(&planned)?
+    };
+    let final_result = if flags.dry_run {
+        initial.result.clone()
+    } else {
+        audit_project(target_dir)?.result
+    };
+
+    if flags.json {
+        println!(
+            "{}",
+            report_json::render_fix_result(
+                flags.dry_run,
+                target_dir,
+                &initial.result,
+                &applied,
+                &final_result,
+            )?
+        );
+    } else {
+        println!(
+            "{}",
+            report_text::format_fix_result(
+                flags.dry_run,
+                target_dir,
+                &initial.result,
+                &applied,
+                &final_result,
+            )
+        );
+    }
+
+    Ok(exit_codes::fix_exit_code(&final_result.summary))
+}
+
+fn resolve_target_dir(path_arg: Option<&OsStr>) -> io::Result<std::path::PathBuf> {
     match path_arg {
-        Some(path) => std::path::absolute(PathBuf::from(path)),
+        Some(path) => std::path::absolute(std::path::PathBuf::from(path)),
         None => env::current_dir(),
     }
 }
 
-fn delegate_to_js(command: &str, target_dir: &Path, flags: &Flags) -> Result<i32, CliError> {
-    let mut child = Command::new("node");
-    child.arg(resolve_reference_cli_entrypoint()?);
-    child.arg(command);
-    child.arg(target_dir);
-
-    if flags.dry_run {
-        child.arg("--dry-run");
-    }
-
-    if flags.json {
-        child.arg("--json");
-    }
-
-    let output = child.output()?;
-
-    if !output.stdout.is_empty() {
-        print!("{}", String::from_utf8_lossy(&output.stdout));
-    }
-
-    if !output.stderr.is_empty() {
-        eprint!("{}", String::from_utf8_lossy(&output.stderr));
-    }
-
-    Ok(output.status.code().unwrap_or(exit_codes::FAILURE))
-}
-
-fn resolve_reference_cli_entrypoint() -> Result<PathBuf, CliError> {
-    let search_roots = build_reference_cli_search_roots()?;
-
-    find_reference_cli_from_roots(search_roots).ok_or_else(|| {
-        CliError::Io(io::Error::new(
-            io::ErrorKind::NotFound,
-            "could not find bin/maximus.js from the current runtime context; run inside the repository checkout or set MAXIMUS_REPO_ROOT",
-        ))
-    })
-}
-
-fn build_reference_cli_search_roots() -> io::Result<Vec<PathBuf>> {
-    let mut roots = Vec::new();
-
-    if let Some(repo_root) = env::var_os("MAXIMUS_REPO_ROOT") {
-        roots.push(PathBuf::from(repo_root));
-    }
-
-    roots.extend(ancestor_paths(env::current_exe()?));
-
-    Ok(roots)
-}
-
-fn ancestor_paths(path: PathBuf) -> Vec<PathBuf> {
-    let start = if path.is_file() {
-        path.parent().map(Path::to_path_buf).unwrap_or(path)
-    } else {
-        path
-    };
-
-    start.ancestors().map(Path::to_path_buf).collect()
-}
-
-fn find_reference_cli_from_roots<I>(roots: I) -> Option<PathBuf>
-where
-    I: IntoIterator<Item = PathBuf>,
-{
-    for root in roots {
-        let candidate = root.join("bin/maximus.js");
-        if candidate.is_file() && root.join("package.json").is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::path::PathBuf;
 
-    use tempfile::tempdir;
-
-    use super::{ancestor_paths, find_reference_cli_from_roots};
+    use super::resolve_target_dir;
 
     #[test]
-    fn ancestor_paths_include_parent_chain_for_files() {
-        let path = PathBuf::from("/tmp/repo/target/debug/maximus");
-        let ancestors = ancestor_paths(path);
-
-        assert!(ancestors.contains(&PathBuf::from("/tmp/repo/target/debug")));
-        assert!(ancestors.contains(&PathBuf::from("/tmp/repo/target")));
-        assert!(ancestors.contains(&PathBuf::from("/tmp/repo")));
+    fn resolve_target_dir_uses_absolute_current_dir_by_default() {
+        let resolved = resolve_target_dir(None).expect("current dir should resolve");
+        assert!(resolved.is_absolute());
     }
 
     #[test]
-    fn reference_cli_path_is_found_from_nested_runtime_roots() {
-        let temp = tempdir().expect("temp dir should exist");
-        let repo_root = temp.path().join("repo");
-        let nested_dir = repo_root.join("target/debug/deps");
-        let bin_dir = repo_root.join("bin");
-
-        fs::create_dir_all(&nested_dir).expect("nested dir should exist");
-        fs::create_dir_all(&bin_dir).expect("bin dir should exist");
-        fs::write(repo_root.join("package.json"), "{}").expect("package.json should exist");
-        fs::write(bin_dir.join("maximus.js"), "console.log('ok');")
-            .expect("reference cli should exist");
-
-        let found = find_reference_cli_from_roots(ancestor_paths(nested_dir))
-            .expect("reference cli should be found");
-
-        assert_eq!(found, repo_root.join("bin/maximus.js"));
+    fn resolve_target_dir_makes_relative_path_absolute() {
+        let resolved = resolve_target_dir(Some(".".as_ref())).expect("path should resolve");
+        assert!(resolved.is_absolute());
     }
 
     #[test]
-    fn reference_cli_path_is_absent_when_repo_markers_are_missing() {
-        let temp = tempdir().expect("temp dir should exist");
-        let root = temp.path().join("random");
-
-        fs::create_dir_all(root.join("bin")).expect("bin dir should exist");
-        fs::write(root.join("bin/maximus.js"), "console.log('ok');")
-            .expect("script should exist");
-
-        assert!(find_reference_cli_from_roots([root]).is_none());
-    }
-
-    #[test]
-    fn search_roots_prefer_current_exe_ancestors_over_current_dir() {
-        let temp = tempdir().expect("temp dir should exist");
-        let right_repo = temp.path().join("right-repo");
-        let wrong_repo = temp.path().join("wrong-repo");
-        let exe_dir = right_repo.join("target/debug");
-
-        fs::create_dir_all(right_repo.join("bin")).expect("right bin dir should exist");
-        fs::create_dir_all(wrong_repo.join("bin")).expect("wrong bin dir should exist");
-        fs::create_dir_all(&exe_dir).expect("exe dir should exist");
-        fs::write(right_repo.join("package.json"), "{}").expect("right package.json should exist");
-        fs::write(wrong_repo.join("package.json"), "{}").expect("wrong package.json should exist");
-        fs::write(right_repo.join("bin/maximus.js"), "console.log('right');")
-            .expect("right maximus should exist");
-        fs::write(wrong_repo.join("bin/maximus.js"), "console.log('wrong');")
-            .expect("wrong maximus should exist");
-
-        let roots = ancestor_paths(exe_dir)
-            .into_iter()
-            .chain(ancestor_paths(wrong_repo.clone()))
-            .collect::<Vec<_>>();
-
-        let found = find_reference_cli_from_roots(roots).expect("reference cli should be found");
-
-        assert_eq!(found, right_repo.join("bin/maximus.js"));
+    fn resolve_target_dir_keeps_absolute_paths() {
+        let path = PathBuf::from("/tmp");
+        let resolved = resolve_target_dir(Some(path.as_os_str())).expect("path should resolve");
+        assert_eq!(resolved, path);
     }
 }

--- a/crates/maximus-cli/src/report_json.rs
+++ b/crates/maximus-cli/src/report_json.rs
@@ -2,10 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
-use maximus_core::{serialize_audit_result, AuditResult, SerializableAuditResult};
+use maximus_core::{serialize_audit_result, AppliedFix, AuditResult, SerializableAuditResult};
 use serde::Serialize;
-
-use crate::AppliedFix;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,7 +47,7 @@ pub fn render_fix_result(
                 id: fix.id.clone(),
                 title: fix.title.clone(),
                 files: fix.files.clone(),
-                outcome: fix.outcome.clone(),
+                outcome: Some(fix.outcome.clone()),
             })
             .collect(),
         final_result: serialize_audit_result(final_result),
@@ -60,7 +58,7 @@ pub fn render_fix_result(
 mod tests {
     use std::path::PathBuf;
 
-    use maximus_core::{AuditResult, AuditSummary, StructureReport};
+    use maximus_core::{AppliedFix, AuditResult, AuditSummary, StructureReport};
     use serde_json::Value;
 
     use super::{render_audit_result, render_fix_result};
@@ -98,11 +96,11 @@ mod tests {
             false,
             PathBuf::from("/tmp/project").as_path(),
             &result,
-            &[crate::AppliedFix {
+            &[AppliedFix {
                 id: "env-example:create:/tmp/project".to_string(),
                 title: "Create .env.example".to_string(),
                 files: vec![PathBuf::from("/tmp/project/.env.example")],
-                outcome: Some("created".to_string()),
+                outcome: "created".to_string(),
             }],
             &result,
         )

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -2,9 +2,7 @@
 
 use std::path::Path;
 
-use maximus_core::{AuditResult, StructureReport};
-
-use crate::AppliedFix;
+use maximus_core::{AppliedFix, AuditResult, StructureReport};
 
 pub fn format_help() -> String {
     [
@@ -277,9 +275,7 @@ fn relative_path_like_js(root_dir: &Path, file_path: &Path) -> Option<String> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use maximus_core::{AuditResult, AuditSummary, StructureReport};
-
-    use crate::AppliedFix;
+    use maximus_core::{AppliedFix, AuditResult, AuditSummary, StructureReport};
 
     use super::{
         format_audit_report, format_doctor_report, format_fix_result, format_help,

--- a/crates/maximus-cli/tests/mvp_parity.rs
+++ b/crates/maximus-cli/tests/mvp_parity.rs
@@ -1,0 +1,218 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn rust_maximus() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+fn js_maximus() -> Command {
+    let mut command = Command::new("node");
+    command.arg(workspace_root().join("bin/maximus.js"));
+    command
+}
+
+#[test]
+fn text_commands_match_js_reference_outputs() {
+    for args in [
+        vec!["audit".to_string(), fixture_path("clean-project").display().to_string()],
+        vec!["doctor".to_string(), fixture_path("clean-project").display().to_string()],
+        vec!["audit".to_string(), fixture_path("reference-env").display().to_string()],
+        vec!["doctor".to_string(), fixture_path("reference-env").display().to_string()],
+        vec![
+            "fix".to_string(),
+            fixture_path("reference-env").display().to_string(),
+            "--dry-run".to_string(),
+        ],
+        vec![
+            "audit".to_string(),
+            fixture_path("reference-tsconfig").display().to_string(),
+        ],
+    ] {
+        assert_command_matches_js(&args);
+    }
+}
+
+#[test]
+fn json_commands_match_js_reference_outputs() {
+    for args in [
+        vec![
+            "audit".to_string(),
+            fixture_path("clean-project").display().to_string(),
+            "--json".to_string(),
+        ],
+        vec![
+            "doctor".to_string(),
+            fixture_path("reference-env").display().to_string(),
+            "--json".to_string(),
+        ],
+        vec![
+            "audit".to_string(),
+            fixture_path("reference-tsconfig").display().to_string(),
+            "--json".to_string(),
+        ],
+        vec![
+            "fix".to_string(),
+            fixture_path("reference-env").display().to_string(),
+            "--dry-run".to_string(),
+            "--json".to_string(),
+        ],
+    ] {
+        assert_json_command_matches_js(&args);
+    }
+}
+
+#[test]
+fn fix_apply_matches_js_for_text_output_and_written_file() {
+    let rust_fixture = prepare_temp_reference_env();
+    let js_fixture = prepare_temp_reference_env();
+
+    let rust_output = rust_maximus()
+        .args(["fix", rust_fixture.to_string_lossy().as_ref()])
+        .output()
+        .expect("rust fix should run");
+    let js_output = js_maximus()
+        .args(["fix", js_fixture.to_string_lossy().as_ref()])
+        .output()
+        .expect("js fix should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+    assert_eq!(
+        normalize_output(&rust_output.stdout, &rust_fixture),
+        normalize_output(&js_output.stdout, &js_fixture)
+    );
+    assert_eq!(rust_output.stderr, js_output.stderr);
+    assert_eq!(
+        fs::read_to_string(rust_fixture.join(".env.example")).expect("rust output file should exist"),
+        fs::read_to_string(js_fixture.join(".env.example")).expect("js output file should exist")
+    );
+}
+
+#[test]
+fn fix_apply_matches_js_for_json_shape_and_written_file() {
+    let rust_fixture = prepare_temp_reference_env();
+    let js_fixture = prepare_temp_reference_env();
+
+    let rust_output = rust_maximus()
+        .args(["fix", rust_fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("rust fix json should run");
+    let js_output = js_maximus()
+        .args(["fix", js_fixture.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("js fix json should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code());
+    assert_eq!(rust_output.stderr, js_output.stderr);
+
+    let rust_json = normalize_json_output(&rust_output, &rust_fixture);
+    let js_json = normalize_json_output(&js_output, &js_fixture);
+
+    assert_eq!(rust_json, js_json);
+    assert_eq!(
+        fs::read_to_string(rust_fixture.join(".env.example")).expect("rust output file should exist"),
+        fs::read_to_string(js_fixture.join(".env.example")).expect("js output file should exist")
+    );
+}
+
+fn assert_command_matches_js(args: &[String]) {
+    let rust_output = rust_maximus()
+        .args(args)
+        .output()
+        .expect("rust command should run");
+    let js_output = js_maximus()
+        .args(args)
+        .output()
+        .expect("js command should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code(), "{args:?}");
+    assert_eq!(
+        normalize_output_for_args(&rust_output, args),
+        normalize_output_for_args(&js_output, args),
+        "{args:?}"
+    );
+    assert_eq!(rust_output.stderr, js_output.stderr, "{args:?}");
+}
+
+fn assert_json_command_matches_js(args: &[String]) {
+    let rust_output = rust_maximus()
+        .args(args)
+        .output()
+        .expect("rust command should run");
+    let js_output = js_maximus()
+        .args(args)
+        .output()
+        .expect("js command should run");
+
+    assert_eq!(rust_output.status.code(), js_output.status.code(), "{args:?}");
+    assert_eq!(
+        normalize_json_output(&rust_output, Path::new(&args[1])),
+        normalize_json_output(&js_output, Path::new(&args[1])),
+        "{args:?}"
+    );
+    assert_eq!(rust_output.stderr, js_output.stderr, "{args:?}");
+}
+
+fn normalize_output_for_args(output: &Output, args: &[String]) -> String {
+    normalize_output(&output.stdout, Path::new(&args[1]))
+}
+
+fn normalize_output(stdout: &[u8], target_dir: &Path) -> String {
+    let target = target_dir.to_string_lossy().into_owned();
+    String::from_utf8(stdout.to_vec())
+        .expect("stdout should be utf8")
+        .replace("\r\n", "\n")
+        .replace(&target, "<TARGET>")
+}
+
+fn normalize_json_output(output: &Output, target_dir: &Path) -> Value {
+    let mut value: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    rewrite_json_paths(&mut value, target_dir);
+    value
+}
+
+fn rewrite_json_paths(value: &mut Value, target_dir: &Path) {
+    let target = target_dir.to_string_lossy().into_owned();
+    match value {
+        Value::String(text) => {
+            *text = text.replace(&target, "<TARGET>");
+        }
+        Value::Array(values) => {
+            for entry in values {
+                rewrite_json_paths(entry, Path::new(&target));
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values_mut() {
+                rewrite_json_paths(value, Path::new(&target));
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    workspace_root().join("test/fixtures").join(name)
+}
+
+fn prepare_temp_reference_env() -> PathBuf {
+    let temp = tempdir().expect("temp dir should exist");
+    let target = temp.keep();
+    let source = fixture_path("reference-env").join(".env");
+
+    fs::create_dir_all(&target).expect("target dir should exist");
+    fs::copy(source, target.join(".env")).expect("env fixture should copy");
+
+    target
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod discover;
 pub mod env_parser;
+pub mod fixes;
 pub mod findings;
 pub mod fs;
 pub mod jsonc;
@@ -12,6 +13,10 @@ pub use discover::{discover_project, find_nearest_package_file, get_directories,
 pub use env_parser::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, parse_env,
     render_env_template, EnvDuplicate, EnvEntry, InvalidEnvLine, ParsedEnv,
+};
+pub use fixes::{
+    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, AppliedFix,
+    FixOperation, PlannedFix,
 };
 pub use findings::{
     make_finding, serialize_audit_result, sort_findings, summarize_findings, unique_fixes,

--- a/test/golden-rust/env-missing-example.doctor.txt
+++ b/test/golden-rust/env-missing-example.doctor.txt
@@ -1,0 +1,15 @@
+Maximus doctor
+Target: <TARGET>
+
+Diagnosis: attention needed
+Project shape: single package, 0 package(s), 1 config file(s), 1 env folder(s)
+
+Prescription
+- Run "maximus fix" to apply 1 safe fix(es).
+- No manual follow-up is required right now.
+
+Findings
+- [warn] Missing .env.example contract
+  file: .env
+  detail: Runtime env files exist, but .env.example is missing.
+  hint: Run "maximus fix" to create a blank contract file.

--- a/test/reference-parity.test.js
+++ b/test/reference-parity.test.js
@@ -31,6 +31,13 @@ const scenarios = [
     targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
   },
   {
+    name: "reference env doctor output stays stable",
+    args: ["doctor", "./test/fixtures/reference-env"],
+    goldenFile: "env-missing-example.doctor.txt",
+    expectedStatus: 1,
+    targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
+  },
+  {
     name: "reference env fix dry-run output stays stable",
     args: ["fix", "./test/fixtures/reference-env", "--dry-run"],
     goldenFile: "env-missing-example.fix-dry-run.txt",


### PR DESCRIPTION
## 요약
- Rust CLI가 JS delegate 없이 audit, doctor, fix, --json을 직접 수행하도록 연결했습니다.
- merged seed였던 env, tsconfig, structure, env-fix를 Rust runtime surface에 묶고 parity integration test를 추가했습니다.
- review loop에서 나온 paths: null parity와 env sync snapshot 이슈를 함께 수정했습니다.

## 주요 변경
- maximus-checks에 audit surface와 planned_fixes wiring을 추가했습니다.
- maximus-core의 fix plan/export surface를 정리하고 audited snapshot 기반 env sync를 사용하도록 맞췄습니다.
- maximus-cli에서 JS delegation을 제거하고 Rust runtime orchestration으로 전환했습니다.
- crates/maximus-cli/tests/mvp_parity.rs와 golden/reference 테스트를 추가해 JS CLI와 text/json/status/file-write parity를 검증했습니다.

## 검증
- cargo test -p maximus-checks --test tsconfig_checks
- cargo test -p maximus-checks --test env_checks
- cargo test --workspace
- npm test

## 리뷰 메모
- Devil's Advocate Round 1에서 High 1건, Medium 1건을 수용해 수정했습니다.
- Round 2 delta review에서는 추가 이슈가 없었습니다.
