### PR TITLE
[codex] Rust package entrypoints seed 추가

### DIFF
--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -5,6 +5,7 @@ mod config_duplicates;
 mod env;
 mod eslint_prettier;
 pub mod lockfiles;
+pub mod package_entrypoints;
 pub mod structure;
 mod tsconfig;
 pub mod registry;

--- a/crates/maximus-checks/src/package_entrypoints.rs
+++ b/crates/maximus-checks/src/package_entrypoints.rs
@@ -1,0 +1,1881 @@
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use maximus_core::{
+    get_files, make_finding, parse_jsonc, path_exists, read_text_if_exists, FileKind, Finding,
+    FindingInput, ProjectSnapshot, Severity,
+};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+
+const RUNTIME_EXTENSIONS: &[&str] = &[
+    ".cjs", ".cts", ".js", ".json", ".jsx", ".mjs", ".mts", ".node", ".ts", ".tsx",
+];
+const TYPES_EXTENSIONS: &[&str] = &[".d.cts", ".d.mts", ".d.ts"];
+const MAX_NESTED_PACKAGE_DEPTH: usize = 8;
+pub fn run_package_entrypoints_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for file in get_files(project, FileKind::Package) {
+        let Some(text) = read_text_if_exists(&file.path)? else {
+            continue;
+        };
+
+        let package_json = match parse_jsonc::<Value>(&text, &file.path.to_string_lossy()) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        let package_dir = file.path.parent().unwrap_or(project.root_dir.as_path());
+        collect_findings(
+            &mut findings,
+            &file.path,
+            package_dir,
+            &package_json,
+            &["main", "module", "types", "bin", "exports", "imports"],
+        )?;
+    }
+
+    findings = unique_findings_by_id(findings);
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn collect_findings(
+    findings: &mut Vec<Finding>,
+    package_path: &Path,
+    package_dir: &Path,
+    package_json: &Value,
+    entrypoint_fields: &[&str],
+) -> io::Result<()> {
+    for field_name in entrypoint_fields {
+        let Some(value) = package_json.get(field_name) else {
+            continue;
+        };
+
+        scan_entrypoint_value(
+            findings,
+            package_path,
+            package_dir,
+            vec![field_name.to_string()],
+            value,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn scan_entrypoint_value(
+    findings: &mut Vec<Finding>,
+    package_path: &Path,
+    package_dir: &Path,
+    field_path: Vec<String>,
+    value: &Value,
+) -> io::Result<()> {
+    let outcome = inspect_entrypoint_value(package_path, package_dir, field_path, value)?;
+    findings.extend(outcome.findings);
+    Ok(())
+}
+
+#[derive(Default)]
+struct InspectOutcome {
+    findings: Vec<Finding>,
+    has_valid_target: bool,
+}
+
+fn inspect_entrypoint_value(
+    package_path: &Path,
+    package_dir: &Path,
+    field_path: Vec<String>,
+    value: &Value,
+) -> io::Result<InspectOutcome> {
+    match value {
+        Value::String(target) => {
+            if let Some(detail) = invalid_local_target_detail(&field_path, target) {
+                return Ok(InspectOutcome {
+                    findings: vec![make_finding(FindingInput {
+                        id: format!(
+                            "package-entrypoints:{}:{}:{}",
+                            package_path.to_string_lossy(),
+                            field_path.join("/"),
+                            target
+                        ),
+                        title: "Package entrypoint target is invalid".to_string(),
+                        category: Some("package-entrypoints".to_string()),
+                        detail: Some(detail),
+                        file: Some(package_path.to_path_buf()),
+                        fix_ids: Vec::new(),
+                        fixable: false,
+                        hint: Some(
+                            "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments."
+                                .to_string(),
+                        ),
+                        severity: Some(severity_for_field_path(&field_path)),
+                    })],
+                    has_valid_target: false,
+                });
+            }
+
+            if field_path.first().is_some_and(|field| field == "imports")
+                && is_valid_external_import_target(target)
+            {
+                return Ok(InspectOutcome {
+                    findings: Vec::new(),
+                    has_valid_target: true,
+                });
+            }
+
+            if !is_relative_target(package_dir, &field_path, target)? {
+                return Ok(InspectOutcome::default());
+            }
+
+            if target.contains('*') {
+                let wildcard_outcome =
+                    inspect_wildcard_target(package_path, package_dir, &field_path, target)?;
+                if wildcard_outcome.has_valid_target || !wildcard_outcome.findings.is_empty() {
+                    return Ok(wildcard_outcome);
+                }
+
+                return Ok(InspectOutcome {
+                    findings: vec![make_finding(FindingInput {
+                        id: format!(
+                            "package-entrypoints:{}:{}:{}",
+                            package_path.to_string_lossy(),
+                            field_path.join("/"),
+                            target
+                        ),
+                        title: "Package entrypoint target does not exist".to_string(),
+                        category: Some("package-entrypoints".to_string()),
+                        detail: Some(format!(
+                            "package.json {} points to {}, but the resolved path was not found.",
+                            field_path.join("/"),
+                            target
+                        )),
+                        file: Some(package_path.to_path_buf()),
+                        fix_ids: Vec::new(),
+                        fixable: false,
+                        hint: Some(
+                            "Update the relative path or remove the stale entrypoint before publishing."
+                                .to_string(),
+                        ),
+                        severity: Some(severity_for_field_path(&field_path)),
+                    })],
+                    has_valid_target: false,
+                });
+            }
+
+            if let Some(finding) =
+                incompatible_exact_file_finding(package_path, package_dir, &field_path, target)
+            {
+                return Ok(InspectOutcome {
+                    findings: vec![finding],
+                    has_valid_target: false,
+                });
+            }
+
+            let nested_directory_outcome =
+                nested_directory_outcome(package_dir, &field_path, target, package_path)?;
+
+            if relative_target_exists(package_dir, &field_path, target, package_path)? {
+                return Ok(InspectOutcome {
+                    findings: nested_directory_outcome.findings,
+                    has_valid_target: true,
+                });
+            }
+
+            if !nested_directory_outcome.findings.is_empty() {
+                let mut findings = nested_directory_outcome.findings;
+                findings.push(make_finding(FindingInput {
+                    id: format!(
+                        "package-entrypoints:{}:{}:{}",
+                        package_path.to_string_lossy(),
+                        field_path.join("/"),
+                        target
+                    ),
+                    title: "Package entrypoint target does not exist".to_string(),
+                    category: Some("package-entrypoints".to_string()),
+                    detail: Some(format!(
+                        "package.json {} points to {}, but the resolved path was not found.",
+                        field_path.join("/"),
+                        target
+                    )),
+                    file: Some(package_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Update the relative path or remove the stale entrypoint before publishing."
+                            .to_string(),
+                    ),
+                    severity: Some(severity_for_field_path(&field_path)),
+                }));
+                return Ok(InspectOutcome {
+                    findings,
+                    has_valid_target: false,
+                });
+            }
+
+            Ok(InspectOutcome {
+                findings: vec![make_finding(FindingInput {
+                    id: format!(
+                        "package-entrypoints:{}:{}:{}",
+                        package_path.to_string_lossy(),
+                        field_path.join("/"),
+                        target
+                    ),
+                    title: "Package entrypoint target does not exist".to_string(),
+                    category: Some("package-entrypoints".to_string()),
+                    detail: Some(format!(
+                        "package.json {} points to {}, but the resolved path was not found.",
+                        field_path.join("/"),
+                        target
+                    )),
+                    file: Some(package_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Update the relative path or remove the stale entrypoint before publishing."
+                            .to_string(),
+                    ),
+                    severity: Some(severity_for_field_path(&field_path)),
+                })],
+                has_valid_target: false,
+            })
+        }
+        Value::Array(values) => {
+            if !allows_array_target(&field_path) {
+                return Ok(InspectOutcome {
+                    findings: vec![invalid_entrypoint_value_finding(
+                        package_path,
+                        &field_path,
+                        value,
+                    )],
+                    has_valid_target: false,
+                });
+            }
+
+            let mut findings = Vec::new();
+
+            for (index, branch) in values.iter().enumerate() {
+                let mut next_path = field_path.clone();
+                next_path.push(format!("[{index}]"));
+                let branch_outcome =
+                    inspect_entrypoint_value(package_path, package_dir, next_path, branch)?;
+
+                if branch_outcome.has_valid_target {
+                    findings.extend(retained_fallback_findings(branch_outcome.findings));
+                    return Ok(InspectOutcome {
+                        findings: unique_findings_by_id(retained_fallback_findings(findings)),
+                        has_valid_target: true,
+                    });
+                }
+
+                findings.extend(branch_outcome.findings);
+            }
+
+            if findings.len() > 1 {
+                findings = vec![select_best_finding(findings)];
+            }
+
+            Ok(InspectOutcome {
+                findings,
+                has_valid_target: false,
+            })
+        }
+        Value::Object(entries) => {
+            if !allows_object_target(&field_path) {
+                return Ok(InspectOutcome {
+                    findings: vec![invalid_entrypoint_value_finding(
+                        package_path,
+                        &field_path,
+                        value,
+                    )],
+                    has_valid_target: false,
+                });
+            }
+
+            let mut findings = invalid_object_key_findings(package_path, &field_path, entries);
+            let mut has_valid_target = false;
+
+            for (key, branch) in entries {
+                let mut next_path = field_path.clone();
+                next_path.push(key.clone());
+                let branch_outcome =
+                    inspect_entrypoint_value(package_path, package_dir, next_path, branch)?;
+                has_valid_target |= branch_outcome.has_valid_target;
+                findings.extend(branch_outcome.findings);
+            }
+
+            if should_compress_object_branches(&field_path, entries) && findings.len() > 1 {
+                findings = vec![select_best_finding(findings)];
+            }
+
+            Ok(InspectOutcome {
+                findings,
+                has_valid_target,
+            })
+        }
+        Value::Null if allows_null_target(&field_path) => Ok(InspectOutcome::default()),
+        _ => Ok(InspectOutcome {
+            findings: vec![invalid_entrypoint_value_finding(
+                package_path,
+                &field_path,
+                value,
+            )],
+            has_valid_target: false,
+        }),
+    }
+}
+
+fn invalid_entrypoint_value_finding(
+    package_path: &Path,
+    field_path: &[String],
+    value: &Value,
+) -> Finding {
+    let value_kind = match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    };
+
+    make_finding(FindingInput {
+        id: format!(
+            "package-entrypoints:{}:{}:invalid-type:{}",
+            package_path.to_string_lossy(),
+            field_path.join("/"),
+            value_kind
+        ),
+        title: "Package entrypoint target is invalid".to_string(),
+        category: Some("package-entrypoints".to_string()),
+        detail: Some(format!(
+            "package.json {} must be a string target or nested fallback branches, but found {}.",
+            field_path.join("/"),
+            value_kind
+        )),
+        file: Some(package_path.to_path_buf()),
+        fix_ids: Vec::new(),
+        fixable: false,
+        hint: Some(
+            "Use a string target or nested fallback branches composed of strings, arrays, and objects."
+                .to_string(),
+        ),
+        severity: Some(severity_for_field_path(field_path)),
+    })
+}
+
+fn relative_target_exists(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    package_path: &Path,
+) -> io::Result<bool> {
+    relative_target_exists_at_depth(base_dir, field_path, target, package_path, 0)
+}
+
+fn relative_target_exists_at_depth(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    package_path: &Path,
+    depth: usize,
+) -> io::Result<bool> {
+    if target.contains('*') {
+        return wildcard_target_exists(base_dir, field_path, target);
+    }
+
+    static_target_exists_at_depth(base_dir, field_path, target, package_path, depth)
+}
+
+fn static_target_exists(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    package_path: &Path,
+) -> io::Result<bool> {
+    static_target_exists_at_depth(base_dir, field_path, target, package_path, 0)
+}
+
+fn static_target_exists_at_depth(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    package_path: &Path,
+    depth: usize,
+) -> io::Result<bool> {
+    let stem = target.split('*').next().unwrap_or(target);
+    let Some(resolved) = resolve_path(base_dir, stem) else {
+        return Ok(false);
+    };
+
+    if resolved.is_file() {
+        return Ok(true);
+    }
+
+    if has_supported_explicit_extension(field_path, target) {
+        return Ok(false);
+    }
+
+    for candidate in build_extension_candidates(field_path, &resolved) {
+        if candidate.is_file() {
+            return Ok(true);
+        }
+    }
+
+    if resolved.is_dir() && allows_directory_target_resolution(field_path) {
+        return directory_target_exists_at_depth(&resolved, field_path, package_path, depth);
+    }
+
+    if allows_index_directory_fallback(field_path) {
+        let directory_candidate = resolved.join("index");
+        for candidate in build_extension_candidates(field_path, &directory_candidate) {
+            if candidate.is_file() {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn wildcard_target_exists(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+) -> io::Result<bool> {
+    let mut segments = target.split('*');
+    let prefix = segments.next().unwrap_or_default();
+    let _rest = segments.collect::<Vec<_>>();
+    let search_prefix = wildcard_search_prefix(prefix);
+    let Some(search_root) = resolve_path(base_dir, search_prefix) else {
+        return Ok(false);
+    };
+
+    if !path_exists(&search_root) {
+        return Ok(false);
+    }
+
+    let patterns = build_wildcard_patterns(base_dir, field_path, target);
+    Ok(!collect_matching_paths(&search_root, &patterns)?.is_empty())
+}
+
+fn collect_matching_paths(candidate_path: &Path, patterns: &[String]) -> io::Result<Vec<PathBuf>> {
+    let mut matches = Vec::new();
+    collect_matching_paths_into(candidate_path, patterns, &mut matches)?;
+    Ok(matches)
+}
+
+fn collect_matching_paths_into(
+    candidate_path: &Path,
+    patterns: &[String],
+    matches: &mut Vec<PathBuf>,
+) -> io::Result<()> {
+    if candidate_path.is_file() && matches_path(candidate_path, patterns) {
+        matches.push(candidate_path.to_path_buf());
+        return Ok(());
+    }
+
+    let entries = match fs::read_dir(candidate_path) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let file_type = entry.file_type()?;
+
+        if file_type.is_file() && matches_path(&entry_path, patterns) {
+            matches.push(entry_path);
+            continue;
+        }
+
+        if file_type.is_dir() {
+            collect_matching_paths_into(&entry_path, patterns, matches)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn matches_path(candidate_path: &Path, patterns: &[String]) -> bool {
+    let normalized_path = normalize_path_for_match(candidate_path);
+    patterns
+        .iter()
+        .any(|pattern| wildcard_pattern_matches(&normalized_path, pattern))
+}
+
+fn build_wildcard_patterns(base_dir: &Path, field_path: &[String], target: &str) -> Vec<String> {
+    let Some(resolved) = resolve_path(base_dir, target) else {
+        return Vec::new();
+    };
+    let mut patterns = vec![normalize_path_for_match(&resolved)];
+
+    if !has_supported_explicit_extension(field_path, target) {
+        for candidate in build_extension_candidates(field_path, &resolved) {
+            patterns.push(normalize_path_for_match(&candidate));
+        }
+
+        if field_path
+            .first()
+            .is_some_and(|field| is_main_like_field(field))
+        {
+            let directory_candidate = resolved.join("index");
+            for candidate in build_extension_candidates(field_path, &directory_candidate) {
+                patterns.push(normalize_path_for_match(&candidate));
+            }
+        }
+    }
+
+    patterns
+}
+
+fn has_supported_explicit_extension(field_path: &[String], target: &str) -> bool {
+    let tail = target.rsplit('*').next().unwrap_or(target);
+    let Some(file_name) = Path::new(tail).file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    extensions_for_field_path(field_path)
+        .iter()
+        .any(|extension| file_name.ends_with(extension))
+}
+
+fn wildcard_search_prefix(prefix: &str) -> &str {
+    if prefix.is_empty() {
+        return ".";
+    }
+
+    if prefix.ends_with('/') || prefix.ends_with('\\') {
+        return prefix;
+    }
+
+    match prefix.rfind(['/', '\\']) {
+        Some(0) => &prefix[..1],
+        Some(index) => &prefix[..index],
+        None => ".",
+    }
+}
+
+fn wildcard_pattern_matches(candidate: &str, pattern: &str) -> bool {
+    let candidate_chars = candidate.chars().collect::<Vec<_>>();
+    let pattern_chars = pattern.chars().collect::<Vec<_>>();
+    let mut memo = vec![vec![None; pattern_chars.len() + 1]; candidate_chars.len() + 1];
+
+    fn matches(
+        candidate: &[char],
+        pattern: &[char],
+        candidate_index: usize,
+        pattern_index: usize,
+        memo: &mut [Vec<Option<bool>>],
+    ) -> bool {
+        if let Some(result) = memo[candidate_index][pattern_index] {
+            return result;
+        }
+
+        let result = if pattern_index == pattern.len() {
+            candidate_index == candidate.len()
+        } else if pattern[pattern_index] == '*' {
+            let mut offset = candidate_index + 1;
+            let mut matched = false;
+            while offset <= candidate.len() {
+                if matches(candidate, pattern, offset, pattern_index + 1, memo) {
+                    matched = true;
+                    break;
+                }
+                offset += 1;
+            }
+            matched
+        } else if candidate_index < candidate.len()
+            && candidate[candidate_index] == pattern[pattern_index]
+        {
+            matches(
+                candidate,
+                pattern,
+                candidate_index + 1,
+                pattern_index + 1,
+                memo,
+            )
+        } else {
+            false
+        };
+
+        memo[candidate_index][pattern_index] = Some(result);
+        result
+    }
+
+    matches(&candidate_chars, &pattern_chars, 0, 0, &mut memo)
+}
+
+fn normalize_path_for_match(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn is_relative_target(base_dir: &Path, field_path: &[String], target: &str) -> io::Result<bool> {
+    let Some(root_field) = field_path.first() else {
+        return Ok(false);
+    };
+
+    match root_field.as_str() {
+        "exports" => Ok(is_exports_local_target(target)),
+        "imports" => Ok(is_imports_local_target(target)),
+        _ => is_main_like_local_target(base_dir, root_field, target),
+    }
+}
+
+fn resolve_path(base_dir: &Path, target: &str) -> Option<PathBuf> {
+    let base_dir = normalize_path(base_dir);
+    let normalized_target = target.replace('\\', "/");
+    let resolved = normalize_path(&base_dir.join(normalized_target));
+
+    if resolved.starts_with(&base_dir) {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized
+                    .components()
+                    .next_back()
+                    .is_some_and(|value| matches!(value, Component::Normal(_)))
+                {
+                    normalized.pop();
+                } else if normalized.as_os_str().is_empty() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+fn build_extension_candidates(field_path: &[String], path: &Path) -> Vec<PathBuf> {
+    let path_string = path.to_string_lossy();
+    extensions_for_field_path(field_path)
+        .iter()
+        .map(|extension| PathBuf::from(format!("{path_string}{extension}")))
+        .collect()
+}
+
+fn directory_target_exists_at_depth(
+    path: &Path,
+    field_path: &[String],
+    package_path: &Path,
+    depth: usize,
+) -> io::Result<bool> {
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(false);
+    }
+
+    let package_manifest_path = path.join("package.json");
+    if package_manifest_path.is_file() && package_manifest_path != package_path {
+        if let Some(text) = read_text_if_exists(&package_manifest_path)? {
+            let package_json =
+                match parse_jsonc::<Value>(&text, &package_manifest_path.to_string_lossy()) {
+                    Ok(package_json) => package_json,
+                    Err(_) => return Ok(false),
+                };
+            if let Some(root_field) = field_path.first() {
+                if let Some(value) = package_json.get(root_field) {
+                    let nested_field_path = vec![root_field.clone()];
+                    let nested_outcome = inspect_nested_directory_value_at_depth(
+                        &package_manifest_path,
+                        path,
+                        nested_field_path,
+                        value,
+                        depth + 1,
+                    )?;
+                    if nested_outcome.has_valid_target {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(build_extension_candidates(field_path, &path.join("index"))
+        .iter()
+        .any(|candidate| candidate.is_file()))
+}
+
+fn is_main_like_field(field: &str) -> bool {
+    matches!(field, "main" | "module" | "types" | "bin")
+}
+
+fn is_main_like_local_target(base_dir: &Path, root_field: &str, target: &str) -> io::Result<bool> {
+    if target.is_empty() || has_url_like_scheme(target) || target.starts_with('#') {
+        return Ok(false);
+    }
+
+    if target.starts_with("./") || target.starts_with("../") {
+        return Ok(true);
+    }
+
+    if target.starts_with('/') || target.starts_with('\\') {
+        return Ok(false);
+    }
+
+    let root_field_path = [root_field.to_string()];
+    let package_path = base_dir.join("package.json");
+    if static_target_exists(base_dir, &root_field_path, target, &package_path)? {
+        return Ok(true);
+    }
+
+    let normalized = target.replace('\\', "/");
+    let segments = normalized
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    match segments.as_slice() {
+        [] => Ok(false),
+        [..] => Ok(true),
+    }
+}
+
+fn is_exports_local_target(target: &str) -> bool {
+    if target.is_empty() || has_url_like_scheme(target) || target.starts_with('#') {
+        return false;
+    }
+
+    let normalized = target.replace('\\', "/");
+    normalized.starts_with("./")
+}
+
+fn is_imports_local_target(target: &str) -> bool {
+    if target.is_empty() || has_url_like_scheme(target) || target.starts_with('#') {
+        return false;
+    }
+
+    let normalized = target.replace('\\', "/");
+    normalized.starts_with("./") || normalized.starts_with("../")
+}
+
+fn has_url_like_scheme(target: &str) -> bool {
+    let Some(index) = target.find(':') else {
+        return false;
+    };
+
+    if index == 0 {
+        return false;
+    }
+
+    let scheme = &target[..index];
+    if !scheme
+        .chars()
+        .all(|value| value.is_ascii_alphanumeric() || matches!(value, '+' | '-' | '.'))
+    {
+        return false;
+    }
+
+    matches!(
+        scheme.to_ascii_lowercase().as_str(),
+        "blob"
+            | "data"
+            | "file"
+            | "ftp"
+            | "ftps"
+            | "http"
+            | "https"
+            | "javascript"
+            | "mailto"
+            | "node"
+            | "ws"
+            | "wss"
+    )
+}
+
+fn should_compress_object_branches(
+    field_path: &[String],
+    entries: &serde_json::Map<String, Value>,
+) -> bool {
+    if field_path.len() > 1 {
+        return true;
+    }
+
+    let Some(root_field) = field_path.first() else {
+        return false;
+    };
+
+    match root_field.as_str() {
+        "exports" => entries.keys().all(|key| !key.starts_with('.')),
+        "imports" => entries.keys().all(|key| !key.starts_with('#')),
+        _ => false,
+    }
+}
+
+fn severity_for_field_path(field_path: &[String]) -> Severity {
+    if uses_types_extensions(field_path) {
+        Severity::Warn
+    } else {
+        Severity::Error
+    }
+}
+
+fn select_best_finding(mut findings: Vec<Finding>) -> Finding {
+    findings.sort_by_key(|finding| match finding.severity {
+        Severity::Error => 0,
+        Severity::Warn => 1,
+        Severity::Info => 2,
+    });
+    findings.remove(0)
+}
+
+fn extensions_for_field_path(field_path: &[String]) -> &'static [&'static str] {
+    if uses_types_extensions(field_path) {
+        TYPES_EXTENSIONS
+    } else {
+        RUNTIME_EXTENSIONS
+    }
+}
+
+fn uses_types_extensions(field_path: &[String]) -> bool {
+    match field_path.first().map(String::as_str) {
+        Some("types") => true,
+        Some("exports" | "imports") => field_path.iter().skip(1).any(|segment| segment == "types"),
+        _ => false,
+    }
+}
+
+fn invalid_local_target_detail(field_path: &[String], target: &str) -> Option<String> {
+    let root_field = field_path.first()?;
+    let reason = match root_field.as_str() {
+        "exports" => invalid_exports_target_reason(target)?,
+        "imports" => invalid_imports_target_reason(target)?,
+        "main" | "module" | "types" | "bin" => invalid_main_like_target_reason(target)?,
+        _ => return None,
+    };
+    Some(format!(
+        "package.json {} points to {}, but {}.",
+        field_path.join("/"),
+        target,
+        reason
+    ))
+}
+
+fn invalid_object_key_findings(
+    package_path: &Path,
+    field_path: &[String],
+    entries: &serde_json::Map<String, Value>,
+) -> Vec<Finding> {
+    let Some(root_field) = field_path.first() else {
+        return Vec::new();
+    };
+
+    match root_field.as_str() {
+        "imports" if field_path.len() == 1 => entries
+            .keys()
+            .filter_map(|key| invalid_imports_key_reason(key).map(|reason| (key, reason)))
+            .map(|(key, reason)| {
+                make_finding(FindingInput {
+                    id: format!(
+                        "package-entrypoints:{}:{}/{}:key",
+                        package_path.to_string_lossy(),
+                        field_path.join("/"),
+                        key
+                    ),
+                    title: "Package entrypoint key is invalid".to_string(),
+                    category: Some("package-entrypoints".to_string()),
+                    detail: Some(format!(
+                        "package.json imports/{key} uses an invalid key. {reason}."
+                    )),
+                    file: Some(package_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Rename the imports entry to a # alias before publishing.".to_string(),
+                    ),
+                    severity: Some(Severity::Error),
+                })
+            })
+            .collect(),
+        "exports" => {
+            let mut findings = Vec::new();
+
+            if field_path.len() == 1 && mixes_exports_subpaths_and_conditions(entries) {
+                findings.push(make_finding(FindingInput {
+                    id: format!(
+                        "package-entrypoints:{}:{}:mixed-keys",
+                        package_path.to_string_lossy(),
+                        field_path.join("/")
+                    ),
+                    title: "Package exports object is invalid".to_string(),
+                    category: Some("package-entrypoints".to_string()),
+                    detail: Some(
+                        "package.json exports mixes subpath keys with condition keys at the same object level."
+                            .to_string(),
+                    ),
+                    file: Some(package_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Use either package subpath keys such as . and ./feature, or conditional keys such as import and default at one level."
+                            .to_string(),
+                    ),
+                    severity: Some(Severity::Error),
+                }));
+            }
+
+            findings.extend(
+                entries
+                    .keys()
+                    .filter_map(|key| invalid_exports_key_reason(key).map(|reason| (key, reason)))
+                    .map(|(key, reason)| {
+                        make_finding(FindingInput {
+                            id: format!(
+                                "package-entrypoints:{}:{}/{}:key",
+                                package_path.to_string_lossy(),
+                                field_path.join("/"),
+                                key
+                            ),
+                            title: "Package entrypoint key is invalid".to_string(),
+                            category: Some("package-entrypoints".to_string()),
+                            detail: Some(format!(
+                                "package.json {}/{} uses an invalid key. {reason}.",
+                                field_path.join("/"),
+                                key
+                            )),
+                            file: Some(package_path.to_path_buf()),
+                            fix_ids: Vec::new(),
+                            fixable: false,
+                            hint: Some(exports_key_hint(key).to_string()),
+                            severity: Some(Severity::Error),
+                        })
+                    }),
+            );
+
+            findings
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn mixes_exports_subpaths_and_conditions(entries: &serde_json::Map<String, Value>) -> bool {
+    let has_subpath_key = entries.keys().any(|key| key.starts_with('.'));
+    let has_condition_key = entries.keys().any(|key| !key.starts_with('.'));
+    has_subpath_key && has_condition_key
+}
+
+fn invalid_exports_target_reason(target: &str) -> Option<&'static str> {
+    let normalized = target.replace('\\', "/");
+
+    if !normalized.starts_with("./") {
+        return Some("exports targets must stay within the package and start with ./");
+    }
+
+    let remainder = normalized.trim_start_matches("./");
+    if remainder.is_empty() {
+        return Some("exports targets must point to a file or directory under ./");
+    }
+
+    if has_invalid_package_path_segment(remainder) {
+        return Some("exports targets cannot contain empty, ., .., or node_modules path segments");
+    }
+
+    None
+}
+
+fn invalid_main_like_target_reason(target: &str) -> Option<&'static str> {
+    if target.is_empty() {
+        return Some("main/module/types/bin targets must not be empty");
+    }
+
+    if target.contains('*') {
+        return Some("main/module/types/bin targets must not use wildcard patterns");
+    }
+
+    if has_url_like_scheme(target) {
+        return Some(
+            "main/module/types/bin targets must be package-local paths and cannot use URL-like schemes",
+        );
+    }
+
+    if target.starts_with('#') {
+        return Some(
+            "main/module/types/bin targets must be package-local paths and cannot use # references",
+        );
+    }
+
+    if is_absolute_like_target(target) {
+        return Some(
+            "main/module/types/bin targets must be package-local paths and cannot use absolute paths",
+        );
+    }
+
+    let normalized = target.replace('\\', "/");
+    let remainder = normalized.strip_prefix("./").unwrap_or(&normalized);
+    if remainder.is_empty() {
+        return Some("main/module/types/bin targets must point to a file or directory under ./");
+    }
+    if has_invalid_package_path_segment(remainder) {
+        return Some(
+            "main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments",
+        );
+    }
+
+    None
+}
+
+fn is_absolute_like_target(target: &str) -> bool {
+    if target.starts_with('/') || target.starts_with('\\') {
+        return true;
+    }
+
+    let bytes = target.as_bytes();
+    bytes.len() >= 3
+        && bytes[1] == b':'
+        && bytes[0].is_ascii_alphabetic()
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+fn invalid_imports_target_reason(target: &str) -> Option<&'static str> {
+    if target.is_empty() {
+        return Some("imports targets must not be empty");
+    }
+
+    if is_absolute_like_target(target) {
+        return Some("imports local targets must stay within the package and start with ./");
+    }
+
+    let normalized = target.replace('\\', "/");
+
+    if normalized.starts_with("../") || normalized.starts_with('/') {
+        return Some("imports local targets must stay within the package and start with ./");
+    }
+
+    if !normalized.starts_with("./") {
+        if is_valid_external_import_target(target) {
+            return None;
+        }
+        return Some(
+            "imports targets must be package-local paths under ./ or valid external package specifiers",
+        );
+    }
+
+    let remainder = normalized.trim_start_matches("./");
+    if remainder.is_empty() {
+        return Some("imports local targets must point to a file or directory under ./");
+    }
+
+    if has_invalid_package_path_segment(remainder) {
+        return Some(
+            "imports local targets cannot contain empty, ., .., or node_modules path segments",
+        );
+    }
+
+    None
+}
+
+fn is_valid_external_import_target(target: &str) -> bool {
+    if target.is_empty()
+        || target.starts_with('.')
+        || target.starts_with('/')
+        || target.starts_with('\\')
+        || target.starts_with('#')
+        || target.contains('\\')
+    {
+        return false;
+    }
+
+    if target.contains(':') {
+        return false;
+    }
+
+    let segments = target.split('/').collect::<Vec<_>>();
+    if segments.iter().any(|segment| segment.is_empty()) {
+        return false;
+    }
+
+    if let Some(scope) = segments.first().filter(|segment| segment.starts_with('@')) {
+        return scope.len() > 1
+            && segments.len() >= 2
+            && !matches!(segments[1], "." | "..")
+            && segments[2..]
+                .iter()
+                .all(|segment| !matches!(*segment, "." | ".."));
+    }
+
+    !matches!(segments[0], "." | "..")
+        && segments[1..]
+            .iter()
+            .all(|segment| !matches!(*segment, "." | ".."))
+}
+
+fn has_invalid_package_path_segment(remainder: &str) -> bool {
+    let decoded = percent_decode_path_like_node(remainder).replace('\\', "/");
+    decoded
+        .split('/')
+        .any(|segment| matches!(segment, "" | "." | ".." | "node_modules"))
+}
+
+fn percent_decode_path_like_node(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hi = bytes[index + 1];
+            let lo = bytes[index + 2];
+            if let (Some(hi), Some(lo)) = (hex_value(hi), hex_value(lo)) {
+                output.push((hi * 16 + lo) as char);
+                index += 3;
+                continue;
+            }
+        }
+
+        output.push(bytes[index] as char);
+        index += 1;
+    }
+
+    output
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn allows_null_target(field_path: &[String]) -> bool {
+    field_path
+        .first()
+        .is_some_and(|field| matches!(field.as_str(), "exports" | "imports"))
+}
+
+fn invalid_imports_key_reason(key: &str) -> Option<&'static str> {
+    if key == "#" {
+        Some("imports keys must include a name after the # prefix")
+    } else if let Some(remainder) = key.strip_prefix("#/") {
+        if remainder.is_empty() {
+            Some("imports keys must include a name after the #/ prefix")
+        } else if has_invalid_package_key_segment(remainder) {
+            Some("imports keys must not contain empty, ., .., or node_modules path segments")
+        } else {
+            None
+        }
+    } else if let Some(remainder) = key.strip_prefix('#') {
+        if remainder.is_empty() {
+            Some("imports keys must include a name after the # prefix")
+        } else if has_invalid_package_key_segment(remainder) {
+            Some("imports keys must not contain empty, ., .., or node_modules path segments")
+        } else {
+            None
+        }
+    } else {
+        Some("imports keys must start with #")
+    }
+}
+
+fn invalid_exports_key_reason(key: &str) -> Option<&'static str> {
+    if key.starts_with('#') {
+        Some("exports keys must not start with #")
+    } else if key == "." {
+        None
+    } else if let Some(remainder) = key.strip_prefix("./") {
+        if remainder.is_empty() || has_invalid_package_key_segment(remainder) {
+            Some(
+                "exports subpath keys must not contain empty, ., .., or node_modules path segments",
+            )
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn exports_key_hint(key: &str) -> &'static str {
+    if key.starts_with('#') {
+        "Rename the exports entry to . or ./subpath, or use a condition key without a # prefix."
+    } else {
+        "Rename the exports entry to . or a ./subpath that stays within the package."
+    }
+}
+
+fn has_invalid_package_key_segment(remainder: &str) -> bool {
+    let decoded = percent_decode_path_like_node(remainder).replace('\\', "/");
+    decoded
+        .split('/')
+        .any(|segment| matches!(segment, "" | "." | ".." | "node_modules"))
+}
+
+fn unique_findings_by_id(findings: Vec<Finding>) -> Vec<Finding> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut unique = Vec::new();
+
+    for finding in findings {
+        if seen.insert(finding.id.clone()) {
+            unique.push(finding);
+        }
+    }
+
+    unique
+}
+
+fn incompatible_exact_file_finding(
+    package_path: &Path,
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+) -> Option<Finding> {
+    if target.contains('*') {
+        return None;
+    }
+
+    let resolved = resolve_path(base_dir, target)?;
+    if !resolved.is_file() || exact_file_matches_field_path(field_path, &resolved) {
+        return None;
+    }
+
+    let detail = if uses_types_extensions(field_path) {
+        format!(
+            "package.json {} points to {}, but types targets must point to declaration files such as .d.ts, .d.mts, or .d.cts.",
+            field_path.join("/"),
+            target
+        )
+    } else {
+        format!(
+            "package.json {} points to {}, but runtime entrypoints must not point to declaration-only files such as .d.ts.",
+            field_path.join("/"),
+            target
+        )
+    };
+
+    let hint = if uses_types_extensions(field_path) {
+        "Point types to a generated declaration file before publishing.".to_string()
+    } else {
+        "Point main/module/bin to a runtime file instead of a declaration-only file.".to_string()
+    };
+
+    Some(make_finding(FindingInput {
+        id: format!(
+            "package-entrypoints:{}:{}:{}",
+            package_path.to_string_lossy(),
+            field_path.join("/"),
+            target
+        ),
+        title: "Package entrypoint target uses an incompatible file type".to_string(),
+        category: Some("package-entrypoints".to_string()),
+        detail: Some(detail),
+        file: Some(package_path.to_path_buf()),
+        fix_ids: Vec::new(),
+        fixable: false,
+        hint: Some(hint),
+        severity: Some(severity_for_field_path(field_path)),
+    }))
+}
+
+fn inspect_wildcard_target(
+    package_path: &Path,
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+) -> io::Result<InspectOutcome> {
+    inspect_wildcard_target_at_depth(package_path, base_dir, field_path, target, 0)
+}
+
+fn inspect_wildcard_target_at_depth(
+    package_path: &Path,
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    depth: usize,
+) -> io::Result<InspectOutcome> {
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(InspectOutcome::default());
+    }
+
+    let mut segments = target.split('*');
+    let prefix = segments.next().unwrap_or_default();
+    let search_prefix = wildcard_search_prefix(prefix);
+    let Some(search_root) = resolve_path(base_dir, search_prefix) else {
+        return Ok(InspectOutcome::default());
+    };
+
+    if !path_exists(&search_root) {
+        return Ok(InspectOutcome::default());
+    }
+
+    let patterns = build_wildcard_patterns(base_dir, field_path, target);
+    let matches = collect_matching_paths(&search_root, &patterns)?;
+    if matches.is_empty() {
+        return Ok(InspectOutcome::default());
+    }
+
+    let mut findings = Vec::new();
+    let mut has_valid_target = false;
+    let current_package_path = normalize_path(package_path);
+
+    for matched_path in matches {
+        if matched_path
+            .file_name()
+            .is_some_and(|value| value == "package.json")
+        {
+            if normalize_path(&matched_path) == current_package_path {
+                continue;
+            }
+
+            let package_outcome =
+                inspect_package_manifest_outcome_at_depth(&matched_path, field_path, depth + 1)?;
+            has_valid_target |= package_outcome.has_valid_target;
+            findings.extend(package_outcome.findings);
+            continue;
+        }
+
+        if exact_file_matches_field_path(field_path, &matched_path) {
+            has_valid_target = true;
+            continue;
+        }
+
+        findings.push(wildcard_incompatible_file_finding(
+            package_path,
+            base_dir,
+            field_path,
+            target,
+            &matched_path,
+        ));
+    }
+
+    Ok(InspectOutcome {
+        findings: unique_findings_by_id(findings),
+        has_valid_target,
+    })
+}
+
+fn wildcard_incompatible_file_finding(
+    package_path: &Path,
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    matched_path: &Path,
+) -> Finding {
+    let matched_display = display_relative_path(base_dir, matched_path);
+    let detail = if uses_types_extensions(field_path) {
+        format!(
+            "package.json {} points to {}, but wildcard match {} is not a declaration file.",
+            field_path.join("/"),
+            target,
+            matched_display
+        )
+    } else {
+        format!(
+            "package.json {} points to {}, but wildcard match {} is a declaration-only file.",
+            field_path.join("/"),
+            target,
+            matched_display
+        )
+    };
+
+    let hint = if uses_types_extensions(field_path) {
+        "Point types to a generated declaration file before publishing.".to_string()
+    } else {
+        "Point runtime entrypoints to runtime files instead of declaration-only files.".to_string()
+    };
+
+    make_finding(FindingInput {
+        id: format!(
+            "package-entrypoints:{}:{}:{}:{}",
+            package_path.to_string_lossy(),
+            field_path.join("/"),
+            target,
+            matched_display
+        ),
+        title: "Package entrypoint target uses an incompatible file type".to_string(),
+        category: Some("package-entrypoints".to_string()),
+        detail: Some(detail),
+        file: Some(package_path.to_path_buf()),
+        fix_ids: Vec::new(),
+        fixable: false,
+        hint: Some(hint),
+        severity: Some(severity_for_field_path(field_path)),
+    })
+}
+
+fn display_relative_path(base_dir: &Path, path: &Path) -> String {
+    match path.strip_prefix(base_dir) {
+        Ok(relative) if relative.as_os_str().is_empty() => ".".to_string(),
+        Ok(relative) => format!("./{}", relative.to_string_lossy().replace('\\', "/")),
+        Err(_) => path.to_string_lossy().replace('\\', "/"),
+    }
+}
+
+fn exact_file_matches_field_path(field_path: &[String], path: &Path) -> bool {
+    let path_string = path.to_string_lossy();
+    let is_declaration_file = TYPES_EXTENSIONS
+        .iter()
+        .any(|extension| path_string.ends_with(extension));
+
+    if uses_types_extensions(field_path) {
+        is_declaration_file
+    } else {
+        !is_declaration_file
+    }
+}
+
+fn nested_directory_outcome(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    current_package_path: &Path,
+) -> io::Result<InspectOutcome> {
+    nested_directory_outcome_at_depth(base_dir, field_path, target, current_package_path, 0)
+}
+
+fn nested_directory_outcome_at_depth(
+    base_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    current_package_path: &Path,
+    depth: usize,
+) -> io::Result<InspectOutcome> {
+    if target.contains('*') {
+        return Ok(InspectOutcome::default());
+    }
+
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(InspectOutcome::default());
+    }
+
+    let Some(resolved) = resolve_path(base_dir, target) else {
+        return Ok(InspectOutcome::default());
+    };
+
+    if !resolved.is_dir() {
+        return Ok(InspectOutcome::default());
+    }
+
+    let package_manifest_path = resolved.join("package.json");
+    if !package_manifest_path.is_file() || package_manifest_path == current_package_path {
+        return Ok(InspectOutcome::default());
+    }
+
+    inspect_package_manifest_outcome_at_depth(&package_manifest_path, field_path, depth + 1)
+}
+
+fn inspect_package_manifest_outcome_at_depth(
+    package_manifest_path: &Path,
+    field_path: &[String],
+    depth: usize,
+) -> io::Result<InspectOutcome> {
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(InspectOutcome::default());
+    }
+
+    let Some(text) = read_text_if_exists(package_manifest_path)? else {
+        return Ok(InspectOutcome::default());
+    };
+
+    let package_json = match parse_jsonc::<Value>(&text, &package_manifest_path.to_string_lossy()) {
+        Ok(package_json) => package_json,
+        Err(_) => return Ok(InspectOutcome::default()),
+    };
+
+    let known_fields = ["main", "module", "types", "bin", "exports", "imports"];
+    let current_root_field = field_path.first().map(String::as_str);
+    let current_root_has_index_fallback = current_root_field.is_some()
+        && has_index_fallback(
+            package_manifest_path
+                .parent()
+                .unwrap_or_else(|| Path::new(".")),
+            field_path,
+        );
+    let mut findings = Vec::new();
+    let mut has_valid_target = false;
+
+    for root_field in known_fields {
+        let Some(value) = package_json.get(root_field) else {
+            continue;
+        };
+
+        let nested_outcome = inspect_nested_directory_value_at_depth(
+            package_manifest_path,
+            package_manifest_path
+                .parent()
+                .unwrap_or_else(|| Path::new(".")),
+            vec![root_field.to_string()],
+            value,
+            depth + 1,
+        )?;
+
+        if Some(root_field) == current_root_field {
+            if nested_outcome.has_valid_target {
+                has_valid_target = true;
+                findings.extend(nested_outcome.findings);
+            } else if current_root_has_index_fallback {
+                has_valid_target = true;
+                findings.extend(retained_index_fallback_findings(nested_outcome.findings));
+            } else {
+                findings.extend(nested_outcome.findings);
+            }
+        } else {
+            findings.extend(nested_outcome.findings);
+        }
+    }
+
+    Ok(InspectOutcome {
+        findings: unique_findings_by_id(findings),
+        has_valid_target,
+    })
+}
+
+fn has_index_fallback(package_dir: &Path, field_path: &[String]) -> bool {
+    if !allows_index_directory_fallback(field_path) {
+        return false;
+    }
+
+    build_extension_candidates(field_path, &package_dir.join("index"))
+        .iter()
+        .any(|candidate| candidate.is_file())
+}
+
+fn allows_directory_target_resolution(field_path: &[String]) -> bool {
+    field_path
+        .first()
+        .is_some_and(|field| !matches!(field.as_str(), "bin"))
+}
+
+fn allows_index_directory_fallback(field_path: &[String]) -> bool {
+    field_path
+        .first()
+        .is_some_and(|field| matches!(field.as_str(), "main" | "module" | "types"))
+}
+
+fn inspect_nested_directory_value_at_depth(
+    package_path: &Path,
+    package_dir: &Path,
+    field_path: Vec<String>,
+    value: &Value,
+    depth: usize,
+) -> io::Result<InspectOutcome> {
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(InspectOutcome::default());
+    }
+
+    match value {
+        Value::String(target) => inspect_nested_directory_target_at_depth(
+            package_path,
+            package_dir,
+            &field_path,
+            target,
+            depth,
+        ),
+        Value::Array(values) => {
+            if !allows_array_target(&field_path) {
+                return Ok(InspectOutcome {
+                    findings: vec![invalid_entrypoint_value_finding(
+                        package_path,
+                        &field_path,
+                        value,
+                    )],
+                    has_valid_target: false,
+                });
+            }
+
+            let mut findings = Vec::new();
+
+            for (index, branch) in values.iter().enumerate() {
+                let mut next_path = field_path.clone();
+                next_path.push(format!("[{index}]"));
+                let branch_outcome = inspect_nested_directory_value_at_depth(
+                    package_path,
+                    package_dir,
+                    next_path,
+                    branch,
+                    depth + 1,
+                )?;
+                if branch_outcome.has_valid_target {
+                    findings.extend(retained_fallback_findings(branch_outcome.findings));
+                    return Ok(InspectOutcome {
+                        findings: unique_findings_by_id(retained_fallback_findings(findings)),
+                        has_valid_target: true,
+                    });
+                }
+                findings.extend(branch_outcome.findings);
+            }
+
+            Ok(InspectOutcome {
+                findings,
+                has_valid_target: false,
+            })
+        }
+        Value::Object(entries) => {
+            if !allows_object_target(&field_path) {
+                return Ok(InspectOutcome {
+                    findings: vec![invalid_entrypoint_value_finding(
+                        package_path,
+                        &field_path,
+                        value,
+                    )],
+                    has_valid_target: false,
+                });
+            }
+
+            let mut findings = invalid_object_key_findings(package_path, &field_path, entries);
+            let mut has_valid_target = false;
+
+            for (key, branch) in entries {
+                let mut next_path = field_path.clone();
+                next_path.push(key.clone());
+                let branch_outcome = inspect_nested_directory_value_at_depth(
+                    package_path,
+                    package_dir,
+                    next_path,
+                    branch,
+                    depth + 1,
+                )?;
+                has_valid_target |= branch_outcome.has_valid_target;
+                findings.extend(branch_outcome.findings);
+            }
+
+            Ok(InspectOutcome {
+                findings,
+                has_valid_target,
+            })
+        }
+        Value::Null if allows_null_target(&field_path) => Ok(InspectOutcome::default()),
+        _ => Ok(InspectOutcome {
+            findings: vec![invalid_entrypoint_value_finding(
+                package_path,
+                &field_path,
+                value,
+            )],
+            has_valid_target: false,
+        }),
+    }
+}
+
+fn retained_fallback_findings(findings: Vec<Finding>) -> Vec<Finding> {
+    findings
+        .into_iter()
+        .filter(|finding| !is_skippable_fallback_branch_finding(finding))
+        .collect()
+}
+
+fn retained_index_fallback_findings(findings: Vec<Finding>) -> Vec<Finding> {
+    findings
+        .into_iter()
+        .filter(|finding| finding.title != "Package entrypoint target does not exist")
+        .collect()
+}
+
+fn is_skippable_fallback_branch_finding(finding: &Finding) -> bool {
+    match finding.title.as_str() {
+        "Package entrypoint target does not exist" => true,
+        "Package entrypoint target uses an incompatible file type" => true,
+        "Package entrypoint target is invalid" => !finding.id.contains(":invalid-type:"),
+        _ => false,
+    }
+}
+
+fn allows_array_target(field_path: &[String]) -> bool {
+    field_path
+        .first()
+        .is_some_and(|field| matches!(field.as_str(), "exports" | "imports"))
+}
+
+fn allows_object_target(field_path: &[String]) -> bool {
+    match field_path.first().map(String::as_str) {
+        Some("exports" | "imports") => true,
+        Some("bin") => field_path.len() == 1,
+        _ => false,
+    }
+}
+
+fn inspect_nested_directory_target_at_depth(
+    package_path: &Path,
+    package_dir: &Path,
+    field_path: &[String],
+    target: &str,
+    depth: usize,
+) -> io::Result<InspectOutcome> {
+    if depth >= MAX_NESTED_PACKAGE_DEPTH {
+        return Ok(InspectOutcome::default());
+    }
+
+    if let Some(detail) = invalid_local_target_detail(field_path, target) {
+        return Ok(InspectOutcome {
+            findings: vec![make_finding(FindingInput {
+                id: format!(
+                    "package-entrypoints:{}:{}:{}",
+                    package_path.to_string_lossy(),
+                    field_path.join("/"),
+                    target
+                ),
+                title: "Package entrypoint target is invalid".to_string(),
+                category: Some("package-entrypoints".to_string()),
+                detail: Some(detail),
+                file: Some(package_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments."
+                        .to_string(),
+                ),
+                severity: Some(severity_for_field_path(field_path)),
+            })],
+            has_valid_target: false,
+        });
+    }
+
+    if field_path.first().is_some_and(|field| field == "imports")
+        && is_valid_external_import_target(target)
+    {
+        return Ok(InspectOutcome {
+            findings: Vec::new(),
+            has_valid_target: true,
+        });
+    }
+
+    if !is_relative_target(package_dir, field_path, target)? {
+        return Ok(InspectOutcome::default());
+    }
+
+    if target.contains('*') {
+        let wildcard_outcome = inspect_wildcard_target_at_depth(
+            package_path,
+            package_dir,
+            field_path,
+            target,
+            depth + 1,
+        )?;
+        if wildcard_outcome.has_valid_target || !wildcard_outcome.findings.is_empty() {
+            return Ok(wildcard_outcome);
+        }
+
+        return Ok(InspectOutcome {
+            findings: vec![make_finding(FindingInput {
+                id: format!(
+                    "package-entrypoints:{}:{}:{}",
+                    package_path.to_string_lossy(),
+                    field_path.join("/"),
+                    target
+                ),
+                title: "Package entrypoint target does not exist".to_string(),
+                category: Some("package-entrypoints".to_string()),
+                detail: Some(format!(
+                    "package.json {} points to {}, but the resolved path was not found.",
+                    field_path.join("/"),
+                    target
+                )),
+                file: Some(package_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Update the relative path or remove the stale entrypoint before publishing."
+                        .to_string(),
+                ),
+                severity: Some(severity_for_field_path(field_path)),
+            })],
+            has_valid_target: false,
+        });
+    }
+
+    if let Some(finding) =
+        incompatible_exact_file_finding(package_path, package_dir, field_path, target)
+    {
+        return Ok(InspectOutcome {
+            findings: vec![finding],
+            has_valid_target: false,
+        });
+    }
+
+    let nested_directory_outcome = nested_directory_outcome_at_depth(
+        package_dir,
+        field_path,
+        target,
+        package_path,
+        depth + 1,
+    )?;
+
+    if relative_target_exists_at_depth(package_dir, field_path, target, package_path, depth + 1)? {
+        return Ok(InspectOutcome {
+            findings: nested_directory_outcome.findings,
+            has_valid_target: true,
+        });
+    }
+
+    if !nested_directory_outcome.findings.is_empty() {
+        let mut findings = nested_directory_outcome.findings;
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "package-entrypoints:{}:{}:{}",
+                package_path.to_string_lossy(),
+                field_path.join("/"),
+                target
+            ),
+            title: "Package entrypoint target does not exist".to_string(),
+            category: Some("package-entrypoints".to_string()),
+            detail: Some(format!(
+                "package.json {} points to {}, but the resolved path was not found.",
+                field_path.join("/"),
+                target
+            )),
+            file: Some(package_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Update the relative path or remove the stale entrypoint before publishing."
+                    .to_string(),
+            ),
+            severity: Some(severity_for_field_path(field_path)),
+        }));
+        return Ok(InspectOutcome {
+            findings,
+            has_valid_target: false,
+        });
+    }
+
+    Ok(InspectOutcome {
+        findings: vec![make_finding(FindingInput {
+            id: format!(
+                "package-entrypoints:{}:{}:{}",
+                package_path.to_string_lossy(),
+                field_path.join("/"),
+                target
+            ),
+            title: "Package entrypoint target does not exist".to_string(),
+            category: Some("package-entrypoints".to_string()),
+            detail: Some(format!(
+                "package.json {} points to {}, but the resolved path was not found.",
+                field_path.join("/"),
+                target
+            )),
+            file: Some(package_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Update the relative path or remove the stale entrypoint before publishing."
+                    .to_string(),
+            ),
+            severity: Some(severity_for_field_path(field_path)),
+        })],
+        has_valid_target: false,
+    })
+}

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -12,6 +12,7 @@ use crate::{
     run_tsconfig_check,
 };
 use crate::lockfiles::run_lockfiles_check;
+use crate::package_entrypoints::run_package_entrypoints_check;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditedProject {
@@ -27,6 +28,7 @@ pub fn run_registered_checks(project: &ProjectSnapshot) -> std::io::Result<Check
         run_eslint_prettier_check(project)?,
         run_tsconfig_check(project)?,
         run_lockfiles_check(project)?,
+        run_package_entrypoints_check(project)?,
     ];
 
     Ok(merge_outcomes(outcomes))

--- a/crates/maximus-checks/tests/package_entrypoints_checks.rs
+++ b/crates/maximus-checks/tests/package_entrypoints_checks.rs
@@ -1,0 +1,3187 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use maximus_checks::package_entrypoints::run_package_entrypoints_check;
+use maximus_core::{discover_project, Severity};
+use tempfile::TempDir;
+
+#[test]
+fn package_entrypoints_check_reports_missing_relative_targets_and_recurses_through_branches() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/missing-main.js",
+          "module": "./dist/module",
+          "types": "./dist/types",
+          "bin": {
+            "maximus": "./bin/cli",
+            "missing": "./bin/missing.js"
+          },
+          "exports": {
+            ".": "./dist/index.js",
+            "./feature": [
+              { "default": "./dist/feature.js" },
+              "./dist/fallback.js"
+            ],
+            "./nested": {
+              "import": "./dist/import.js",
+              "default": "./dist/missing-exports.js"
+            },
+            "./package": "./dist/package.js",
+            "./url": "./dist/url.js"
+          },
+          "imports": {
+            "#ok": "./src/ok.ts",
+            "#missing": ["react", "./src/missing.ts"],
+            "#nested": {
+              "types": "./src/types.d.ts",
+              "default": "./src/missing-imports.js"
+            }
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/module.js"), "export default 1;\n");
+    write(
+        fixture.path().join("dist/types.d.ts"),
+        "export type Types = string;\n",
+    );
+    write(fixture.path().join("bin/cli.js"), "#!/usr/bin/env node\n");
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+    write(
+        fixture.path().join("dist/feature.js"),
+        "export default 1;\n",
+    );
+    write(fixture.path().join("dist/import.js"), "export default 1;\n");
+    write(
+        fixture.path().join("dist/package.js"),
+        "export default 1;\n",
+    );
+    write(fixture.path().join("dist/url.js"), "export default 1;\n");
+    write(
+        fixture.path().join("src/ok.ts"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("src/types.d.ts"),
+        "export type Types = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/missing-main.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/missing-main.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/missing", "./bin/missing.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json bin/missing points to ./bin/missing.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./nested/default", "./dist/missing-exports.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json exports/./nested/default points to ./dist/missing-exports.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#nested/default", "./src/missing-imports.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json imports/#nested/default points to ./src/missing-imports.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "module", "./dist/module"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "./dist/types"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/maximus", "./bin/cli"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "./dist/index.js"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(
+            fixture.path(),
+            "exports/./feature/[1]",
+            "./dist/fallback.js",
+        ),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./package", "./dist/package.js"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./url", "./dist/url.js"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#missing/[0]", "react"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#missing/[1]", "./src/missing.ts"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_main_like_bare_targets_as_package_relative_paths() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "index",
+          "module": "dist/module",
+          "types": "types/index",
+          "bin": {
+            "cli": "bin/cli"
+          },
+          "exports": {
+            ".": "./index.js",
+            "./nested": { "default": "./dist/module.js" }
+          },
+          "imports": {
+            "#alias": ["@scope/pkg", "https://example.com/x.js"]
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("index.js"), "export default 1;\n");
+    write(fixture.path().join("dist/module.js"), "export default 1;\n");
+    write(
+        fixture.path().join("types/index.d.ts"),
+        "export type Maximus = string;\n",
+    );
+    write(fixture.path().join("bin/cli.js"), "#!/usr/bin/env node\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_reports_single_segment_file_paths() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "index.js",
+          "bin": {
+            "cli": "cli.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "index.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to index.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/cli", "cli.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json bin/cli points to cli.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_bin_directory_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "bin": {
+            "cli": "./bin"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("bin/index.js"), "#!/usr/bin/env node\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/cli", "./bin"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json bin/cli points to ./bin, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_wildcards_for_main_like_fields() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/*.js"
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/*.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ./dist/*.js, but main/module/types/bin targets must not use wildcard patterns.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_directory_targets_when_the_entrypoint_has_an_explicit_extension(
+) {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "main": "./dist/module.js" }"#,
+    );
+    write(
+        fixture.path().join("dist/module.js/index.js"),
+        "console.log('nested');",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "package-entrypoints:{}:main:./dist/module.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/module.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_accepts_dotted_directory_targets_without_known_extensions() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "main": "./dist/v1.0" }"#,
+    );
+    write(
+        fixture.path().join("dist/v1.0/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/v1.0"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_dependency_named_targets_for_main_like_fields() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "dependencies": {
+            "react": "^19.0.0",
+            "@scope/pkg": "^1.0.0",
+            "@scope/cli": "^1.0.0"
+          },
+          "main": "react",
+          "module": "node:fs",
+          "types": "@scope/pkg",
+          "bin": {
+            "cli": "@scope/cli"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "react"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to react, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "@scope/pkg"),
+        Severity::Warn,
+        "Package entrypoint target does not exist",
+        "package.json types points to @scope/pkg, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/cli", "@scope/cli"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json bin/cli points to @scope/cli, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "module", "node:fs"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json module points to node:fs, but main/module/types/bin targets must be package-local paths and cannot use URL-like schemes.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_url_like_schemes_for_main_like_fields() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "ftp:shim.js"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "ftp:shim.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ftp:shim.js, but main/module/types/bin targets must be package-local paths and cannot use URL-like schemes.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_multi_segment_package_relative_paths() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "components/Button.js"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "components/Button.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to components/Button.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_missing_single_segment_bare_local_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "server",
+          "types": "entry"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "server"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to server, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "entry"),
+        Severity::Warn,
+        "Package entrypoint target does not exist",
+        "package.json types points to entry, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_exports_and_imports_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "./dist/../dist/main.js",
+            "./bad": "./node_modules/foo.js"
+          },
+          "imports": {
+            "#bad": "../outside.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/main.js"), "export default 1;\n");
+    write(
+        fixture.path().join("node_modules/foo.js"),
+        "export default 'bad';\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "./dist/../dist/main.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to ./dist/../dist/main.js, but exports targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./bad", "./node_modules/foo.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/./bad points to ./node_modules/foo.js, but exports targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#bad", "../outside.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#bad points to ../outside.js, but imports local targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_invalid_non_local_import_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#dot": ".foo",
+            "#ftp": "ftp:shim.js",
+            "#node": "node:fs",
+            "#pkg": "@scope/pkg/subpath",
+            "#traversal": "pkg/../sub.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#dot", ".foo"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#dot points to .foo, but imports targets must be package-local paths under ./ or valid external package specifiers.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#ftp", "ftp:shim.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#ftp points to ftp:shim.js, but imports targets must be package-local paths under ./ or valid external package specifiers.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#node", "node:fs"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#node points to node:fs, but imports targets must be package-local paths under ./ or valid external package specifiers.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#pkg", "@scope/pkg/subpath"),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#traversal", "pkg/../sub.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#traversal points to pkg/../sub.js, but imports targets must be package-local paths under ./ or valid external package specifiers.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_non_string_entrypoint_values() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": true,
+          "types": 123,
+          "bin": {
+            "cli": null
+          },
+          "exports": false,
+          "imports": {
+            "#alias": 0
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "main", "boolean"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main must be a string target or nested fallback branches, but found boolean.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "types", "number"),
+        Severity::Warn,
+        "Package entrypoint target is invalid",
+        "package.json types must be a string target or nested fallback branches, but found number.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "bin/cli", "null"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json bin/cli must be a string target or nested fallback branches, but found null.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "exports", "boolean"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports must be a string target or nested fallback branches, but found boolean.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "imports/#alias", "number"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#alias must be a string target or nested fallback branches, but found number.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_compound_values_for_main_like_fields_and_nested_bin_values() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": ["./dist/index.js"],
+          "module": {
+            "default": "./dist/module.js"
+          },
+          "types": {
+            "default": "./dist/types.d.ts"
+          },
+          "bin": {
+            "cli": {
+              "default": "./bin/cli.js"
+            }
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.js"),
+        "module.exports = {};\n",
+    );
+    write(
+        fixture.path().join("dist/module.js"),
+        "module.exports = {};\n",
+    );
+    write(
+        fixture.path().join("dist/types.d.ts"),
+        "export type T = string;\n",
+    );
+    write(fixture.path().join("bin/cli.js"), "#!/usr/bin/env node\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "main", "array"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main must be a string target or nested fallback branches, but found array.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "module", "object"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json module must be a string target or nested fallback branches, but found object.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "types", "object"),
+        Severity::Warn,
+        "Package entrypoint target is invalid",
+        "package.json types must be a string target or nested fallback branches, but found object.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "bin/cli", "object"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json bin/cli must be a string target or nested fallback branches, but found object.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_allows_null_targets_for_exports_and_imports() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./private/*": null
+          },
+          "imports": {
+            "#private/*": null
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "exports/./private/*", "null"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &invalid_type_finding_id(fixture.path(), "imports/#private/*", "null"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_percent_encoded_invalid_segments() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./node_modules%2ffoo.js",
+          "exports": {
+            ".": "./node_modules%2ffoo.js"
+          },
+          "imports": {
+            "#bad": "./node_modules%2ffoo.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./node_modules%2ffoo.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ./node_modules%2ffoo.js, but main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "./node_modules%2ffoo.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to ./node_modules%2ffoo.js, but exports targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#bad", "./node_modules%2ffoo.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#bad points to ./node_modules%2ffoo.js, but imports local targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_empty_target_path_segments() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist//index.js",
+          "exports": {
+            ".": "./dist/%2findex.js"
+          },
+          "imports": {
+            "#bad": "./dist//index.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist//index.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ./dist//index.js, but main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "./dist/%2findex.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to ./dist/%2findex.js, but exports targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#bad", "./dist//index.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#bad points to ./dist//index.js, but imports local targets cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_does_not_recurse_on_root_directory_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "."
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "."),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ., but main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn package_entrypoints_check_limits_symlink_cycles_in_nested_package_manifests() {
+    use std::os::unix::fs as unix_fs;
+
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./pkg"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("pkg/package.json"),
+        r##"
+        {
+          "main": "./loop"
+        }
+        "##,
+    );
+    unix_fs::symlink(fixture.path().join("pkg"), fixture.path().join("pkg/loop"))
+        .expect("symlink cycle should be created");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.len() <= 12,
+        "cycle guard should cap nested manifest findings, got {}",
+        outcome.findings.len()
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_empty_targets_as_invalid() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "",
+          "imports": {
+            "#empty": ""
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", ""),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to , but main/module/types/bin targets must not be empty.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#empty", ""),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#empty points to , but imports targets must not be empty.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_compresses_multiple_broken_branches_per_key() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": ["./dist/missing-one.js", "./dist/missing-two.js"]
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_eq!(outcome.findings.len(), 1);
+    assert_eq!(
+        outcome.findings[0].id,
+        finding_id(fixture.path(), "exports/./[0]", "./dist/missing-one.js")
+    );
+}
+
+#[test]
+fn package_entrypoints_check_compresses_root_exports_arrays() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": ["./dist/missing-one.js", "./dist/missing-two.js"]
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_eq!(outcome.findings.len(), 1);
+    assert_eq!(
+        outcome.findings[0].id,
+        finding_id(fixture.path(), "exports/[0]", "./dist/missing-one.js")
+    );
+}
+
+#[test]
+fn package_entrypoints_check_compresses_multiple_broken_object_branches_even_with_one_valid_branch()
+{
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": {
+              "import": "./dist/import.js",
+              "types": "./dist/missing-types.d.ts",
+              "default": "./dist/missing-default.js"
+            }
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/import.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_eq!(outcome.findings.len(), 1);
+}
+
+#[test]
+fn package_entrypoints_check_compresses_root_exports_condition_objects() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "import": "./dist/missing-import.js",
+            "require": "./dist/missing-require.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_eq!(outcome.findings.len(), 1);
+}
+
+#[test]
+fn package_entrypoints_check_prefers_error_over_warn_when_compressing_branches() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": {
+              "types": "./dist/missing-types.d.ts",
+              "default": "./dist/missing-default.js"
+            }
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_eq!(outcome.findings.len(), 1);
+    assert_eq!(outcome.findings[0].severity, Severity::Error);
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_exports_but_skips_external_imports() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": ["left-pad", "file:///tmp/asset.js"],
+            "./nested": { "default": "#internal" }
+          },
+          "imports": {
+            "#alias": ["@scope/pkg", "https://example.com/x.js"]
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./[0]", "left-pad"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/./[0] points to left-pad, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./nested/default", "#internal"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/./nested/default points to #internal, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#alias/[0]", "@scope/pkg"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_skips_absolute_targets_for_exports_and_imports() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "/usr/local/lib/maximus.js"
+          },
+          "imports": {
+            "#abs": "/usr/local/lib/maximus.js",
+            "#winabs": "C:/maximus/shim.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "/usr/local/lib/maximus.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to /usr/local/lib/maximus.js, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#abs", "/usr/local/lib/maximus.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#abs points to /usr/local/lib/maximus.js, but imports local targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#winabs", "C:/maximus/shim.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json imports/#winabs points to C:/maximus/shim.js, but imports local targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn package_entrypoints_check_accepts_posix_colon_filenames() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "foo:bar.js"
+        }
+        "##,
+    );
+    write(fixture.path().join("foo:bar.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_accepts_windows_style_relative_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": ".\\dist\\index.js"
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", ".\\dist\\index.js"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_accepts_package_relative_main_and_bin_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "dist/index.js",
+          "bin": {
+            "maximus": "bin/cli.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+    write(fixture.path().join("bin/cli.js"), "#!/usr/bin/env node\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_prefers_file_extension_matches_before_directory_fallback() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/foo"
+        }
+        "##,
+    );
+    fs::create_dir_all(fixture.path().join("dist/foo")).expect("directory should exist");
+    write(fixture.path().join("dist/foo.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_rejects_targets_that_escape_the_package_root() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let outside_file = fixture.path().parent().unwrap().join("outside-shared.js");
+    write(&outside_file, "export default 1;\n");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "../outside-shared.js",
+          "exports": {
+            ".": "../outside-shared.js"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "../outside-shared.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ../outside-shared.js, but main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "../outside-shared.js"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to ../outside-shared.js, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_requires_concrete_file_matches_for_directories_and_wildcards() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module",
+          "exports": {
+            "./*": "./dist/*"
+          }
+        }
+        "##,
+    );
+    fs::create_dir_all(fixture.path().join("dist/module"))
+        .expect("directory-only entrypoint should exist");
+    fs::create_dir_all(fixture.path().join("dist")).expect("dist dir should exist");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/module, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./*", "./dist/*"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json exports/./* points to ./dist/*, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_falls_back_to_index_when_nested_package_main_is_broken() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./missing.js"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_preserves_nested_incompatible_targets_when_index_fallback_exists() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./index.d.ts"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.js"),
+        "module.exports = {};\n",
+    );
+    write(
+        fixture.path().join("dist/module/index.d.ts"),
+        "export type Bad = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "main",
+            "./index.d.ts",
+        ),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json main points to ./index.d.ts, but runtime entrypoints must not point to declaration-only files such as .d.ts.",
+        "Point main/module/bin to a runtime file instead of a declaration-only file.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_preserves_nested_structural_findings_when_index_fallback_exists() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./missing.js",
+          "exports": {
+            "#bad": "./index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "exports/#bad",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/#bad uses an invalid key. exports keys must not start with #.",
+        "Rename the exports entry to . or ./subpath, or use a condition key without a # prefix.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_respects_explicit_wildcard_extensions() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./dist/*.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/feature.js.cjs"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./*", "./dist/*.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json exports/./* points to ./dist/*.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_arrays_as_fallback_when_an_earlier_relative_branch_exists() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": ["./dist/index.js", "./dist/missing.js"]
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_skips_invalid_specifier_array_branches_after_valid_fallbacks() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": ["not:valid", "./dist/index.js"]
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./[0]", "not:valid"),
+    );
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_treats_condition_objects_inside_arrays_as_fallback_branches() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": [
+              {
+                "default": "./dist/index.js",
+                "types": "./dist/missing-types.d.ts"
+              },
+              "./dist/missing-fallback.js"
+            ]
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_preserves_structural_findings_before_valid_array_fallbacks() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": [
+              {
+                "#bad": "./dist/index.js"
+              },
+              "./dist/index.js"
+            ]
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/./[0]/#bad"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/./[0]/#bad uses an invalid key. exports keys must not start with #.",
+        "Rename the exports entry to . or ./subpath, or use a condition key without a # prefix.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./[1]", "./dist/index.js"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_accepts_directory_targets_with_nested_package_main() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./entry.js"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/entry.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_reports_other_nested_entrypoints_in_hidden_package_manifests() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./entry.js",
+          "module": "./missing.js"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/entry.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "module",
+            "./missing.js",
+        ),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json module points to ./missing.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_nested_wildcard_incompatible_matches() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "./dist/module"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./dist/*"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/dist/index.d.ts"),
+        "export type Nested = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "package-entrypoints:{}:exports/./*:./dist/*:./dist/index.d.ts",
+            fixture
+                .path()
+                .join("dist/module/package.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json exports/./* points to ./dist/*, but wildcard match ./dist/index.d.ts is a declaration-only file.",
+        "Point runtime entrypoints to runtime files instead of declaration-only files.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_nested_import_arrays_with_valid_external_targets_as_resolved() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#nested": "./dist/module"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "imports": {
+            "#nested": ["react", "./missing.js"]
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "imports/#nested/[1]",
+            "./missing.js",
+        ),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_nested_condition_objects_as_valid_when_a_branch_resolves() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": {
+            "default": "./entry.js",
+            "types": "./missing-types.d.ts"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/entry.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "main",
+            "object",
+        ),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main must be a string target or nested fallback branches, but found object.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_nested_arrays_with_valid_condition_branches_as_resolved() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": [
+            {
+              "default": "./entry.js",
+              "types": "./missing-types.d.ts"
+            },
+            "./missing-fallback.js"
+          ]
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/entry.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &invalid_type_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "main",
+            "array",
+        ),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main must be a string target or nested fallback branches, but found array.",
+        "Use a string target or nested fallback branches composed of strings, arrays, and objects.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_preserves_types_branch_context_in_nested_exports() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "./dist/module"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "exports": {
+            ".": {
+              "types": "./index"
+            }
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.d.ts"),
+        "export type Maximus = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_reports_nested_types_targets_as_warn() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "types": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "types": "./missing"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "./dist/module"),
+        Severity::Warn,
+        "Package entrypoint target does not exist",
+        "package.json types points to ./dist/module, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_missing_nested_package_paths_with_multiple_segments() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "packages/ui/index.js"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "packages/ui/index.js"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to packages/ui/index.js, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_accepts_native_addon_entrypoints() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./addon"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("addon.node"),
+        "native addon placeholder\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn package_entrypoints_check_reports_types_targets_as_warn() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "types": "./dist/missing-types.d.ts"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "./dist/missing-types.d.ts"),
+        Severity::Warn,
+        "Package entrypoint target does not exist",
+        "package.json types points to ./dist/missing-types.d.ts, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_treats_bin_command_named_types_as_runtime_entrypoint() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "bin": {
+            "types": "./bin/cli.d.ts"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("bin/cli.d.ts"),
+        "export type Cli = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "bin/types", "./bin/cli.d.ts"),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json bin/types points to ./bin/cli.d.ts, but runtime entrypoints must not point to declaration-only files such as .d.ts.",
+        "Point main/module/bin to a runtime file instead of a declaration-only file.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_uses_field_specific_extension_probing() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/index",
+          "types": "./dist/types"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.d.ts"),
+        "export type Runtime = string;\n",
+    );
+    write(
+        fixture.path().join("dist/types.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/index"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/index, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "./dist/types"),
+        Severity::Warn,
+        "Package entrypoint target does not exist",
+        "package.json types points to ./dist/types, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_exports_but_skips_external_import_subpaths() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "pkg/subpath",
+            "./feature": "@scope/pkg/subpath"
+          },
+          "imports": {
+            "#pkg": "pkg/subpath",
+            "#scoped": "@scope/pkg/subpath"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/.", "pkg/subpath"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/. points to pkg/subpath, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./feature", "@scope/pkg/subpath"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json exports/./feature points to @scope/pkg/subpath, but exports targets must stay within the package and start with ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#pkg", "pkg/subpath"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#scoped", "@scope/pkg/subpath"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_parent_segments_in_main_like_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("packages/app/package.json"),
+        r##"
+        {
+          "main": "../app/index.js"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("packages/app/index.js"),
+        "module.exports = {}\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id_for_package(
+            &fixture.path().join("packages/app/package.json"),
+            "main",
+            "../app/index.js",
+        ),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ../app/index.js, but main/module/types/bin targets must stay within the package and cannot contain empty, ., .., or node_modules path segments.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("packages/app/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_root_directory_alias_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./"
+        }
+        "##,
+    );
+    write(fixture.path().join("index.js"), "module.exports = {}\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./"),
+        Severity::Error,
+        "Package entrypoint target is invalid",
+        "package.json main points to ./, but main/module/types/bin targets must point to a file or directory under ./.",
+        "Use a package-local target that stays under ./ and avoids ., .., or node_modules segments.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_incompatible_exact_file_types() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/index.d.ts",
+          "types": "./dist/index.js"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.d.ts"),
+        "export type Maximus = string;\n",
+    );
+    write(fixture.path().join("dist/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/index.d.ts"),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json main points to ./dist/index.d.ts, but runtime entrypoints must not point to declaration-only files such as .d.ts.",
+        "Point main/module/bin to a runtime file instead of a declaration-only file.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "types", "./dist/index.js"),
+        Severity::Warn,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json types points to ./dist/index.js, but types targets must point to declaration files such as .d.ts, .d.mts, or .d.cts.",
+        "Point types to a generated declaration file before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_root_import_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "react": "./src/index.js",
+            "#ok": "./src/ok.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("src/index.js"), "export default 1;\n");
+    write(fixture.path().join("src/ok.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/react"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#ok", "./src/ok.js"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_import_subpath_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#alias/../x": "./src/index.js",
+            "#ok/path": "./src/ok.js",
+            "#/ok": "./src/slash.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("src/index.js"), "export default 1;\n");
+    write(fixture.path().join("src/ok.js"), "export default 1;\n");
+    write(fixture.path().join("src/slash.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/#alias/../x"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/#alias/../x uses an invalid key. imports keys must not contain empty, ., .., or node_modules path segments.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/#ok/path"),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/#/ok"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_trailing_slash_import_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#alias/": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("src/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/#alias/"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/#alias/ uses an invalid key. imports keys must not contain empty, ., .., or node_modules path segments.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_exports_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "#alias": "./dist/index.js",
+            ".": {
+              "#nested": "./dist/index.js",
+              "default": "./dist/index.js"
+            }
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/#alias"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/#alias uses an invalid key. exports keys must not start with #.",
+        "Rename the exports entry to . or ./subpath, or use a condition key without a # prefix.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/./#nested"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/./#nested uses an invalid key. exports keys must not start with #.",
+        "Rename the exports entry to . or ./subpath, or use a condition key without a # prefix.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_mixed_root_exports_subpath_and_condition_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            ".": "./dist/index.js",
+            "import": "./dist/index.mjs"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/index.js"), "module.exports = {};\n");
+    write(fixture.path().join("dist/index.mjs"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "package-entrypoints:{}:exports:mixed-keys",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Error,
+        "Package exports object is invalid",
+        "package.json exports mixes subpath keys with condition keys at the same object level.",
+        "Use either package subpath keys such as . and ./feature, or conditional keys such as import and default at one level.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_exports_subpath_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./../bad": "./dist/bad.js",
+            "./ok/path": "./dist/ok.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("dist/bad.js"), "module.exports = {};\n");
+    write(fixture.path().join("dist/ok.js"), "module.exports = {};\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/./../bad"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/./../bad uses an invalid key. exports subpath keys must not contain empty, ., .., or node_modules path segments.",
+        "Rename the exports entry to . or a ./subpath that stays within the package.",
+        Some(fixture.path().join("package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/./ok/path"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_trailing_slash_exports_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./feature/": "./feature/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("feature/index.js"),
+        "module.exports = {};\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "exports/./feature/"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json exports/./feature/ uses an invalid key. exports subpath keys must not contain empty, ., .., or node_modules path segments.",
+        "Rename the exports entry to . or a ./subpath that stays within the package.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_empty_named_import_aliases() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(fixture.path().join("src/index.js"), "export default 1;\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id(fixture.path(), "imports/#"),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/# uses an invalid key. imports keys must include a name after the # prefix.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_nested_import_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#nested": "./dist/module"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "imports": {
+            "react": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/src/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "imports/react",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "imports/#nested", "./dist/module"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_nested_import_keys_for_main_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./entry.js",
+          "imports": {
+            "react": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/entry.js"),
+        "module.exports = {}\n",
+    );
+    write(
+        fixture.path().join("dist/module/src/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "imports/react",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_preserves_findings_from_deeper_nested_package_manifests() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./subdir"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/subdir/package.json"),
+        r##"
+        {
+          "main": "./index.js",
+          "imports": {
+            "react": "./shim.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/subdir/index.js"),
+        "module.exports = {}\n",
+    );
+    write(
+        fixture.path().join("dist/module/subdir/shim.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/module/subdir/package.json"),
+            "imports/react",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("dist/module/subdir/package.json")),
+    );
+    assert_no_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_incompatible_nested_exact_file_types() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./index.d.ts"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.d.ts"),
+        "export type Maximus = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "main",
+            "./index.d.ts",
+        ),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json main points to ./index.d.ts, but runtime entrypoints must not point to declaration-only files such as .d.ts.",
+        "Point main/module/bin to a runtime file instead of a declaration-only file.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_preserves_nested_import_key_findings_when_directory_target_still_fails(
+) {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./missing.js",
+          "imports": {
+            "react": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/src/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/module/package.json"),
+            "imports/react",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("dist/module/package.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/module, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_invalid_nested_import_keys_for_wildcard_exports() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./dist/*"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/pkg/package.json"),
+        r##"
+        {
+          "imports": {
+            "react": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/pkg/src/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &key_finding_id_for_package(
+            &fixture.path().join("dist/pkg/package.json"),
+            "imports/react",
+        ),
+        Severity::Error,
+        "Package entrypoint key is invalid",
+        "package.json imports/react uses an invalid key. imports keys must start with #.",
+        "Rename the imports entry to a # alias before publishing.",
+        Some(fixture.path().join("dist/pkg/package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_rejects_wildcard_matches_that_only_hit_package_manifests() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./dist/*"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/pkg/package.json"),
+        r##"
+        {
+          "name": "pkg",
+          "version": "0.0.0"
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./*", "./dist/*"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json exports/./* points to ./dist/*, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_skips_current_manifest_when_wildcard_matches_package_json() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./*"
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "exports/./*", "./*"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json exports/./* points to ./*, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_reports_incompatible_wildcard_runtime_matches() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "exports": {
+            "./*": "./dist/*"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/index.d.ts"),
+        "export type Maximus = string;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "package-entrypoints:{}:exports/./*:./dist/*:./dist/index.d.ts",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Error,
+        "Package entrypoint target uses an incompatible file type",
+        "package.json exports/./* points to ./dist/*, but wildcard match ./dist/index.d.ts is a declaration-only file.",
+        "Point runtime entrypoints to runtime files instead of declaration-only files.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+#[test]
+fn package_entrypoints_check_deduplicates_nested_import_key_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "imports": {
+            "#nested": "./packages/foo"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("packages/foo/package.json"),
+        r##"
+        {
+          "name": "foo",
+          "version": "0.0.0",
+          "imports": {
+            "react": "./src/index.js"
+          }
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("packages/foo/src/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+    let duplicate_id = key_finding_id_for_package(
+        &fixture.path().join("packages/foo/package.json"),
+        "imports/react",
+    );
+    let duplicate_count = outcome
+        .findings
+        .iter()
+        .filter(|finding| finding.id == duplicate_id)
+        .count();
+
+    assert_eq!(duplicate_count, 1);
+}
+
+#[test]
+fn package_entrypoints_check_treats_invalid_nested_package_json_as_missing_target() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r##"
+        {
+          "main": "./dist/module"
+        }
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/package.json"),
+        r##"
+        {
+          "main": "./entry.js"
+        "##,
+    );
+    write(
+        fixture.path().join("dist/module/index.js"),
+        "export default 1;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &finding_id(fixture.path(), "main", "./dist/module"),
+        Severity::Error,
+        "Package entrypoint target does not exist",
+        "package.json main points to ./dist/module, but the resolved path was not found.",
+        "Update the relative path or remove the stale entrypoint before publishing.",
+        Some(fixture.path().join("package.json")),
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn finding_id(root: &Path, field_path: &str, target: &str) -> String {
+    finding_id_for_package(&root.join("package.json"), field_path, target)
+}
+
+fn finding_id_for_package(package_json_path: &Path, field_path: &str, target: &str) -> String {
+    format!(
+        "package-entrypoints:{}:{}:{}",
+        package_json_path.to_string_lossy(),
+        field_path,
+        target
+    )
+}
+
+fn key_finding_id(root: &Path, field_path: &str) -> String {
+    key_finding_id_for_package(&root.join("package.json"), field_path)
+}
+
+fn key_finding_id_for_package(package_json_path: &Path, field_path: &str) -> String {
+    format!(
+        "package-entrypoints:{}:{}:key",
+        package_json_path.to_string_lossy(),
+        field_path
+    )
+}
+
+fn invalid_type_finding_id(root: &Path, field_path: &str, value_kind: &str) -> String {
+    invalid_type_finding_id_for_package(&root.join("package.json"), field_path, value_kind)
+}
+
+fn invalid_type_finding_id_for_package(
+    package_json_path: &Path,
+    field_path: &str,
+    value_kind: &str,
+) -> String {
+    format!(
+        "package-entrypoints:{}:{}:invalid-type:{}",
+        package_json_path.to_string_lossy(),
+        field_path,
+        value_kind
+    )
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    detail: &str,
+    hint: &str,
+    file: Option<PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| {
+            let ids = findings
+                .iter()
+                .map(|finding| finding.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            panic!("missing finding {id}; available ids: {ids}");
+        });
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.detail, detail);
+    assert_eq!(finding.hint, hint);
+    assert_eq!(finding.file, file);
+    assert!(!finding.fixable);
+    assert!(finding.fix_ids.is_empty());
+}
+
+fn assert_no_finding(findings: &[maximus_core::Finding], id: &str) {
+    assert!(
+        findings.iter().all(|finding| finding.id != id),
+        "unexpected finding {id}"
+    );
+}

--- a/crates/maximus-checks/tests/package_entrypoints_registry.rs
+++ b/crates/maximus-checks/tests/package_entrypoints_registry.rs
@@ -1,0 +1,39 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::audit_project;
+use tempfile::TempDir;
+
+#[test]
+fn audit_project_runs_package_entrypoints_check() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "main": "./dist/missing-main.js" }"#,
+    );
+
+    let audited = audit_project(fixture.path()).expect("audit should run");
+
+    assert!(
+        audited
+            .result
+            .findings
+            .iter()
+            .any(|finding| finding.id
+                == format!(
+                    "package-entrypoints:{}:main:./dist/missing-main.js",
+                    fixture.path().join("package.json").to_string_lossy()
+                )),
+        "registered audit path should include package-entrypoints findings"
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}


### PR DESCRIPTION
## 요약
- Rust checks에 package entrypoint drift seed를 추가했습니다.
- `main`, `module`, `types`, `bin`, `exports`, `imports`의 상대 경로 target을 재귀적으로 검사합니다.
- registry/main wiring은 아직 넣지 않고, seed 모듈과 전용 테스트만 추가했습니다.

## 변경
- `crates/maximus-checks/src/package_entrypoints.rs` 추가
- `crates/maximus-checks/src/lib.rs` export 추가
- `crates/maximus-checks/tests/package_entrypoints_checks.rs` 추가

## 검증
- `cargo test -p maximus-checks --test package_entrypoints_checks`
