### PR TITLE
[codex] Rust config loader seed 추가

### DIFF
--- a/crates/maximus-core/src/config.rs
+++ b/crates/maximus-core/src/config.rs
@@ -9,6 +9,7 @@ use crate::{parse_jsonc, read_text_if_exists, ParseJsoncError};
 const CONFIG_FILE_NAMES: [&str; 2] = ["maximus.config.json", ".maximusrc.json"];
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MaximusConfig {
     #[serde(default)]
     pub checks: CheckFilterConfig,
@@ -21,6 +22,7 @@ pub struct MaximusConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CheckFilterConfig {
     #[serde(default)]
     pub only: Vec<String>,
@@ -46,6 +48,7 @@ pub enum FailOnLevel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReportConfig {
     #[serde(default, rename = "failOn")]
     pub fail_on: Option<FailOnLevel>,

--- a/crates/maximus-core/src/config.rs
+++ b/crates/maximus-core/src/config.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{parse_jsonc, read_text_if_exists, ParseJsoncError};
+
+const CONFIG_FILE_NAMES: [&str; 2] = ["maximus.config.json", ".maximusrc.json"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct MaximusConfig {
+    #[serde(default)]
+    pub checks: CheckFilterConfig,
+    #[serde(default)]
+    pub ignore: Vec<String>,
+    #[serde(default)]
+    pub severity: BTreeMap<String, ConfigSeverity>,
+    #[serde(default)]
+    pub report: ReportConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CheckFilterConfig {
+    #[serde(default)]
+    pub only: Vec<String>,
+    #[serde(default)]
+    pub skip: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigSeverity {
+    Error,
+    Warn,
+    Info,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailOnLevel {
+    Error,
+    Warn,
+    Info,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ReportConfig {
+    #[serde(default, rename = "failOn")]
+    pub fail_on: Option<FailOnLevel>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedConfig {
+    pub path: PathBuf,
+    pub config: MaximusConfig,
+}
+
+#[derive(Debug)]
+pub enum LoadConfigError {
+    Io(io::Error),
+    Parse(ParseJsoncError),
+}
+
+impl std::fmt::Display for LoadConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Parse(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadConfigError {}
+
+impl From<io::Error> for LoadConfigError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<ParseJsoncError> for LoadConfigError {
+    fn from(value: ParseJsoncError) -> Self {
+        Self::Parse(value)
+    }
+}
+
+pub fn load_maximus_config(start_dir: &Path) -> Result<Option<LoadedConfig>, LoadConfigError> {
+    let Some(config_path) = find_maximus_config_path(start_dir)? else {
+        return Ok(None);
+    };
+    let Some(text) = read_text_if_exists(&config_path)? else {
+        return Ok(None);
+    };
+    let config = parse_jsonc::<MaximusConfig>(&text, &config_path.to_string_lossy())?;
+
+    Ok(Some(LoadedConfig {
+        path: config_path,
+        config,
+    }))
+}
+
+pub fn find_maximus_config_path(start_dir: &Path) -> io::Result<Option<PathBuf>> {
+    let start_dir = std::path::absolute(start_dir)?;
+
+    for directory in start_dir.ancestors() {
+        for file_name in CONFIG_FILE_NAMES {
+            let candidate = directory.join(file_name);
+            if candidate.is_file() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+
+    Ok(None)
+}

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Pure data-model and parsing helpers for the Maximus Rust rewrite.
 
 pub mod baseline;
+pub mod config;
 pub mod discover;
 pub mod env_parser;
 pub mod fixes;
@@ -11,6 +12,10 @@ pub mod models;
 mod text_order;
 
 pub use discover::{discover_project, find_nearest_package_file, get_directories, get_files};
+pub use config::{
+    find_maximus_config_path, load_maximus_config, CheckFilterConfig, ConfigSeverity,
+    FailOnLevel, LoadedConfig, LoadConfigError, MaximusConfig, ReportConfig,
+};
 pub use env_parser::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, parse_env,
     render_env_template, EnvDuplicate, EnvEntry, InvalidEnvLine, ParsedEnv,

--- a/crates/maximus-core/tests/config_loader.rs
+++ b/crates/maximus-core/tests/config_loader.rs
@@ -1,0 +1,101 @@
+use std::fs;
+
+use maximus_core::{
+    find_maximus_config_path, load_maximus_config, ConfigSeverity, FailOnLevel,
+};
+use tempfile::tempdir;
+
+#[test]
+fn finds_root_maximus_config_when_searching_nested_directory() {
+    let temp = tempdir().expect("temp dir should exist");
+    let nested = temp.path().join("apps/web");
+    fs::create_dir_all(&nested).expect("nested dir should exist");
+    fs::write(temp.path().join("maximus.config.json"), "{ \"ignore\": [\"dist\"] }")
+        .expect("config should write");
+
+    let found = find_maximus_config_path(&nested).expect("search should succeed");
+
+    assert_eq!(found, Some(temp.path().join("maximus.config.json")));
+}
+
+#[test]
+fn prefers_nearest_config_and_then_file_name_precedence() {
+    let temp = tempdir().expect("temp dir should exist");
+    let nested = temp.path().join("apps/web");
+    fs::create_dir_all(&nested).expect("nested dir should exist");
+    fs::write(temp.path().join("maximus.config.json"), "{ \"ignore\": [\"root\"] }")
+        .expect("root config should write");
+    fs::write(nested.join(".maximusrc.json"), "{ \"ignore\": [\"nested\"] }")
+        .expect("nested config should write");
+    fs::write(
+        nested.join("maximus.config.json"),
+        "{ \"ignore\": [\"nested-maximus\"] }",
+    )
+    .expect("nested maximus config should write");
+
+    let loaded = load_maximus_config(&nested)
+        .expect("load should succeed")
+        .expect("config should exist");
+
+    assert_eq!(loaded.path, nested.join("maximus.config.json"));
+    assert_eq!(loaded.config.ignore, vec!["nested-maximus".to_string()]);
+}
+
+#[test]
+fn parses_jsonc_shape_for_checks_severity_and_report() {
+    let temp = tempdir().expect("temp dir should exist");
+    fs::write(
+        temp.path().join("maximus.config.json"),
+        r#"
+        {
+          // comment
+          "checks": {
+            "only": ["env", "tsconfig"],
+            "skip": ["duplicates"]
+          },
+          "ignore": ["dist", "coverage"],
+          "severity": {
+            "env-mismatch": "info"
+          },
+          "report": {
+            "failOn": "error"
+          }
+        }
+        "#,
+    )
+    .expect("config should write");
+
+    let loaded = load_maximus_config(temp.path())
+        .expect("load should succeed")
+        .expect("config should exist");
+
+    assert_eq!(loaded.config.checks.only, vec!["env", "tsconfig"]);
+    assert_eq!(loaded.config.checks.skip, vec!["duplicates"]);
+    assert_eq!(loaded.config.ignore, vec!["dist", "coverage"]);
+    assert_eq!(
+        loaded.config.severity.get("env-mismatch"),
+        Some(&ConfigSeverity::Info)
+    );
+    assert_eq!(loaded.config.report.fail_on, Some(FailOnLevel::Error));
+}
+
+#[test]
+fn returns_none_when_no_config_exists() {
+    let temp = tempdir().expect("temp dir should exist");
+
+    assert_eq!(find_maximus_config_path(temp.path()).expect("search should succeed"), None);
+    assert!(load_maximus_config(temp.path()).expect("load should succeed").is_none());
+}
+
+#[test]
+fn parse_errors_include_config_path_label() {
+    let temp = tempdir().expect("temp dir should exist");
+    let config_path = temp.path().join(".maximusrc.json");
+    fs::write(&config_path, "{ \"checks\": { \"only\": [\"env\",] }")
+        .expect("broken config should write");
+
+    let error = load_maximus_config(temp.path()).expect_err("parse should fail");
+    let rendered = error.to_string();
+
+    assert!(rendered.contains(&config_path.to_string_lossy().to_string()));
+}

--- a/crates/maximus-core/tests/config_loader.rs
+++ b/crates/maximus-core/tests/config_loader.rs
@@ -99,3 +99,26 @@ fn parse_errors_include_config_path_label() {
 
     assert!(rendered.contains(&config_path.to_string_lossy().to_string()));
 }
+
+#[test]
+fn parse_errors_when_unknown_config_keys_are_present() {
+    let temp = tempdir().expect("temp dir should exist");
+    let config_path = temp.path().join("maximus.config.json");
+    fs::write(
+        &config_path,
+        r#"
+        {
+          "checks": {
+            "skp": ["env"]
+          }
+        }
+        "#,
+    )
+    .expect("config should write");
+
+    let error = load_maximus_config(temp.path()).expect_err("unknown keys should fail");
+    let rendered = error.to_string();
+
+    assert!(rendered.contains(&config_path.to_string_lossy().to_string()));
+    assert!(rendered.contains("skp"));
+}


### PR DESCRIPTION
## 요약
- Rust core에 `maximus.config.json` / `.maximusrc.json` 탐색과 JSONC 파싱 seed를 추가했습니다.
- `checks.only`, `checks.skip`, `ignore`, `severity`, `report.failOn` shape를 담는 config 모델을 추가했습니다.
- 아직 CLI wiring은 하지 않고, adoption PR에서 얹을 수 있는 core seed만 고정했습니다.

## 변경
- `crates/maximus-core/src/config.rs` 추가
- `crates/maximus-core/src/lib.rs` export 추가
- `crates/maximus-core/tests/config_loader.rs` 추가

## 검증
- `cargo test -p maximus-core --test config_loader`
