### PR TITLE
[codex] Rust baseline seed 추가

### DIFF
--- a/crates/maximus-core/src/baseline.rs
+++ b/crates/maximus-core/src/baseline.rs
@@ -1,0 +1,120 @@
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaselineRecord {
+    pub id: String,
+    pub file: PathBuf,
+    pub detail_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineMatchKey<'a> {
+    pub id: &'a str,
+    pub file: &'a Path,
+    pub detail_hash: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BaselineError {
+    Io {
+        label: String,
+        message: String,
+    },
+    Parse {
+        label: String,
+        message: String,
+    },
+}
+
+impl BaselineError {
+    fn io(label: impl Into<String>, error: std::io::Error) -> Self {
+        Self::Io {
+            label: label.into(),
+            message: error.to_string(),
+        }
+    }
+
+    fn parse(label: impl Into<String>, error: serde_json::Error) -> Self {
+        Self::Parse {
+            label: label.into(),
+            message: error.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for BaselineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BaselineError::Io { label, message } | BaselineError::Parse { label, message } => {
+                write!(formatter, "{}: {}", label, message)
+            }
+        }
+    }
+}
+
+impl Error for BaselineError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BaselineDocument {
+    Bare(Vec<BaselineRecord>),
+    Wrapped { baseline: Vec<BaselineRecord> },
+    Records { records: Vec<BaselineRecord> },
+}
+
+pub fn parse_baseline_records(
+    text: &str,
+    label: impl Into<String>,
+) -> Result<Vec<BaselineRecord>, BaselineError> {
+    let label = label.into();
+    let document = serde_json::from_str::<BaselineDocument>(text)
+        .map_err(|error| BaselineError::parse(label.clone(), error))?;
+
+    Ok(match document {
+        BaselineDocument::Bare(records) => records,
+        BaselineDocument::Wrapped { baseline } => baseline,
+        BaselineDocument::Records { records } => records,
+    })
+}
+
+pub fn load_baseline_records(path: impl AsRef<Path>) -> Result<Vec<BaselineRecord>, BaselineError> {
+    let path = path.as_ref();
+    let label = path.display().to_string();
+    let text = fs::read_to_string(path).map_err(|error| BaselineError::io(label.clone(), error))?;
+
+    parse_baseline_records(&text, label)
+}
+
+pub fn record_matches(record: &BaselineRecord, key: &BaselineMatchKey<'_>) -> bool {
+    record.id == key.id
+        && record.file == key.file
+        && record.detail_hash == key.detail_hash
+}
+
+pub fn find_matching_record<'a>(
+    records: &'a [BaselineRecord],
+    key: &BaselineMatchKey<'_>,
+) -> Option<&'a BaselineRecord> {
+    records.iter().find(|record| record_matches(record, key))
+}
+
+pub fn contains_match(records: &[BaselineRecord], key: &BaselineMatchKey<'_>) -> bool {
+    find_matching_record(records, key).is_some()
+}
+
+pub fn detail_hash(detail: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+
+    for byte in detail.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+
+    format!("{hash:016x}")
+}

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Pure data-model and parsing helpers for the Maximus Rust rewrite.
 
+pub mod baseline;
 pub mod discover;
 pub mod env_parser;
 pub mod fixes;

--- a/crates/maximus-core/tests/baseline.rs
+++ b/crates/maximus-core/tests/baseline.rs
@@ -1,0 +1,103 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_core::baseline::{
+    contains_match, detail_hash, find_matching_record, load_baseline_records,
+    parse_baseline_records, record_matches, BaselineMatchKey, BaselineRecord,
+};
+use tempfile::TempDir;
+
+fn sample_record() -> BaselineRecord {
+    BaselineRecord {
+        id: "env-example".to_string(),
+        file: Path::new("packages/app/.env.example").to_path_buf(),
+        detail_hash: detail_hash("Create .env.example"),
+    }
+}
+
+#[test]
+fn load_baseline_records_parses_wrapped_json_successfully() {
+    let fixture = TempDir::new().unwrap();
+    let path = fixture.path().join("baseline.json");
+    let record = sample_record();
+
+    fs::write(
+        &path,
+        format!(
+            r#"{{
+  "baseline": [
+    {{
+      "id": "{id}",
+      "file": "{file}",
+      "detailHash": "{detail_hash}"
+    }}
+  ]
+}}"#,
+            id = record.id,
+            file = record.file.display(),
+            detail_hash = record.detail_hash
+        ),
+    )
+    .unwrap();
+
+    let parsed = load_baseline_records(&path).unwrap();
+
+    assert_eq!(parsed, vec![record]);
+}
+
+#[test]
+fn load_baseline_records_surfaces_parse_errors() {
+    let fixture = TempDir::new().unwrap();
+    let path = fixture.path().join("baseline.json");
+
+    fs::write(&path, "{ not valid json").unwrap();
+
+    let error = load_baseline_records(&path).unwrap_err();
+
+    assert!(error.to_string().contains("baseline.json"));
+}
+
+#[test]
+fn exact_match_requires_matching_id_file_and_detail_hash() {
+    let record = sample_record();
+    let key = BaselineMatchKey {
+        id: &record.id,
+        file: &record.file,
+        detail_hash: &record.detail_hash,
+    };
+
+    assert!(record_matches(&record, &key));
+    assert_eq!(find_matching_record(std::slice::from_ref(&record), &key), Some(&record));
+    assert!(contains_match(std::slice::from_ref(&record), &key));
+}
+
+#[test]
+fn non_match_rejects_mismatched_detail_hash() {
+    let record = sample_record();
+    let key = BaselineMatchKey {
+        id: &record.id,
+        file: &record.file,
+        detail_hash: "0000000000000000",
+    };
+
+    assert!(!record_matches(&record, &key));
+    assert!(find_matching_record(std::slice::from_ref(&record), &key).is_none());
+    assert!(!contains_match(std::slice::from_ref(&record), &key));
+}
+
+#[test]
+fn parse_baseline_records_supports_bare_arrays() {
+    let record = sample_record();
+    let parsed = parse_baseline_records(
+        &format!(
+            r#"[{{"id":"{id}","file":"{file}","detailHash":"{detail_hash}"}}]"#,
+            id = record.id,
+            file = record.file.display(),
+            detail_hash = record.detail_hash
+        ),
+        "baseline.json",
+    )
+    .unwrap();
+
+    assert_eq!(parsed, vec![record]);
+}


### PR DESCRIPTION
## 요약
- Rust core에 baseline 로더와 matching helper seed를 추가했습니다.
- `id`, `file`, `detailHash` 기준 exact-match semantics를 core 레벨에서 고정했습니다.
- 아직 CLI/main wiring은 하지 않고, adoption PR에서 사용할 seed만 추가했습니다.

## 변경
- `crates/maximus-core/src/baseline.rs` 추가
- `crates/maximus-core/src/lib.rs` export 추가
- `crates/maximus-core/tests/baseline.rs` 추가

## 검증
- `cargo test -p maximus-core --test baseline`
