### PR TITLE
feat: fix selector와 dry-run diff preview 추가

### DIFF
--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -1,8 +1,12 @@
 use std::ffi::OsString;
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Flags {
+    pub diff: bool,
     pub dry_run: bool,
+    pub fix_ids: Vec<String>,
+    pub fix_prefixes: Vec<String>,
     pub help: bool,
     pub json: bool,
 }
@@ -14,39 +18,78 @@ pub struct ParsedArgs {
     pub flags: Flags,
 }
 
-pub fn parse_args<I, S>(argv: I) -> ParsedArgs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArgsError {
+    MissingValue(&'static str),
+}
+
+impl Display for ArgsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingValue(flag) => write!(f, "Option \"{flag}\" requires a value."),
+        }
+    }
+}
+
+pub fn parse_args<I, S>(argv: I) -> Result<ParsedArgs, ArgsError>
 where
     I: IntoIterator<Item = S>,
     S: Into<OsString>,
 {
     let mut args = Vec::new();
     let mut flags = Flags::default();
+    let mut tokens = argv.into_iter().map(Into::into);
 
-    for token in argv.into_iter().map(Into::into) {
+    while let Some(token) = tokens.next() {
         match token.to_str() {
+            Some("--diff") => flags.diff = true,
             Some("--dry-run") => flags.dry_run = true,
+            Some("--fix-id") => {
+                let value = next_option_value(tokens.next(), "--fix-id")?;
+                flags.fix_ids.push(value.to_string_lossy().into_owned());
+            }
+            Some("--fix-prefix") => {
+                let value = next_option_value(tokens.next(), "--fix-prefix")?;
+                flags.fix_prefixes.push(value.to_string_lossy().into_owned());
+            }
             Some("--json") => flags.json = true,
             Some("--help") | Some("-h") => flags.help = true,
             _ => args.push(token),
         }
     }
 
-    ParsedArgs {
+    Ok(ParsedArgs {
         command: args.first().map(|value| value.to_string_lossy().into_owned()),
         args: args.into_iter().skip(1).collect(),
         flags,
+    })
+}
+
+fn next_option_value(value: Option<OsString>, flag: &'static str) -> Result<OsString, ArgsError> {
+    let Some(value) = value else {
+        return Err(ArgsError::MissingValue(flag));
+    };
+
+    if value
+        .to_str()
+        .is_some_and(|candidate| candidate.starts_with('-'))
+    {
+        return Err(ArgsError::MissingValue(flag));
     }
+
+    Ok(value)
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
 
-    use super::{parse_args, Flags, ParsedArgs};
+    use super::{parse_args, ArgsError, Flags, ParsedArgs};
 
     #[test]
     fn parse_args_collects_known_flags_and_positionals() {
-        let parsed = parse_args(["fix", "./repo", "--dry-run", "--json"]);
+        let parsed = parse_args(["fix", "./repo", "--dry-run", "--json"])
+            .expect("args should parse");
 
         assert_eq!(
             parsed,
@@ -54,7 +97,10 @@ mod tests {
                 command: Some("fix".to_string()),
                 args: vec![OsString::from("./repo")],
                 flags: Flags {
+                    diff: false,
                     dry_run: true,
+                    fix_ids: Vec::new(),
+                    fix_prefixes: Vec::new(),
                     help: false,
                     json: true,
                 },
@@ -64,13 +110,49 @@ mod tests {
 
     #[test]
     fn parse_args_treats_unknown_tokens_as_positionals() {
-        let parsed = parse_args(["audit", "--mystery", "target"]);
+        let parsed =
+            parse_args(["audit", "--mystery", "target"]).expect("args should parse");
 
         assert_eq!(parsed.command.as_deref(), Some("audit"));
         assert_eq!(
             parsed.args,
             vec![OsString::from("--mystery"), OsString::from("target")]
         );
+    }
+
+    #[test]
+    fn parse_args_collects_fix_selectors_and_diff_flag() {
+        let parsed = parse_args([
+            "fix",
+            "./repo",
+            "--fix-id",
+            "env-example:create:.",
+            "--fix-prefix",
+            "env-example:",
+            "--diff",
+        ])
+        .expect("args should parse");
+
+        assert_eq!(parsed.command.as_deref(), Some("fix"));
+        assert_eq!(parsed.args, vec![OsString::from("./repo")]);
+        assert_eq!(parsed.flags.fix_ids, vec!["env-example:create:.".to_string()]);
+        assert_eq!(parsed.flags.fix_prefixes, vec!["env-example:".to_string()]);
+        assert!(parsed.flags.diff);
+    }
+
+    #[test]
+    fn parse_args_errors_when_fix_selector_value_is_missing() {
+        let error = parse_args(["fix", "--fix-id"]).expect_err("missing selector should fail");
+
+        assert_eq!(error, ArgsError::MissingValue("--fix-id"));
+    }
+
+    #[test]
+    fn parse_args_errors_when_fix_selector_value_is_another_flag() {
+        let error = parse_args(["fix", "--fix-id", "--dry-run"])
+            .expect_err("flag-shaped selector should fail");
+
+        assert_eq!(error, ArgsError::MissingValue("--fix-id"));
     }
 
     #[cfg(unix)]
@@ -81,7 +163,8 @@ mod tests {
         let parsed = parse_args([
             OsString::from("audit"),
             OsString::from_vec(vec![0x66, 0x6f, 0x80, 0x6f]),
-        ]);
+        ])
+        .expect("args should parse");
 
         assert_eq!(parsed.command.as_deref(), Some("audit"));
         assert_eq!(parsed.args.len(), 1);

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod exit_codes;
+mod report_diff;
 mod report_json;
 mod report_text;
 
@@ -11,22 +12,29 @@ use std::io;
 use std::process;
 
 use maximus_checks::audit_project;
-use maximus_core::apply_fixes;
+use maximus_core::{
+    apply_fixes, preview_fixes, select_fix_plans, select_planned_fixes, AuditResult, FixPlan,
+    FixSelector,
+};
 
-use crate::args::{parse_args, Flags};
+use crate::args::{parse_args, ArgsError, Flags};
 
 #[derive(Debug)]
 enum CliError {
+    Args(ArgsError),
     Io(io::Error),
     Json(serde_json::Error),
+    InvalidArguments(String),
     UnknownCommand(String),
 }
 
 impl Display for CliError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Args(error) => write!(f, "{error}"),
             Self::Io(error) => write!(f, "{error}"),
             Self::Json(error) => write!(f, "{error}"),
+            Self::InvalidArguments(message) => write!(f, "{message}"),
             Self::UnknownCommand(command) => {
                 write!(f, "Unknown command \"{command}\". Run \"maximus help\" for usage.")
             }
@@ -35,6 +43,12 @@ impl Display for CliError {
 }
 
 impl Error for CliError {}
+
+impl From<ArgsError> for CliError {
+    fn from(value: ArgsError) -> Self {
+        Self::Args(value)
+    }
+}
 
 impl From<io::Error> for CliError {
     fn from(value: io::Error) -> Self {
@@ -65,7 +79,8 @@ where
     I: IntoIterator<Item = S>,
     S: Into<std::ffi::OsString>,
 {
-    let parsed = parse_args(argv);
+    let parsed = parse_args(argv)?;
+    validate_command_flags(parsed.command.as_deref(), &parsed.flags)?;
 
     if parsed.command.is_none()
         || parsed.command.as_deref() == Some("help")
@@ -118,14 +133,31 @@ fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, C
             "one or more fixes are not executable from the Rust runtime yet",
         )));
     }
-    let planned = initial.planned_fixes.clone();
+
+    let selector = FixSelector {
+        ids: flags.fix_ids.clone(),
+        prefixes: flags.fix_prefixes.clone(),
+    };
+    let planned = select_planned_fixes(&initial.planned_fixes, &selector);
+    if !selector.is_empty() && planned.is_empty() {
+        return Err(CliError::InvalidArguments(
+            "No matching fixes for the requested selector.".to_string(),
+        ));
+    }
+    let selected_fixes = select_fix_plans(&initial.result.fixes, &selector);
+    let selected_initial = result_with_selected_fixes(&initial.result, selected_fixes.clone());
+    let previewed = if flags.dry_run && flags.diff {
+        Some(preview_fixes(&planned)?)
+    } else {
+        None
+    };
     let applied = if flags.dry_run {
         Vec::new()
     } else {
         apply_fixes(&planned)?
     };
     let final_result = if flags.dry_run {
-        initial.result.clone()
+        selected_initial.clone()
     } else {
         audit_project(target_dir)?.result
     };
@@ -136,20 +168,31 @@ fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, C
             report_json::render_fix_result(
                 flags.dry_run,
                 target_dir,
-                &initial.result,
+                &selected_initial,
                 &applied,
                 &final_result,
+                previewed.as_deref(),
             )?
         );
     } else {
+        let selected_for_report = if selector.is_empty() && !flags.diff {
+            None
+        } else {
+            Some(selected_initial.fixes.as_slice())
+        };
+        let preview_report = previewed
+            .as_ref()
+            .map(|previews| report_diff::render_fix_preview(target_dir, previews));
         println!(
             "{}",
             report_text::format_fix_result(
                 flags.dry_run,
                 target_dir,
-                &initial.result,
+                &selected_initial,
                 &applied,
                 &final_result,
+                selected_for_report,
+                preview_report.as_deref(),
             )
         );
     }
@@ -157,11 +200,38 @@ fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, C
     Ok(exit_codes::fix_exit_code(&final_result.summary))
 }
 
+fn validate_command_flags(command: Option<&str>, flags: &Flags) -> Result<(), CliError> {
+    let uses_fix_only_flags =
+        flags.diff || !flags.fix_ids.is_empty() || !flags.fix_prefixes.is_empty();
+
+    if uses_fix_only_flags && (flags.help || command != Some("fix")) {
+        return Err(CliError::InvalidArguments(
+            "Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\"."
+                .to_string(),
+        ));
+    }
+
+    if flags.diff && !flags.dry_run {
+        return Err(CliError::InvalidArguments(
+            "Option \"--diff\" requires \"fix --dry-run\".".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn resolve_target_dir(path_arg: Option<&OsStr>) -> io::Result<std::path::PathBuf> {
     match path_arg {
         Some(path) => std::path::absolute(std::path::PathBuf::from(path)),
         None => env::current_dir(),
     }
+}
+
+fn result_with_selected_fixes(result: &AuditResult, fixes: Vec<FixPlan>) -> AuditResult {
+    let mut selected = result.clone();
+    selected.summary.fixes_available = fixes.len();
+    selected.fixes = fixes;
+    selected
 }
 
 #[cfg(test)]

--- a/crates/maximus-cli/src/report_diff.rs
+++ b/crates/maximus-cli/src/report_diff.rs
@@ -1,0 +1,184 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::Path;
+
+use maximus_core::{FixFilePreview, PreviewedFix};
+
+pub fn render_fix_preview(target_dir: &Path, previews: &[PreviewedFix]) -> String {
+    let mut blocks = Vec::new();
+
+    for preview in previews {
+        blocks.push(format!("- {}", preview.title));
+
+        for file_preview in &preview.previews {
+            blocks.push(render_file_diff(target_dir, file_preview));
+        }
+    }
+
+    blocks.join("\n\n")
+}
+
+fn render_file_diff(target_dir: &Path, preview: &FixFilePreview) -> String {
+    let path = display_preview_path(target_dir, &preview.path);
+
+    if !preview.existed_before {
+        return render_create_diff(&path, &preview.after);
+    }
+
+    if let Some(addition) = preview.after.strip_prefix(&preview.before) {
+        return render_append_diff(&path, &preview.before, addition);
+    }
+
+    render_replace_diff(&path, &preview.before, &preview.after)
+}
+
+fn render_create_diff(path: &str, after: &str) -> String {
+    let after_lines = diff_lines(after);
+    let mut lines = vec![
+        "--- /dev/null".to_string(),
+        format!("+++ {path}"),
+        format!("@@ -0,0 +1,{} @@", after_lines.len()),
+    ];
+
+    for line in after_lines {
+        lines.push(format!("+{line}"));
+    }
+
+    lines.join("\n")
+}
+
+fn render_append_diff(path: &str, before: &str, addition: &str) -> String {
+    let before_lines = diff_lines(before);
+    let addition_lines = diff_lines(addition);
+    let before_start = if before_lines.is_empty() { 0 } else { 1 };
+    let mut lines = vec![
+        format!("--- {path}"),
+        format!("+++ {path}"),
+        format!(
+            "@@ -{before_start},{} +1,{} @@",
+            before_lines.len(),
+            before_lines.len() + addition_lines.len()
+        ),
+    ];
+
+    for line in before_lines {
+        lines.push(format!(" {line}"));
+    }
+
+    for line in addition_lines {
+        lines.push(format!("+{line}"));
+    }
+
+    lines.join("\n")
+}
+
+fn render_replace_diff(path: &str, before: &str, after: &str) -> String {
+    let before_lines = diff_lines(before);
+    let after_lines = diff_lines(after);
+    let mut lines = vec![
+        format!("--- {path}"),
+        format!("+++ {path}"),
+        format!("@@ -1,{} +1,{} @@", before_lines.len(), after_lines.len()),
+    ];
+
+    for line in before_lines {
+        lines.push(format!("-{line}"));
+    }
+
+    for line in after_lines {
+        lines.push(format!("+{line}"));
+    }
+
+    lines.join("\n")
+}
+
+fn diff_lines(text: &str) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = text.split('\n').map(ToString::to_string).collect::<Vec<_>>();
+    if text.ends_with('\n') {
+        lines.pop();
+    }
+    lines
+}
+
+fn display_preview_path(root_dir: &Path, path: &Path) -> String {
+    path.strip_prefix(root_dir)
+        .ok()
+        .map(|relative| relative.to_string_lossy().into_owned())
+        .filter(|relative| !relative.is_empty())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use maximus_core::{FixFilePreview, PreviewedFix};
+
+    use super::render_fix_preview;
+
+    #[test]
+    fn render_fix_preview_formats_create_and_append_diffs() {
+        let target_dir = PathBuf::from("/tmp/project");
+        let preview = render_fix_preview(
+            &target_dir,
+            &[
+                PreviewedFix {
+                    id: "env-example:create:/tmp/project".to_string(),
+                    title: "Create .env.example".to_string(),
+                    files: vec![target_dir.join(".env.example")],
+                    previews: vec![FixFilePreview {
+                        path: target_dir.join(".env.example"),
+                        existed_before: false,
+                        before: String::new(),
+                        after: "API_URL=\n".to_string(),
+                    }],
+                },
+                PreviewedFix {
+                    id: "env-example:sync:/tmp/project".to_string(),
+                    title: "Append missing keys to .env.example".to_string(),
+                    files: vec![target_dir.join(".env.example")],
+                    previews: vec![FixFilePreview {
+                        path: target_dir.join(".env.example"),
+                        existed_before: true,
+                        before: "EXISTING=\n".to_string(),
+                        after: "EXISTING=\nAPI_URL=\n".to_string(),
+                    }],
+                },
+            ],
+        );
+
+        assert!(preview.contains("--- /dev/null"));
+        assert!(preview.contains("+++ .env.example"));
+        assert!(preview.contains("+API_URL="));
+        assert!(preview.contains("@@ -1,1 +1,2 @@"));
+        assert!(preview.contains(" EXISTING="));
+    }
+
+    #[test]
+    fn render_fix_preview_treats_existing_empty_file_as_append() {
+        let target_dir = PathBuf::from("/tmp/project");
+        let preview = render_fix_preview(
+            &target_dir,
+            &[PreviewedFix {
+                id: "env-example:sync:/tmp/project".to_string(),
+                title: "Append missing keys to .env.example".to_string(),
+                files: vec![target_dir.join(".env.example")],
+                previews: vec![FixFilePreview {
+                    path: target_dir.join(".env.example"),
+                    existed_before: true,
+                    before: String::new(),
+                    after: "API_URL=\n".to_string(),
+                }],
+            }],
+        );
+
+        assert!(preview.contains("--- .env.example"));
+        assert!(preview.contains("+++ .env.example"));
+        assert!(preview.contains("@@ -0,0 +1,1 @@"));
+        assert!(!preview.contains("/dev/null"));
+    }
+}

--- a/crates/maximus-cli/src/report_json.rs
+++ b/crates/maximus-cli/src/report_json.rs
@@ -2,7 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
-use maximus_core::{serialize_audit_result, AppliedFix, AuditResult, SerializableAuditResult};
+use maximus_core::{
+    serialize_audit_result, AppliedFix, AuditResult, PreviewedFix, SerializableAuditResult,
+};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -14,6 +16,8 @@ struct SerializableFixOutput {
     applied: Vec<SerializableAppliedFix>,
     #[serde(rename = "final")]
     final_result: SerializableAuditResult,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preview: Option<Vec<SerializablePreviewedFix>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -26,6 +30,24 @@ struct SerializableAppliedFix {
     outcome: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializablePreviewedFix {
+    id: String,
+    title: String,
+    files: Vec<PathBuf>,
+    diffs: Vec<SerializablePreviewedFile>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializablePreviewedFile {
+    path: PathBuf,
+    existed_before: bool,
+    before: String,
+    after: String,
+}
+
 pub fn render_audit_result(result: &AuditResult) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&serialize_audit_result(result))
 }
@@ -36,6 +58,7 @@ pub fn render_fix_result(
     initial: &AuditResult,
     applied: &[AppliedFix],
     final_result: &AuditResult,
+    preview: Option<&[PreviewedFix]>,
 ) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&SerializableFixOutput {
         dry_run,
@@ -51,6 +74,26 @@ pub fn render_fix_result(
             })
             .collect(),
         final_result: serialize_audit_result(final_result),
+        preview: preview.map(|previews| {
+            previews
+                .iter()
+                .map(|preview| SerializablePreviewedFix {
+                    id: preview.id.clone(),
+                    title: preview.title.clone(),
+                    files: preview.files.clone(),
+                    diffs: preview
+                        .previews
+                        .iter()
+                        .map(|file| SerializablePreviewedFile {
+                            path: file.path.clone(),
+                            existed_before: file.existed_before,
+                            before: file.before.clone(),
+                            after: file.after.clone(),
+                        })
+                        .collect(),
+                })
+                .collect()
+        }),
     })
 }
 
@@ -58,7 +101,7 @@ pub fn render_fix_result(
 mod tests {
     use std::path::PathBuf;
 
-    use maximus_core::{AppliedFix, AuditResult, AuditSummary, StructureReport};
+    use maximus_core::{AppliedFix, AuditResult, AuditSummary, PreviewedFix, StructureReport};
     use serde_json::Value;
 
     use super::{render_audit_result, render_fix_result};
@@ -78,8 +121,15 @@ mod tests {
     #[test]
     fn fix_json_keeps_js_top_level_keys() {
         let result = sample_result(PathBuf::from("/tmp/project"));
-        let json = render_fix_result(true, PathBuf::from("/tmp/project").as_path(), &result, &[], &result)
-            .expect("fix json should render");
+        let json = render_fix_result(
+            true,
+            PathBuf::from("/tmp/project").as_path(),
+            &result,
+            &[],
+            &result,
+            None,
+        )
+        .expect("fix json should render");
         let value: Value = serde_json::from_str(&json).expect("fix json should parse");
 
         assert_eq!(value["dryRun"], true);
@@ -103,11 +153,40 @@ mod tests {
                 outcome: "created".to_string(),
             }],
             &result,
+            None,
         )
         .expect("fix json should render");
         let value: Value = serde_json::from_str(&json).expect("fix json should parse");
 
         assert_eq!(value["applied"][0]["outcome"], "created");
+    }
+
+    #[test]
+    fn fix_json_includes_preview_when_requested() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_fix_result(
+            true,
+            PathBuf::from("/tmp/project").as_path(),
+            &result,
+            &[],
+            &result,
+            Some(&[PreviewedFix {
+                id: "env-example:create:/tmp/project".to_string(),
+                title: "Create .env.example".to_string(),
+                files: vec![PathBuf::from("/tmp/project/.env.example")],
+                previews: vec![maximus_core::FixFilePreview {
+                    path: PathBuf::from("/tmp/project/.env.example"),
+                    existed_before: false,
+                    before: String::new(),
+                    after: "API_URL=\n".to_string(),
+                }],
+            }]),
+        )
+        .expect("fix json should render");
+        let value: Value = serde_json::from_str(&json).expect("fix json should parse");
+
+        assert_eq!(value["preview"][0]["id"], "env-example:create:/tmp/project");
+        assert_eq!(value["preview"][0]["diffs"][0]["after"], "API_URL=\n");
     }
 
     fn sample_result(root_dir: PathBuf) -> AuditResult {

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use maximus_core::{AppliedFix, AuditResult, StructureReport};
+use maximus_core::{AppliedFix, AuditResult, FixPlan, StructureReport};
 
 pub fn format_help() -> String {
     [
@@ -13,7 +13,7 @@ pub fn format_help() -> String {
         "Usage",
         "  maximus audit [path] [--json]",
         "  maximus doctor [path] [--json]",
-        "  maximus fix [path] [--dry-run] [--json]",
+        "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
         "  maximus help",
     ]
     .join("\n")
@@ -120,19 +120,30 @@ pub fn format_fix_result(
     initial: &AuditResult,
     applied: &[AppliedFix],
     final_result: &AuditResult,
+    selected_fixes: Option<&[FixPlan]>,
+    preview_report: Option<&str>,
 ) -> String {
     let mut lines = Vec::new();
     let result = if dry_run { initial } else { final_result };
+    let should_show_selected_fixes = selected_fixes.is_some_and(|fixes| !fixes.is_empty());
+    let selected_fixes = selected_fixes.unwrap_or(&[]);
 
     lines.push("Maximus fix".to_string());
     lines.push(format!("Target: {}", display_path(target_dir)));
     lines.push(String::new());
 
     if dry_run {
-        lines.push(format!(
-            "Dry run: {} safe fix(es) available.",
-            initial.summary.fixes_available
-        ));
+        if should_show_selected_fixes {
+            lines.push(format!(
+                "Dry run: {} safe fix(es) selected.",
+                selected_fixes.len()
+            ));
+        } else {
+            lines.push(format!(
+                "Dry run: {} safe fix(es) available.",
+                initial.summary.fixes_available
+            ));
+        }
     } else {
         lines.push(format!("Applied: {} fix(es).", applied.len()));
     }
@@ -146,6 +157,23 @@ pub fn format_fix_result(
                 lines.push(format!("  file: {}", display_path(file)));
             }
         }
+    }
+
+    if dry_run && should_show_selected_fixes {
+        lines.push(String::new());
+        lines.push("Planned changes".to_string());
+        for fix in selected_fixes {
+            lines.push(format!("- {}", fix.title));
+            for file in &fix.files {
+                lines.push(format!("  file: {}", display_path(file)));
+            }
+        }
+    }
+
+    if let Some(preview_report) = preview_report.filter(|report| !report.is_empty()) {
+        lines.push(String::new());
+        lines.push("Preview diffs".to_string());
+        lines.extend(preview_report.lines().map(ToString::to_string));
     }
 
     lines.push(String::new());
@@ -294,7 +322,7 @@ mod tests {
                 "Usage",
                 "  maximus audit [path] [--json]",
                 "  maximus doctor [path] [--json]",
-                "  maximus fix [path] [--dry-run] [--json]",
+                "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
                 "  maximus help",
             ]
             .join("\n")
@@ -348,7 +376,15 @@ mod tests {
         );
 
         assert_eq!(
-            format_fix_result(true, &root_dir, &result, &Vec::<AppliedFix>::new(), &result),
+            format_fix_result(
+                true,
+                &root_dir,
+                &result,
+                &Vec::<AppliedFix>::new(),
+                &result,
+                None,
+                None,
+            ),
             [
                 "Maximus fix",
                 "Target: /tmp/project",

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -24,7 +24,7 @@ fn no_args_prints_help() {
             "Usage",
             "  maximus audit [path] [--json]",
             "  maximus doctor [path] [--json]",
-            "  maximus fix [path] [--dry-run] [--json]",
+            "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
             "  maximus help",
             "",
         ]

--- a/crates/maximus-cli/tests/fix_selection_and_diff.rs
+++ b/crates/maximus-cli/tests/fix_selection_and_diff.rs
@@ -1,0 +1,332 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn maximus_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+#[test]
+fn fix_id_applies_only_the_selected_fix() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+    write(
+        root.join("packages/app/.env"),
+        "API_URL=https://app.example\nAUTH_TOKEN=secretvalue123456\n",
+    );
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--fix-id",
+            &format!("env-example:create:{}", root.to_string_lossy()),
+        ])
+        .output()
+        .expect("fix command should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(root.join(".env.example").is_file());
+    assert!(!root.join("packages/app/.env.example").exists());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("Applied: 1 fix(es)."));
+    assert!(stdout.contains("Create .env.example"));
+}
+
+#[test]
+fn fix_prefix_filters_dry_run_json_to_matching_fixes() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+    write(
+        root.join("packages/app/.env"),
+        "API_URL=https://app.example\nAUTH_TOKEN=secretvalue123456\n",
+    );
+    write(root.join("packages/app/.env.example"), "API_URL=\n");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--fix-prefix",
+            "env-example:sync:",
+            "--json",
+        ])
+        .output()
+        .expect("dry-run command should run");
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("json should parse");
+    assert_eq!(value["initial"]["summary"]["fixesAvailable"], 1);
+    assert_eq!(value["initial"]["fixes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        value["initial"]["fixes"][0]["id"],
+        format!("env-example:sync:{}", root.join("packages/app").to_string_lossy())
+    );
+}
+
+#[test]
+fn fix_command_errors_when_selector_matches_nothing() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--fix-id",
+            "does-not-exist",
+        ])
+        .output()
+        .expect("fix command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: No matching fixes for the requested selector.\n"
+    );
+}
+
+#[test]
+fn fix_id_requires_a_real_value_instead_of_another_flag() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--fix-id",
+            "--dry-run",
+        ])
+        .output()
+        .expect("fix command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Option \"--fix-id\" requires a value.\n"
+    );
+}
+
+#[test]
+fn fix_prefix_requires_a_real_value_instead_of_another_flag() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--fix-prefix",
+            "--diff",
+        ])
+        .output()
+        .expect("fix command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Option \"--fix-prefix\" requires a value.\n"
+    );
+}
+
+#[test]
+fn diff_requires_dry_run() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+
+    let output = maximus_bin()
+        .args(["fix", root.to_string_lossy().as_ref(), "--diff"])
+        .output()
+        .expect("fix command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Option \"--diff\" requires \"fix --dry-run\".\n"
+    );
+}
+
+#[test]
+fn fix_only_flags_are_rejected_without_fix_command() {
+    let output = maximus_bin()
+        .args(["--fix-id", "env-example:create:."])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    );
+}
+
+#[test]
+fn fix_only_flags_are_rejected_for_help_command() {
+    let output = maximus_bin()
+        .args(["help", "--fix-id", "env-example:create:."])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    );
+}
+
+#[test]
+fn fix_only_flags_are_rejected_for_fix_help_command() {
+    let output = maximus_bin()
+        .args(["fix", "--help", "--fix-id", "env-example:create:."])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    );
+}
+
+#[test]
+fn fix_only_flags_are_rejected_when_help_flag_precedes_fix_command() {
+    let output = maximus_bin()
+        .args(["--help", "fix", "--fix-id", "env-example:create:."])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    );
+}
+
+#[test]
+fn audit_rejects_fix_only_flags() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+
+    let output = maximus_bin()
+        .args(["audit", root.to_string_lossy().as_ref(), "--fix-id", "env-example:"])
+        .output()
+        .expect("audit command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    );
+}
+
+#[test]
+fn diff_preview_shows_create_diff_without_writing_files() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(
+        root.join(".env"),
+        "API_URL=https://root.example\nAUTH_TOKEN=secretvalue123456\n",
+    );
+
+    let output = maximus_bin()
+        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .output()
+        .expect("dry-run diff should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!root.join(".env.example").exists());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("Preview diffs"));
+    assert!(stdout.contains("--- /dev/null"));
+    assert!(stdout.contains("+++ .env.example"));
+    assert!(stdout.contains("+API_URL="));
+    assert!(stdout.contains("+AUTH_TOKEN="));
+}
+
+#[test]
+fn diff_preview_shows_update_diff_without_mutating_existing_file() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(
+        root.join(".env"),
+        "API_URL=https://root.example\nAUTH_TOKEN=secretvalue123456\n",
+    );
+    write(root.join(".env.example"), "API_URL=\n");
+
+    let output = maximus_bin()
+        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .output()
+        .expect("dry-run diff should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        fs::read_to_string(root.join(".env.example")).expect("file should remain unchanged"),
+        "API_URL=\n"
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("+++ .env.example"));
+    assert!(stdout.contains("@@ -1,1 +1,2 @@"));
+    assert!(stdout.contains(" API_URL="));
+    assert!(stdout.contains("+AUTH_TOKEN="));
+}
+
+#[test]
+fn diff_preview_treats_existing_empty_env_example_as_update() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    write(root.join(".env"), "API_URL=https://root.example\n");
+    write(root.join(".env.example"), "");
+
+    let output = maximus_bin()
+        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .output()
+        .expect("dry-run diff should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        fs::read_to_string(root.join(".env.example")).expect("file should remain unchanged"),
+        ""
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("Append missing keys to .env.example"));
+    assert!(stdout.contains("--- .env.example"));
+    assert!(stdout.contains("+++ .env.example"));
+    assert!(stdout.contains("@@ -0,0 +1,1 @@"));
+    assert!(!stdout.contains("/dev/null"));
+}
+
+fn write(path: PathBuf, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, contents).expect("file should write");
+}

--- a/crates/maximus-core/src/fixes.rs
+++ b/crates/maximus-core/src/fixes.rs
@@ -2,8 +2,14 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::env_parser::render_env_template;
-use crate::fs::write_text;
+use crate::fs::{read_text_if_exists, write_text};
 use crate::models::FixPlan;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FixSelector {
+    pub ids: Vec<String>,
+    pub prefixes: Vec<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FixOperation {
@@ -30,6 +36,22 @@ pub struct AppliedFix {
     pub title: String,
     pub files: Vec<PathBuf>,
     pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FixFilePreview {
+    pub path: PathBuf,
+    pub existed_before: bool,
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewedFix {
+    pub id: String,
+    pub title: String,
+    pub files: Vec<PathBuf>,
+    pub previews: Vec<FixFilePreview>,
 }
 
 pub fn plan_create_env_example(
@@ -118,6 +140,26 @@ pub fn apply_fixes(fixes: &[PlannedFix]) -> io::Result<Vec<AppliedFix>> {
     fixes.iter().map(apply_fix).collect()
 }
 
+pub fn select_fix_plans(fixes: &[FixPlan], selector: &FixSelector) -> Vec<FixPlan> {
+    fixes
+        .iter()
+        .filter(|fix| selector.matches(&fix.id))
+        .cloned()
+        .collect()
+}
+
+pub fn select_planned_fixes(fixes: &[PlannedFix], selector: &FixSelector) -> Vec<PlannedFix> {
+    fixes
+        .iter()
+        .filter(|fix| selector.matches(&fix.public.id))
+        .cloned()
+        .collect()
+}
+
+pub fn preview_fixes(fixes: &[PlannedFix]) -> io::Result<Vec<PreviewedFix>> {
+    fixes.iter().map(preview_fix).collect()
+}
+
 fn relative_or_fallback(root_dir: &Path, target_path: &Path, fallback: &str) -> String {
     target_path
         .strip_prefix(root_dir)
@@ -134,4 +176,65 @@ fn applied_fix_from_public(fix: &FixPlan, outcome: &str) -> AppliedFix {
         files: fix.files.clone(),
         outcome: outcome.to_string(),
     }
+}
+
+impl FixSelector {
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty() && self.prefixes.is_empty()
+    }
+
+    pub fn matches(&self, fix_id: &str) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        self.ids.iter().any(|id| id == fix_id)
+            || self
+                .prefixes
+                .iter()
+                .any(|prefix| fix_id.starts_with(prefix))
+    }
+}
+
+fn preview_fix(fix: &PlannedFix) -> io::Result<PreviewedFix> {
+    let previews = match &fix.operation {
+        FixOperation::CreateEnvExample { output_path, keys } => {
+            let before = read_text_if_exists(output_path)?.unwrap_or_default();
+            let existed_before = output_path.exists();
+            let after = render_env_template(keys.iter().map(|key| key.as_str()));
+
+            vec![FixFilePreview {
+                path: output_path.clone(),
+                existed_before,
+                before,
+                after,
+            }]
+        }
+        FixOperation::SyncEnvExample {
+            example_path,
+            existing_text,
+            missing_keys,
+        } => {
+            let prefix = if existing_text.ends_with('\n') || existing_text.is_empty() {
+                ""
+            } else {
+                "\n"
+            };
+            let addition = render_env_template(missing_keys.iter().map(|key| key.as_str()));
+
+            vec![FixFilePreview {
+                path: example_path.clone(),
+                existed_before: true,
+                before: existing_text.clone(),
+                after: format!("{existing_text}{prefix}{addition}"),
+            }]
+        }
+    };
+
+    Ok(PreviewedFix {
+        id: fix.public.id.clone(),
+        title: fix.public.title.clone(),
+        files: fix.public.files.clone(),
+        previews,
+    })
 }

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -21,8 +21,9 @@ pub use env_parser::{
     render_env_template, EnvDuplicate, EnvEntry, InvalidEnvLine, ParsedEnv,
 };
 pub use fixes::{
-    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, AppliedFix,
-    FixOperation, PlannedFix,
+    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, preview_fixes,
+    select_fix_plans, select_planned_fixes, AppliedFix, FixFilePreview, FixOperation,
+    FixSelector, PlannedFix, PreviewedFix,
 };
 pub use findings::{
     make_finding, serialize_audit_result, sort_findings, summarize_findings, unique_fixes,


### PR DESCRIPTION
배경

- Rust CLI의 `fix` 명령은 모든 safe fix를 한 번에 실행할 수 있었지만, exact id / prefix 기준의 선택 실행과 dry-run diff preview는 아직 없었습니다.
- 이번 변경은 `P065-C` 범위로 fix selector와 `fix --dry-run --diff` preview를 Rust 런타임에 추가합니다.

변경 사항

- `--fix-id`, `--fix-prefix`, `--diff` 플래그를 Rust CLI 인자 파서와 검증 경로에 추가했습니다.
- 선택된 fix만 실행하거나 dry-run 대상으로 표시하도록 `PlannedFix` / public fix 선택 경로를 연결했습니다.
- env example create/update fix에 대해 unified diff 스타일 preview를 출력하는 `report_diff.rs`를 추가했습니다.
- malformed selector 입력, help/no-command 경로의 fix-only flag 오용, 빈 `.env.example` preview edge case를 회귀 테스트로 고정했습니다.

검증

- `git diff --check`
- `cargo metadata --format-version 1 --no-deps`
- `cargo test -p maximus-cli --test fix_selection_and_diff`
- `cargo test -p maximus-cli`
- `cargo test --workspace`
- `npm test`

브랜치 / 워크트리

- 대상 브랜치: `codex/p065-fix-selection-diff-preview`
- 현재 워크트리: `/Users/pjw/workspace/maximus`
- 이번 publish에 포함한 추가 source 브랜치 / 워크트리: 없음

이슈 연결

- 별도 이슈 연결 없음