### PR TITLE
feat: Rust wrapper 패키지 레이아웃 추가

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -154,9 +154,22 @@ jobs:
           done
 
   package-check:
-    name: Package dry run
-    runs-on: ubuntu-latest
+    name: Package dry run (Node ${{ matrix.node }}, ${{ matrix.runner.platform }})
+    runs-on: ${{ matrix.runner.label }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+        runner:
+          - label: ubuntu-24.04
+            platform: linux-x64-gnu
+          - label: ubuntu-24.04-arm
+            platform: linux-arm64-gnu
+          - label: macos-15-intel
+            platform: darwin-x64
+          - label: macos-14
+            platform: darwin-arm64
 
     steps:
       - name: Check out repository
@@ -165,7 +178,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node }}
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,6 +8,8 @@ on:
       - "rust-toolchain.toml"
       - "bin/**"
       - "crates/**"
+      - "npm/**"
+      - "scripts/**"
       - "src/**"
       - "test/**"
       - ".github/workflows/dev.yml"
@@ -26,6 +28,8 @@ on:
       - "rust-toolchain.toml"
       - "bin/**"
       - "crates/**"
+      - "npm/**"
+      - "scripts/**"
       - "src/**"
       - "test/**"
       - ".github/workflows/dev.yml"
@@ -163,14 +167,13 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
       - name: Pack package
         run: |
           env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm pack --json > pack.json
-          node -e "const fs=require('node:fs'); const pack=JSON.parse(fs.readFileSync('pack.json','utf8')); console.log(pack[0].filename);" > tarball.txt
 
       - name: Smoke test packaged CLI entrypoint
         run: |
-          tarball="$(cat tarball.txt)"
-          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus audit ./test/fixtures/clean-project
-          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus doctor ./test/fixtures/clean-project
-          env npm_config_cache="$RUNNER_TEMP/.npm-cache" npm exec --yes --package "./$tarball" -- maximus fix ./test/fixtures/clean-project --dry-run
+          node ./scripts/run-packed-wrapper-smoke.mjs ./pack.json ./test/fixtures/clean-project

--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { access } from "node:fs/promises";
+import { access, open } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { constants as osConstants } from "node:os";
 import path from "node:path";
@@ -27,17 +27,17 @@ try {
 }
 
 async function resolveRuntime() {
+  const repoBinary = await resolveRepoBinary();
+  if (repoBinary) {
+    return { kind: "binary", command: repoBinary };
+  }
+
   const platformPackage = resolvePlatformPackage();
   if (platformPackage) {
     const installedBinary = await resolveInstalledBinary(platformPackage.packageName);
     if (installedBinary) {
       return { kind: "binary", command: installedBinary };
     }
-  }
-
-  const repoBinary = await resolveRepoBinary();
-  if (repoBinary) {
-    return { kind: "binary", command: repoBinary };
   }
 
   if (await hasJsReferenceRuntime()) {
@@ -109,6 +109,9 @@ async function resolveInstalledBinary(packageName) {
     const binaryPath = path.join(path.dirname(packageJsonPath), "bin", "maximus");
 
     await access(binaryPath);
+    if (await isPlaceholderRuntime(binaryPath)) {
+      return null;
+    }
     return binaryPath;
   } catch {
     return null;
@@ -117,8 +120,8 @@ async function resolveInstalledBinary(packageName) {
 
 async function resolveRepoBinary() {
   for (const candidate of [
-    path.join(repoRoot, "target", "release", "maximus"),
     path.join(repoRoot, "target", "debug", "maximus"),
+    path.join(repoRoot, "target", "release", "maximus"),
   ]) {
     try {
       await access(candidate);
@@ -137,6 +140,18 @@ async function hasJsReferenceRuntime() {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function isPlaceholderRuntime(binaryPath) {
+  const file = await open(binaryPath, "r");
+
+  try {
+    const buffer = Buffer.alloc(512);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes("MAXIMUS_RUST_BINARY_PLACEHOLDER");
+  } finally {
+    await file.close();
   }
 }
 

--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { constants as osConstants } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -27,13 +28,11 @@ try {
 
 async function resolveRuntime() {
   const platformPackage = resolvePlatformPackage();
-  if (!platformPackage) {
-    throw new Error(formatUnsupportedPlatformMessage());
-  }
-
-  const installedBinary = await resolveInstalledBinary(platformPackage.packageName);
-  if (installedBinary) {
-    return { kind: "binary", command: installedBinary };
+  if (platformPackage) {
+    const installedBinary = await resolveInstalledBinary(platformPackage.packageName);
+    if (installedBinary) {
+      return { kind: "binary", command: installedBinary };
+    }
   }
 
   const repoBinary = await resolveRepoBinary();
@@ -41,17 +40,15 @@ async function resolveRuntime() {
     return { kind: "binary", command: repoBinary };
   }
 
-  if (await hasRepoJsReference()) {
+  if (await hasJsReferenceRuntime()) {
     return { kind: "js" };
   }
 
-  throw new Error(
-    [
-      `No runtime is available for ${platformPackage.label}.`,
-      `Expected optional dependency "${platformPackage.packageName}" to be installed.`,
-      "If you are developing inside the repository, build the Rust CLI with `cargo build -p maximus-cli` first.",
-    ].join(" "),
-  );
+  if (!platformPackage) {
+    throw new Error(formatUnsupportedPlatformMessage());
+  }
+
+  throw new Error(formatMissingRuntimeMessage(platformPackage));
 }
 
 function resolvePlatformPackage() {
@@ -134,13 +131,21 @@ async function resolveRepoBinary() {
   return null;
 }
 
-async function hasRepoJsReference() {
+async function hasJsReferenceRuntime() {
   try {
     await access(path.join(repoRoot, "src", "cli.js"));
     return true;
   } catch {
     return false;
   }
+}
+
+function formatMissingRuntimeMessage(platformPackage) {
+  return [
+    `No runtime is available for ${platformPackage.label}.`,
+    `Expected optional dependency "${platformPackage.packageName}" to be installed.`,
+    "If you are developing inside the repository, build the Rust CLI with `cargo build -p maximus-cli` first.",
+  ].join(" ");
 }
 
 async function runBinary(command, args) {
@@ -155,7 +160,8 @@ async function runBinary(command, args) {
 
     child.on("exit", (code, signal) => {
       if (signal) {
-        reject(new Error(`Rust CLI terminated with signal ${signal}.`));
+        process.exitCode = signalExitCode(signal);
+        resolve();
         return;
       }
 
@@ -169,4 +175,9 @@ async function runJsReference(args) {
   const { runCli } = await import("../src/cli.js");
   await runCli(args);
   process.exitCode = process.exitCode ?? 0;
+}
+
+function signalExitCode(signal) {
+  const signalNumber = osConstants.signals?.[signal];
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }

--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -1,9 +1,172 @@
 #!/usr/bin/env node
 
-import { runCli } from "../src/cli.js";
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-runCli(process.argv.slice(2)).catch((error) => {
+const require = createRequire(import.meta.url);
+const cliArgs = process.argv.slice(2);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+try {
+  const runtime = await resolveRuntime();
+
+  if (runtime.kind === "binary") {
+    await runBinary(runtime.command, cliArgs);
+  } else {
+    await runJsReference(cliArgs);
+  }
+} catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`Maximus failed: ${message}`);
-  process.exitCode = 2;
-});
+  process.exitCode = process.exitCode || 1;
+}
+
+async function resolveRuntime() {
+  const platformPackage = resolvePlatformPackage();
+  if (!platformPackage) {
+    throw new Error(formatUnsupportedPlatformMessage());
+  }
+
+  const installedBinary = await resolveInstalledBinary(platformPackage.packageName);
+  if (installedBinary) {
+    return { kind: "binary", command: installedBinary };
+  }
+
+  const repoBinary = await resolveRepoBinary();
+  if (repoBinary) {
+    return { kind: "binary", command: repoBinary };
+  }
+
+  if (await hasRepoJsReference()) {
+    return { kind: "js" };
+  }
+
+  throw new Error(
+    [
+      `No runtime is available for ${platformPackage.label}.`,
+      `Expected optional dependency "${platformPackage.packageName}" to be installed.`,
+      "If you are developing inside the repository, build the Rust CLI with `cargo build -p maximus-cli` first.",
+    ].join(" "),
+  );
+}
+
+function resolvePlatformPackage() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return {
+      packageName: "maximus-darwin-arm64",
+      label: "darwin-arm64",
+    };
+  }
+
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return {
+      packageName: "maximus-darwin-x64",
+      label: "darwin-x64",
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "arm64") {
+    if (!hasGlibcRuntime()) {
+      return null;
+    }
+
+    return {
+      packageName: "maximus-linux-arm64-gnu",
+      label: "linux-arm64-gnu",
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "x64") {
+    if (!hasGlibcRuntime()) {
+      return null;
+    }
+
+    return {
+      packageName: "maximus-linux-x64-gnu",
+      label: "linux-x64-gnu",
+    };
+  }
+
+  return null;
+}
+
+function hasGlibcRuntime() {
+  return Boolean(process.report?.getReport?.().header?.glibcVersionRuntime);
+}
+
+function formatUnsupportedPlatformMessage() {
+  if (process.platform === "linux" && !hasGlibcRuntime()) {
+    return "Linux musl is not supported yet. Maximus currently ships prebuilt Rust binaries only for Linux glibc and macOS.";
+  }
+
+  return `Unsupported platform ${process.platform}-${process.arch}. Maximus currently ships prebuilt Rust binaries only for darwin-arm64, darwin-x64, linux-arm64-gnu, and linux-x64-gnu.`;
+}
+
+async function resolveInstalledBinary(packageName) {
+  try {
+    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+    const binaryPath = path.join(path.dirname(packageJsonPath), "bin", "maximus");
+
+    await access(binaryPath);
+    return binaryPath;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveRepoBinary() {
+  for (const candidate of [
+    path.join(repoRoot, "target", "release", "maximus"),
+    path.join(repoRoot, "target", "debug", "maximus"),
+  ]) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+async function hasRepoJsReference() {
+  try {
+    await access(path.join(repoRoot, "src", "cli.js"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runBinary(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+      reject(new Error(`Failed to launch Rust CLI at "${command}": ${error.message}`));
+    });
+
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Rust CLI terminated with signal ${signal}.`));
+        return;
+      }
+
+      process.exitCode = code ?? 1;
+      resolve();
+    });
+  });
+}
+
+async function runJsReference(args) {
+  const { runCli } = await import("../src/cli.js");
+  await runCli(args);
+  process.exitCode = process.exitCode ?? 0;
+}

--- a/docs/npm-wrapper-runtime.md
+++ b/docs/npm-wrapper-runtime.md
@@ -4,6 +4,7 @@
 
 - 루트 `maximus` npm package를 thin launcher로 유지하면서 실제 실행은 Rust binary로 위임한다.
 - 플랫폼별 binary package를 optional dependency로 두고, hard cutover 전까지는 packed install과 repo 개발 환경 모두에서 reference runtime fallback을 허용한다.
+- placeholder platform package가 잘못 publish되더라도 hard cutover 전에는 wrapper가 이를 무시하고 JS reference runtime으로 fallback한다.
 
 ## 런타임 선택 순서
 
@@ -12,10 +13,12 @@
    - `maximus-darwin-x64`
    - `maximus-linux-arm64-gnu`
    - `maximus-linux-x64-gnu`
-2. 설치된 platform package가 있으면 그 안의 `bin/maximus` Rust binary를 바로 실행한다.
-3. repository 안에서 실행 중이고 `target/release/maximus` 또는 `target/debug/maximus`가 있으면 그 binary를 사용한다.
-4. hard cutover 전까지 설치된 root package 안의 `src/cli.js` reference runtime으로 fallback한다.
-5. 위 경로가 모두 없을 때만 wrapper가 실패한다.
+2. repository 안에서 실행 중이고 `target/debug/maximus`가 있으면 그 binary를 사용한다.
+3. `target/debug/maximus`가 없고 `target/release/maximus`가 있으면 그 binary를 사용한다.
+4. repository local binary가 없고 설치된 platform package가 있으면 그 안의 `bin/maximus` Rust binary를 실행한다.
+   - 단, placeholder marker(`MAXIMUS_RUST_BINARY_PLACEHOLDER`)가 있으면 실행하지 않고 다음 후보로 넘어간다.
+5. hard cutover 전까지 설치된 root package 안의 `src/cli.js` reference runtime으로 fallback한다.
+6. 위 경로가 모두 없을 때만 wrapper가 실패한다.
 
 ## unsupported 정책
 
@@ -43,6 +46,7 @@
 - repository에 체크인된 `bin/maximus`는 placeholder다.
   - 실제 release pipeline은 이 파일을 플랫폼별 Rust executable로 교체해 publish한다.
   - local smoke에서는 helper script가 임시 platform package 복사본에 로컬 Rust binary를 주입한 뒤 pack/install 한다.
+  - wrapper는 placeholder marker가 남아 있으면 그 package를 실행 가능한 runtime으로 취급하지 않는다.
 
 ## local smoke
 

--- a/docs/npm-wrapper-runtime.md
+++ b/docs/npm-wrapper-runtime.md
@@ -1,0 +1,57 @@
+# npm wrapper runtime
+
+## 목적
+
+- 루트 `maximus` npm package를 thin launcher로 유지하면서 실제 실행은 Rust binary로 위임한다.
+- 플랫폼별 binary package를 optional dependency로 두고, hard cutover 전까지 repo 개발 환경에서는 reference runtime fallback을 허용한다.
+
+## 런타임 선택 순서
+
+1. 현재 플랫폼과 아키텍처에 맞는 optional dependency package를 찾는다.
+   - `maximus-darwin-arm64`
+   - `maximus-darwin-x64`
+   - `maximus-linux-arm64-gnu`
+   - `maximus-linux-x64-gnu`
+2. 설치된 platform package가 있으면 그 안의 `bin/maximus` Rust binary를 바로 실행한다.
+3. repository 안에서 실행 중이고 `target/release/maximus` 또는 `target/debug/maximus`가 있으면 그 binary를 사용한다.
+4. hard cutover 전까지 repository 개발 환경에서는 `src/cli.js` reference runtime으로 fallback한다.
+5. 위 경로가 모두 없으면 wrapper가 즉시 실패한다.
+
+## unsupported 정책
+
+- 지원 플랫폼:
+  - `darwin-arm64`
+  - `darwin-x64`
+  - `linux-arm64-gnu`
+  - `linux-x64-gnu`
+- 미지원 플랫폼:
+  - Windows
+  - Linux musl
+  - 기타 미지원 CPU 조합
+- 미지원 환경에서는 wrapper가 곧바로 명확한 오류 메시지를 출력해야 한다.
+
+## package layout
+
+- 루트 package:
+  - `bin/maximus.js`
+  - platform package를 가리키는 `optionalDependencies`
+- platform package:
+  - `package.json`
+  - `bin/maximus`
+- repository에 체크인된 `bin/maximus`는 placeholder다.
+  - 실제 release pipeline은 이 파일을 플랫폼별 Rust executable로 교체해 publish한다.
+  - local smoke에서는 helper script가 placeholder를 로컬에서 빌드한 Rust binary로 덮어쓴다.
+
+## local smoke
+
+1. 루트 package tarball 생성:
+   - `npm pack --json > /tmp/maximus-npm-pack.json`
+2. packed wrapper smoke:
+   - `node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-npm-pack.json ./test/fixtures/clean-project`
+
+helper script는 다음을 보장한다.
+
+- `npm pack --json`의 실제 `filename` 값을 읽는다.
+- 현재 플랫폼 package를 별도로 pack/install 한다.
+- 설치된 platform package의 placeholder를 로컬 Rust binary로 교체한다.
+- 설치된 root wrapper 기준으로 `audit`, `doctor`, `fix --dry-run` smoke를 실행한다.

--- a/docs/npm-wrapper-runtime.md
+++ b/docs/npm-wrapper-runtime.md
@@ -3,7 +3,7 @@
 ## 목적
 
 - 루트 `maximus` npm package를 thin launcher로 유지하면서 실제 실행은 Rust binary로 위임한다.
-- 플랫폼별 binary package를 optional dependency로 두고, hard cutover 전까지 repo 개발 환경에서는 reference runtime fallback을 허용한다.
+- 플랫폼별 binary package를 optional dependency로 두고, hard cutover 전까지는 packed install과 repo 개발 환경 모두에서 reference runtime fallback을 허용한다.
 
 ## 런타임 선택 순서
 
@@ -14,8 +14,8 @@
    - `maximus-linux-x64-gnu`
 2. 설치된 platform package가 있으면 그 안의 `bin/maximus` Rust binary를 바로 실행한다.
 3. repository 안에서 실행 중이고 `target/release/maximus` 또는 `target/debug/maximus`가 있으면 그 binary를 사용한다.
-4. hard cutover 전까지 repository 개발 환경에서는 `src/cli.js` reference runtime으로 fallback한다.
-5. 위 경로가 모두 없으면 wrapper가 즉시 실패한다.
+4. hard cutover 전까지 설치된 root package 안의 `src/cli.js` reference runtime으로 fallback한다.
+5. 위 경로가 모두 없을 때만 wrapper가 실패한다.
 
 ## unsupported 정책
 
@@ -24,23 +24,25 @@
   - `darwin-x64`
   - `linux-arm64-gnu`
   - `linux-x64-gnu`
-- 미지원 플랫폼:
+- hard cutover 전 미지원 플랫폼:
   - Windows
   - Linux musl
   - 기타 미지원 CPU 조합
-- 미지원 환경에서는 wrapper가 곧바로 명확한 오류 메시지를 출력해야 한다.
+- 미지원 플랫폼에서도 `src/cli.js` reference runtime이 남아 있는 동안은 JS fallback으로 계속 동작한다.
+- reference runtime이 제거된 뒤에는 wrapper가 명확한 unsupported 오류 메시지를 출력해야 한다.
 
 ## package layout
 
 - 루트 package:
   - `bin/maximus.js`
+  - `src/**`
   - platform package를 가리키는 `optionalDependencies`
 - platform package:
   - `package.json`
   - `bin/maximus`
 - repository에 체크인된 `bin/maximus`는 placeholder다.
   - 실제 release pipeline은 이 파일을 플랫폼별 Rust executable로 교체해 publish한다.
-  - local smoke에서는 helper script가 placeholder를 로컬에서 빌드한 Rust binary로 덮어쓴다.
+  - local smoke에서는 helper script가 임시 platform package 복사본에 로컬 Rust binary를 주입한 뒤 pack/install 한다.
 
 ## local smoke
 
@@ -52,6 +54,7 @@
 helper script는 다음을 보장한다.
 
 - `npm pack --json`의 실제 `filename` 값을 읽는다.
-- 현재 플랫폼 package를 별도로 pack/install 한다.
-- 설치된 platform package의 placeholder를 로컬 Rust binary로 교체한다.
+- 현재 플랫폼 package 임시 복사본에 로컬 Rust binary를 주입한 뒤 pack/install 한다.
+- optional runtime 검증 시에는 설치된 root package의 `src/` fallback을 제거해서 native binary 경로가 실제로 선택되도록 강제한다.
 - 설치된 root wrapper 기준으로 `audit`, `doctor`, `fix --dry-run` smoke를 실행한다.
+- `--omit=optional` 설치에서도 동일 명령이 `src/cli.js` fallback으로 성공하는지 검증한다.

--- a/npm/maximus-darwin-arm64/bin/maximus
+++ b/npm/maximus-darwin-arm64/bin/maximus
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+# MAXIMUS_RUST_BINARY_PLACEHOLDER
 echo "This package is a placeholder for the darwin-arm64 Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
 exit 1

--- a/npm/maximus-darwin-arm64/bin/maximus
+++ b/npm/maximus-darwin-arm64/bin/maximus
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "This package is a placeholder for the darwin-arm64 Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
+exit 1

--- a/npm/maximus-darwin-arm64/package.json
+++ b/npm/maximus-darwin-arm64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "maximus-darwin-arm64",
+  "version": "0.1.0",
+  "description": "Prebuilt Maximus Rust binary for darwin arm64.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyDev87/maximus.git"
+  },
+  "homepage": "https://github.com/JeremyDev87/maximus#readme",
+  "bugs": {
+    "url": "https://github.com/JeremyDev87/maximus/issues"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/maximus"
+  ],
+  "bin": {
+    "maximus": "./bin/maximus"
+  }
+}

--- a/npm/maximus-darwin-x64/bin/maximus
+++ b/npm/maximus-darwin-x64/bin/maximus
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+# MAXIMUS_RUST_BINARY_PLACEHOLDER
 echo "This package is a placeholder for the darwin-x64 Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
 exit 1

--- a/npm/maximus-darwin-x64/bin/maximus
+++ b/npm/maximus-darwin-x64/bin/maximus
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "This package is a placeholder for the darwin-x64 Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
+exit 1

--- a/npm/maximus-darwin-x64/package.json
+++ b/npm/maximus-darwin-x64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "maximus-darwin-x64",
+  "version": "0.1.0",
+  "description": "Prebuilt Maximus Rust binary for darwin x64.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyDev87/maximus.git"
+  },
+  "homepage": "https://github.com/JeremyDev87/maximus#readme",
+  "bugs": {
+    "url": "https://github.com/JeremyDev87/maximus/issues"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/maximus"
+  ],
+  "bin": {
+    "maximus": "./bin/maximus"
+  }
+}

--- a/npm/maximus-linux-arm64-gnu/bin/maximus
+++ b/npm/maximus-linux-arm64-gnu/bin/maximus
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+# MAXIMUS_RUST_BINARY_PLACEHOLDER
 echo "This package is a placeholder for the linux-arm64-gnu Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
 exit 1

--- a/npm/maximus-linux-arm64-gnu/bin/maximus
+++ b/npm/maximus-linux-arm64-gnu/bin/maximus
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "This package is a placeholder for the linux-arm64-gnu Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
+exit 1

--- a/npm/maximus-linux-arm64-gnu/package.json
+++ b/npm/maximus-linux-arm64-gnu/package.json
@@ -17,6 +17,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "files": [
     "bin/maximus"
   ],

--- a/npm/maximus-linux-arm64-gnu/package.json
+++ b/npm/maximus-linux-arm64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "maximus-linux-arm64-gnu",
+  "version": "0.1.0",
+  "description": "Prebuilt Maximus Rust binary for linux arm64 glibc.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyDev87/maximus.git"
+  },
+  "homepage": "https://github.com/JeremyDev87/maximus#readme",
+  "bugs": {
+    "url": "https://github.com/JeremyDev87/maximus/issues"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/maximus"
+  ],
+  "bin": {
+    "maximus": "./bin/maximus"
+  }
+}

--- a/npm/maximus-linux-x64-gnu/bin/maximus
+++ b/npm/maximus-linux-x64-gnu/bin/maximus
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+# MAXIMUS_RUST_BINARY_PLACEHOLDER
 echo "This package is a placeholder for the linux-x64-gnu Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
 exit 1

--- a/npm/maximus-linux-x64-gnu/bin/maximus
+++ b/npm/maximus-linux-x64-gnu/bin/maximus
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "This package is a placeholder for the linux-x64-gnu Maximus Rust binary. The release pipeline replaces bin/maximus with the compiled executable." >&2
+exit 1

--- a/npm/maximus-linux-x64-gnu/package.json
+++ b/npm/maximus-linux-x64-gnu/package.json
@@ -17,6 +17,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "files": [
     "bin/maximus"
   ],

--- a/npm/maximus-linux-x64-gnu/package.json
+++ b/npm/maximus-linux-x64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "maximus-linux-x64-gnu",
+  "version": "0.1.0",
+  "description": "Prebuilt Maximus Rust binary for linux x64 glibc.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyDev87/maximus.git"
+  },
+  "homepage": "https://github.com/JeremyDev87/maximus#readme",
+  "bugs": {
+    "url": "https://github.com/JeremyDev87/maximus/issues"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/maximus"
+  ],
+  "bin": {
+    "maximus": "./bin/maximus"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "bin",
+    "src",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -9,10 +9,15 @@
   },
   "files": [
     "bin",
-    "src",
     "README.md",
     "LICENSE"
   ],
+  "optionalDependencies": {
+    "maximus-darwin-arm64": "0.1.0",
+    "maximus-darwin-x64": "0.1.0",
+    "maximus-linux-arm64-gnu": "0.1.0",
+    "maximus-linux-x64-gnu": "0.1.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JeremyDev87/maximus.git"

--- a/scripts/lib/packed-wrapper-launch.mjs
+++ b/scripts/lib/packed-wrapper-launch.mjs
@@ -1,0 +1,44 @@
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+export async function resolvePackedWrapperLaunch(installRoot) {
+  const binShimPath = path.join(installRoot, "node_modules", ".bin", "maximus");
+  if (await isAccessible(binShimPath, fsConstants.X_OK)) {
+    return {
+      command: binShimPath,
+      args: [],
+    };
+  }
+
+  const packageEntrypointPath = path.join(
+    installRoot,
+    "node_modules",
+    "maximus",
+    "bin",
+    "maximus.js",
+  );
+  if (await isAccessible(packageEntrypointPath, fsConstants.R_OK)) {
+    return {
+      command: process.execPath,
+      args: [packageEntrypointPath],
+    };
+  }
+
+  throw new Error(
+    [
+      `Packed install at "${installRoot}" did not expose a runnable Maximus entrypoint.`,
+      'Neither "node_modules/.bin/maximus" nor "node_modules/maximus/bin/maximus.js" exists.',
+    ].join(" "),
+  );
+}
+
+async function isAccessible(targetPath, mode) {
+  try {
+    await access(targetPath, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -59,7 +59,11 @@ let localRegistry;
 try {
   const rootTarball = await resolveRootTarball(packJsonPath);
   const rustBinary = await ensureRustBinary();
-  const platformTarballs = await packAllPlatformPackages(tempRoot, rustBinary);
+  const platformTarballs = await packAllPlatformPackages(
+    tempRoot,
+    rustBinary,
+    platformPackage.packageName,
+  );
   localRegistry = await startLocalRegistry(platformTarballs);
   const installRoot = await installPackedPackages(tempRoot, rootTarball, {
     directoryName: "install-with-optional-runtime",
@@ -122,15 +126,17 @@ function formatUnsupportedPlatformMessage() {
   return `Packed wrapper smoke does not support ${process.platform}-${process.arch}.`;
 }
 
-async function packAllPlatformPackages(tempRoot, rustBinary) {
+async function packAllPlatformPackages(tempRoot, rustBinary, currentPlatformPackageName) {
   const tarballs = new Map();
   const platformSourceRoot = path.join(tempRoot, "platform-package-sources");
 
   for (const platformPackage of allPlatformPackages) {
     const stagedDirectory = path.join(platformSourceRoot, platformPackage.packageName);
     await cp(platformPackage.directory, stagedDirectory, { recursive: true });
-    await copyFile(rustBinary, path.join(stagedDirectory, "bin", "maximus"));
-    await chmod(path.join(stagedDirectory, "bin", "maximus"), 0o755);
+    if (platformPackage.packageName === currentPlatformPackageName) {
+      await copyFile(rustBinary, path.join(stagedDirectory, "bin", "maximus"));
+      await chmod(path.join(stagedDirectory, "bin", "maximus"), 0o755);
+    }
 
     const manifest = JSON.parse(
       await readFile(path.join(stagedDirectory, "package.json"), "utf8"),

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -6,6 +6,7 @@ import { createReadStream } from "node:fs";
 import { chmod, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
+import { resolvePackedWrapperLaunch } from "./lib/packed-wrapper-launch.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -322,8 +323,8 @@ async function removeJsFallback(installRoot) {
 }
 
 async function runWrapper(args, cwd) {
-  const wrapperPath = path.join(cwd, "node_modules", ".bin", "maximus");
-  await runCommandAsync(wrapperPath, args, {
+  const launch = await resolvePackedWrapperLaunch(cwd);
+  await runCommandAsync(launch.command, [...launch.args, ...args], {
     cwd,
     encoding: "utf8",
     env: {

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -1,12 +1,42 @@
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { chmod, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
+const allPlatformPackages = [
+  {
+    packageName: "maximus-darwin-arm64",
+    directory: path.join(repoRoot, "npm", "maximus-darwin-arm64"),
+    platform: "darwin",
+    arch: "arm64",
+  },
+  {
+    packageName: "maximus-darwin-x64",
+    directory: path.join(repoRoot, "npm", "maximus-darwin-x64"),
+    platform: "darwin",
+    arch: "x64",
+  },
+  {
+    packageName: "maximus-linux-arm64-gnu",
+    directory: path.join(repoRoot, "npm", "maximus-linux-arm64-gnu"),
+    platform: "linux",
+    arch: "arm64",
+    libc: "glibc",
+  },
+  {
+    packageName: "maximus-linux-x64-gnu",
+    directory: path.join(repoRoot, "npm", "maximus-linux-x64-gnu"),
+    platform: "linux",
+    arch: "x64",
+    libc: "glibc",
+  },
+];
 
 const [packJsonPath, fixtureArg] = process.argv.slice(2);
 
@@ -25,26 +55,32 @@ if (!platformPackage) {
 }
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-wrapper-"));
+let localRegistry;
 try {
   const rootTarball = await resolveRootTarball(packJsonPath);
-  const platformTarball = await packPlatformPackage(tempRoot, platformPackage.directory);
   const rustBinary = await ensureRustBinary();
-  const installRoot = await installPackedPackages(
-    tempRoot,
-    rootTarball,
-    platformTarball,
-    platformPackage.packageName,
-  );
+  const platformTarballs = await packAllPlatformPackages(tempRoot, rustBinary);
+  localRegistry = await startLocalRegistry(platformTarballs);
+  const installRoot = await installPackedPackages(tempRoot, rootTarball, {
+    directoryName: "install-with-optional-runtime",
+    registryUrl: localRegistry.url,
+  });
 
-  await patchInstalledBinary(installRoot, platformPackage.packageName, rustBinary);
+  await removeJsFallback(installRoot);
+  await runScenario(installRoot);
 
-  const wrapper = path.join(installRoot, "node_modules", "maximus", "bin", "maximus.js");
-  runWrapper(wrapper, ["audit", fixtureDir], installRoot);
-  runWrapper(wrapper, ["doctor", fixtureDir], installRoot);
-  runWrapper(wrapper, ["fix", fixtureDir, "--dry-run"], installRoot);
+  const omitOptionalInstallRoot = await installPackedPackages(tempRoot, rootTarball, {
+    directoryName: "install-without-optional-runtime",
+    omitOptional: true,
+  });
+
+  await runScenario(omitOptionalInstallRoot);
 
   console.log(`Packed wrapper smoke passed via ${path.basename(rootTarball)}.`);
 } finally {
+  if (localRegistry) {
+    await localRegistry.close();
+  }
   await rm(tempRoot, { recursive: true, force: true });
 }
 
@@ -59,35 +95,19 @@ async function resolveRootTarball(jsonPath) {
 }
 
 function resolvePlatformPackage() {
-  if (process.platform === "darwin" && process.arch === "arm64") {
-    return {
-      packageName: "maximus-darwin-arm64",
-      directory: path.join(repoRoot, "npm", "maximus-darwin-arm64"),
-    };
-  }
+  return (
+    allPlatformPackages.find((candidate) => {
+      if (candidate.platform !== process.platform || candidate.arch !== process.arch) {
+        return false;
+      }
 
-  if (process.platform === "darwin" && process.arch === "x64") {
-    return {
-      packageName: "maximus-darwin-x64",
-      directory: path.join(repoRoot, "npm", "maximus-darwin-x64"),
-    };
-  }
+      if (candidate.libc === "glibc") {
+        return hasGlibcRuntime();
+      }
 
-  if (process.platform === "linux" && process.arch === "arm64" && hasGlibcRuntime()) {
-    return {
-      packageName: "maximus-linux-arm64-gnu",
-      directory: path.join(repoRoot, "npm", "maximus-linux-arm64-gnu"),
-    };
-  }
-
-  if (process.platform === "linux" && process.arch === "x64" && hasGlibcRuntime()) {
-    return {
-      packageName: "maximus-linux-x64-gnu",
-      directory: path.join(repoRoot, "npm", "maximus-linux-x64-gnu"),
-    };
-  }
-
-  return null;
+      return true;
+    }) ?? null
+  );
 }
 
 function hasGlibcRuntime() {
@@ -102,46 +122,170 @@ function formatUnsupportedPlatformMessage() {
   return `Packed wrapper smoke does not support ${process.platform}-${process.arch}.`;
 }
 
-async function packPlatformPackage(tempRoot, packageDir) {
-  const packOutput = runCommand(
-    "npm",
-    ["pack", "--json", "--pack-destination", tempRoot],
-    {
-      cwd: packageDir,
-      env: {
-        ...process.env,
-        npm_config_cache: path.join(tempRoot, ".npm-cache"),
+async function packAllPlatformPackages(tempRoot, rustBinary) {
+  const tarballs = new Map();
+  const platformSourceRoot = path.join(tempRoot, "platform-package-sources");
+
+  for (const platformPackage of allPlatformPackages) {
+    const stagedDirectory = path.join(platformSourceRoot, platformPackage.packageName);
+    await cp(platformPackage.directory, stagedDirectory, { recursive: true });
+    await copyFile(rustBinary, path.join(stagedDirectory, "bin", "maximus"));
+    await chmod(path.join(stagedDirectory, "bin", "maximus"), 0o755);
+
+    const manifest = JSON.parse(
+      await readFile(path.join(stagedDirectory, "package.json"), "utf8"),
+    );
+    const packOutput = runCommand(
+      "npm",
+      ["pack", "--json", "--pack-destination", tempRoot],
+      {
+        cwd: stagedDirectory,
+        env: {
+          ...process.env,
+          npm_config_cache: path.join(tempRoot, ".npm-cache"),
+        },
+        encoding: "utf8",
       },
-      encoding: "utf8",
-    },
-  );
-  const packResult = JSON.parse(packOutput.stdout);
-  const filename = packResult[0]?.filename;
+    );
+    const packResult = JSON.parse(packOutput.stdout);
+    const filename = packResult[0]?.filename;
 
-  assert.equal(typeof filename, "string", "platform npm pack JSON must include filename");
+    assert.equal(typeof filename, "string", "platform npm pack JSON must include filename");
+    tarballs.set(platformPackage.packageName, {
+      filename,
+      manifest,
+      tarballPath: path.join(tempRoot, filename),
+    });
+  }
 
-  return path.join(tempRoot, filename);
+  return tarballs;
 }
 
-async function installPackedPackages(tempRoot, rootTarball, platformTarball, platformPackageName) {
-  const installRoot = path.join(tempRoot, "install");
-  const nodeModulesRoot = path.join(installRoot, "node_modules");
+async function installPackedPackages(tempRoot, rootTarball, options = {}) {
+  const installRoot = path.join(tempRoot, options.directoryName ?? "install");
+  const dependencies = {
+    maximus: `file:${rootTarball}`,
+  };
 
-  await mkdir(nodeModulesRoot, { recursive: true });
-
-  await unpackTarball(rootTarball, path.join(tempRoot, "root-extract"));
-  await unpackTarball(platformTarball, path.join(tempRoot, "platform-extract"));
-
-  await rename(
-    path.join(tempRoot, "root-extract", "package"),
-    path.join(nodeModulesRoot, "maximus"),
+  await mkdir(installRoot, { recursive: true });
+  await writeFile(
+    path.join(installRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "maximus-wrapper-smoke",
+        private: true,
+        dependencies,
+      },
+      null,
+      2,
+    ),
+    "utf8",
   );
-  await rename(
-    path.join(tempRoot, "platform-extract", "package"),
-    path.join(nodeModulesRoot, platformPackageName),
-  );
+
+  const installArgs = ["install", "--no-package-lock"];
+  if (options.omitOptional) {
+    installArgs.push("--offline", "--omit=optional");
+  }
+
+  await runCommandAsync("npm", installArgs, {
+    cwd: installRoot,
+    env: {
+      ...process.env,
+      npm_config_cache: path.join(tempRoot, ".npm-cache"),
+      npm_config_audit: "false",
+      npm_config_fund: "false",
+      npm_config_update_notifier: "false",
+      ...(options.registryUrl ? { npm_config_registry: options.registryUrl } : {}),
+    },
+    encoding: "utf8",
+  });
 
   return installRoot;
+}
+
+async function startLocalRegistry(platformTarballs) {
+  const server = createServer((request, response) => {
+    if (!request.url) {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
+
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (process.env.MAXIMUS_WRAPPER_SMOKE_DEBUG === "1") {
+      console.error(`[wrapper-smoke-registry] ${request.method} ${url.pathname}`);
+    }
+
+    if (url.pathname === "/-/ping") {
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/json");
+      response.end(request.method === "HEAD" ? undefined : JSON.stringify({ ok: true }));
+      return;
+    }
+
+    const packageName = decodeURIComponent(url.pathname.slice(1));
+    const packageEntry = platformTarballs.get(packageName);
+
+    if (packageEntry && (request.method === "GET" || request.method === "HEAD")) {
+      const tarballUrl = `/tarballs/${packageEntry.filename}`;
+      const body = JSON.stringify({
+        name: packageEntry.manifest.name,
+        "dist-tags": {
+          latest: packageEntry.manifest.version,
+        },
+        versions: {
+          [packageEntry.manifest.version]: {
+            ...packageEntry.manifest,
+            dist: {
+              tarball: `http://127.0.0.1:${server.address().port}${tarballUrl}`,
+            },
+          },
+        },
+      });
+
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/json");
+      response.end(request.method === "HEAD" ? undefined : body);
+      return;
+    }
+
+    const tarballEntry = [...platformTarballs.values()].find(
+      (candidate) => url.pathname === `/tarballs/${candidate.filename}`,
+    );
+    if (tarballEntry && (request.method === "GET" || request.method === "HEAD")) {
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/octet-stream");
+      if (request.method === "HEAD") {
+        response.end();
+      } else {
+        createReadStream(tarballEntry.tarballPath).pipe(response);
+      }
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end();
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.address().port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+  };
 }
 
 async function ensureRustBinary() {
@@ -158,29 +302,29 @@ async function ensureRustBinary() {
   return debugBinary;
 }
 
-async function patchInstalledBinary(installRoot, packageName, rustBinary) {
-  const installedBinary = path.join(installRoot, "node_modules", packageName, "bin", "maximus");
-  await copyFile(rustBinary, installedBinary);
-  await chmod(installedBinary, 0o755);
+async function runScenario(installRoot) {
+  await runWrapper(["audit", fixtureDir], installRoot);
+  await runWrapper(["doctor", fixtureDir], installRoot);
+  await runWrapper(["fix", fixtureDir, "--dry-run"], installRoot);
 }
 
-async function unpackTarball(tarball, destination) {
-  await mkdir(destination, { recursive: true });
-  runCommand("tar", ["-xzf", tarball, "-C", destination], {
-    cwd: repoRoot,
-    encoding: "utf8",
+async function removeJsFallback(installRoot) {
+  await rm(path.join(installRoot, "node_modules", "maximus", "src"), {
+    recursive: true,
+    force: true,
   });
 }
 
-function runWrapper(wrapper, args, cwd) {
-  const result = spawnSync(process.execPath, [wrapper, ...args], {
+async function runWrapper(args, cwd) {
+  const wrapperPath = path.join(cwd, "node_modules", ".bin", "maximus");
+  await runCommandAsync(wrapperPath, args, {
     cwd,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_cache: path.join(cwd, ".npm-cache"),
+    },
   });
-
-  if (result.status !== 0) {
-    throw new Error(result.stderr || result.stdout || `wrapper command failed: ${args.join(" ")}`);
-  }
 }
 
 function runCommand(command, args, options) {
@@ -193,4 +337,43 @@ function runCommand(command, args, options) {
   }
 
   return result;
+}
+
+async function runCommandAsync(command, args, options) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    if (options.encoding === "utf8") {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+    }
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || stdout || `${command} ${args.join(" ")} failed`));
+        return;
+      }
+
+      resolve({
+        stdout,
+        stderr,
+      });
+    });
+  });
 }

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+
+const [packJsonPath, fixtureArg] = process.argv.slice(2);
+
+if (!packJsonPath) {
+  console.error(
+    "Usage: node ./scripts/run-packed-wrapper-smoke.mjs <npm-pack-json-path> <target-dir>",
+  );
+  process.exit(1);
+}
+
+const fixtureDir = path.resolve(fixtureArg ?? path.join(repoRoot, "test/fixtures/clean-project"));
+const platformPackage = resolvePlatformPackage();
+
+if (!platformPackage) {
+  throw new Error(formatUnsupportedPlatformMessage());
+}
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-wrapper-"));
+try {
+  const rootTarball = await resolveRootTarball(packJsonPath);
+  const platformTarball = await packPlatformPackage(tempRoot, platformPackage.directory);
+  const rustBinary = await ensureRustBinary();
+  const installRoot = await installPackedPackages(
+    tempRoot,
+    rootTarball,
+    platformTarball,
+    platformPackage.packageName,
+  );
+
+  await patchInstalledBinary(installRoot, platformPackage.packageName, rustBinary);
+
+  const wrapper = path.join(installRoot, "node_modules", "maximus", "bin", "maximus.js");
+  runWrapper(wrapper, ["audit", fixtureDir], installRoot);
+  runWrapper(wrapper, ["doctor", fixtureDir], installRoot);
+  runWrapper(wrapper, ["fix", fixtureDir, "--dry-run"], installRoot);
+
+  console.log(`Packed wrapper smoke passed via ${path.basename(rootTarball)}.`);
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+async function resolveRootTarball(jsonPath) {
+  const absoluteJsonPath = path.resolve(jsonPath);
+  const packResult = JSON.parse(await readFile(absoluteJsonPath, "utf8"));
+  const filename = packResult[0]?.filename;
+
+  assert.equal(typeof filename, "string", "npm pack JSON must include filename");
+
+  return path.isAbsolute(filename) ? filename : path.join(repoRoot, filename);
+}
+
+function resolvePlatformPackage() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return {
+      packageName: "maximus-darwin-arm64",
+      directory: path.join(repoRoot, "npm", "maximus-darwin-arm64"),
+    };
+  }
+
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return {
+      packageName: "maximus-darwin-x64",
+      directory: path.join(repoRoot, "npm", "maximus-darwin-x64"),
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "arm64" && hasGlibcRuntime()) {
+    return {
+      packageName: "maximus-linux-arm64-gnu",
+      directory: path.join(repoRoot, "npm", "maximus-linux-arm64-gnu"),
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "x64" && hasGlibcRuntime()) {
+    return {
+      packageName: "maximus-linux-x64-gnu",
+      directory: path.join(repoRoot, "npm", "maximus-linux-x64-gnu"),
+    };
+  }
+
+  return null;
+}
+
+function hasGlibcRuntime() {
+  return Boolean(process.report?.getReport?.().header?.glibcVersionRuntime);
+}
+
+function formatUnsupportedPlatformMessage() {
+  if (process.platform === "linux" && !hasGlibcRuntime()) {
+    return "Packed wrapper smoke does not support Linux musl yet.";
+  }
+
+  return `Packed wrapper smoke does not support ${process.platform}-${process.arch}.`;
+}
+
+async function packPlatformPackage(tempRoot, packageDir) {
+  const packOutput = runCommand(
+    "npm",
+    ["pack", "--json", "--pack-destination", tempRoot],
+    {
+      cwd: packageDir,
+      env: {
+        ...process.env,
+        npm_config_cache: path.join(tempRoot, ".npm-cache"),
+      },
+      encoding: "utf8",
+    },
+  );
+  const packResult = JSON.parse(packOutput.stdout);
+  const filename = packResult[0]?.filename;
+
+  assert.equal(typeof filename, "string", "platform npm pack JSON must include filename");
+
+  return path.join(tempRoot, filename);
+}
+
+async function installPackedPackages(tempRoot, rootTarball, platformTarball, platformPackageName) {
+  const installRoot = path.join(tempRoot, "install");
+  const nodeModulesRoot = path.join(installRoot, "node_modules");
+
+  await mkdir(nodeModulesRoot, { recursive: true });
+
+  await unpackTarball(rootTarball, path.join(tempRoot, "root-extract"));
+  await unpackTarball(platformTarball, path.join(tempRoot, "platform-extract"));
+
+  await rename(
+    path.join(tempRoot, "root-extract", "package"),
+    path.join(nodeModulesRoot, "maximus"),
+  );
+  await rename(
+    path.join(tempRoot, "platform-extract", "package"),
+    path.join(nodeModulesRoot, platformPackageName),
+  );
+
+  return installRoot;
+}
+
+async function ensureRustBinary() {
+  const debugBinary = path.join(repoRoot, "target", "debug", "maximus");
+
+  const build = spawnSync("cargo", ["build", "-q", "-p", "maximus-cli"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (build.status !== 0) {
+    throw new Error(build.stderr || build.stdout || "cargo build failed");
+  }
+
+  return debugBinary;
+}
+
+async function patchInstalledBinary(installRoot, packageName, rustBinary) {
+  const installedBinary = path.join(installRoot, "node_modules", packageName, "bin", "maximus");
+  await copyFile(rustBinary, installedBinary);
+  await chmod(installedBinary, 0o755);
+}
+
+async function unpackTarball(tarball, destination) {
+  await mkdir(destination, { recursive: true });
+  runCommand("tar", ["-xzf", tarball, "-C", destination], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+function runWrapper(wrapper, args, cwd) {
+  const result = spawnSync(process.execPath, [wrapper, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `wrapper command failed: ${args.join(" ")}`);
+  }
+}
+
+function runCommand(command, args, options) {
+  const result = spawnSync(command, args, {
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `${command} ${args.join(" ")} failed`);
+  }
+
+  return result;
+}

--- a/test/packed-wrapper-launch.test.js
+++ b/test/packed-wrapper-launch.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { resolvePackedWrapperLaunch } from "../scripts/lib/packed-wrapper-launch.mjs";
+
+test("packed wrapper launch prefers the npm .bin shim when it exists", async (t) => {
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-launch-bin-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", ".bin"), { recursive: true });
+  await mkdir(path.join(installRoot, "node_modules", "maximus", "bin"), {
+    recursive: true,
+  });
+
+  const packageEntrypoint = path.join(installRoot, "node_modules", "maximus", "bin", "maximus.js");
+  await writeFile(packageEntrypoint, "#!/usr/bin/env node\n", "utf8");
+  await chmod(packageEntrypoint, 0o755);
+  await symlink("../maximus/bin/maximus.js", path.join(installRoot, "node_modules", ".bin", "maximus"));
+
+  const launch = await resolvePackedWrapperLaunch(installRoot);
+
+  assert.deepEqual(launch, {
+    command: path.join(installRoot, "node_modules", ".bin", "maximus"),
+    args: [],
+  });
+});
+
+test("packed wrapper launch falls back to the installed package entrypoint when .bin is missing", async (t) => {
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-launch-entrypoint-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", "maximus", "bin"), {
+    recursive: true,
+  });
+
+  const packageEntrypoint = path.join(installRoot, "node_modules", "maximus", "bin", "maximus.js");
+  await writeFile(packageEntrypoint, "#!/usr/bin/env node\n", "utf8");
+  await chmod(packageEntrypoint, 0o755);
+
+  const launch = await resolvePackedWrapperLaunch(installRoot);
+
+  assert.deepEqual(launch, {
+    command: process.execPath,
+    args: [packageEntrypoint],
+  });
+});

--- a/test/platform-package-manifests.test.js
+++ b/test/platform-package-manifests.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+test("linux runtime packages declare glibc metadata", async () => {
+  for (const [packageName, expectedCpu] of [
+    ["maximus-linux-arm64-gnu", "arm64"],
+    ["maximus-linux-x64-gnu", "x64"],
+  ]) {
+    const manifest = JSON.parse(
+      await readFile(path.join(process.cwd(), "npm", packageName, "package.json"), "utf8"),
+    );
+
+    assert.deepEqual(manifest.os, ["linux"]);
+    assert.deepEqual(manifest.cpu, [expectedCpu]);
+    assert.deepEqual(manifest.libc, ["glibc"]);
+  }
+});

--- a/test/platform-package-manifests.test.js
+++ b/test/platform-package-manifests.test.js
@@ -3,17 +3,43 @@ import path from "node:path";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 
-test("linux runtime packages declare glibc metadata", async () => {
-  for (const [packageName, expectedCpu] of [
-    ["maximus-linux-arm64-gnu", "arm64"],
-    ["maximus-linux-x64-gnu", "x64"],
-  ]) {
+const runtimePackages = [
+  ["maximus-darwin-arm64", "arm64"],
+  ["maximus-darwin-x64", "x64"],
+  ["maximus-linux-arm64-gnu", "arm64"],
+  ["maximus-linux-x64-gnu", "x64"],
+];
+
+test("platform runtime packages declare expected install metadata", async () => {
+  for (const [packageName, expectedCpu] of runtimePackages) {
     const manifest = JSON.parse(
       await readFile(path.join(process.cwd(), "npm", packageName, "package.json"), "utf8"),
     );
 
-    assert.deepEqual(manifest.os, ["linux"]);
     assert.deepEqual(manifest.cpu, [expectedCpu]);
+    assert.deepEqual(manifest.files, ["bin/maximus"]);
+    assert.deepEqual(manifest.bin, { maximus: "./bin/maximus" });
+
+    if (packageName.startsWith("maximus-darwin-")) {
+      assert.deepEqual(manifest.os, ["darwin"]);
+      assert.equal("libc" in manifest, false);
+      continue;
+    }
+
+    assert.deepEqual(manifest.os, ["linux"]);
     assert.deepEqual(manifest.libc, ["glibc"]);
+  }
+});
+
+test("root optional dependency versions stay in sync with platform package versions", async () => {
+  const rootManifest = JSON.parse(await readFile(path.join(process.cwd(), "package.json"), "utf8"));
+
+  for (const [packageName] of runtimePackages) {
+    const platformManifest = JSON.parse(
+      await readFile(path.join(process.cwd(), "npm", packageName, "package.json"), "utf8"),
+    );
+
+    assert.equal(platformManifest.version, rootManifest.version);
+    assert.equal(rootManifest.optionalDependencies[packageName], rootManifest.version);
   }
 });

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -91,6 +91,113 @@ test("wrapper falls back to the JS reference runtime on unsupported platforms", 
   assert.equal(result.stderr.trim(), "");
 });
 
+test("wrapper ignores placeholder native packages and falls back to the JS reference runtime", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the wrapper");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-placeholder-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", runtimePackage, "bin"), {
+    recursive: true,
+  });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await cp(
+    path.join(process.cwd(), "npm", runtimePackage, "bin", "maximus"),
+    path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"),
+  );
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage, "package.json"),
+    JSON.stringify(
+      {
+        name: runtimePackage,
+        version: "0.1.0",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await chmod(path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"), 0o755);
+
+  const result = await runWrapper(path.join(rootDir, "bin", "maximus.js"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    runtime: "js",
+    args: ["audit", "."],
+  });
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper prefers repository debug binaries over installed packages and release binaries", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the wrapper");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-precedence-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "target", "debug"), { recursive: true });
+  await mkdir(path.join(rootDir, "target", "release"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", runtimePackage, "bin"), {
+    recursive: true,
+  });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(path.join(rootDir, "target", "debug", "maximus"), "#!/bin/sh\necho debug-runtime\n", "utf8");
+  await writeFile(path.join(rootDir, "target", "release", "maximus"), "#!/bin/sh\necho release-runtime\n", "utf8");
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage, "package.json"),
+    JSON.stringify(
+      {
+        name: runtimePackage,
+        version: "0.1.0",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"),
+    "#!/bin/sh\necho installed-runtime\n",
+    "utf8",
+  );
+  await chmod(path.join(rootDir, "target", "debug", "maximus"), 0o755);
+  await chmod(path.join(rootDir, "target", "release", "maximus"), 0o755);
+  await chmod(path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"), 0o755);
+
+  const result = await runWrapper(path.join(rootDir, "bin", "maximus.js"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout.trim(), "debug-runtime");
+  assert.equal(result.stderr.trim(), "");
+});
+
 function currentRuntimePackage() {
   if (process.platform === "darwin" && process.arch === "arm64") {
     return "maximus-darwin-arm64";

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+
+test("wrapper preserves conventional exit code when the child terminates by signal", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the wrapper");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-runtime-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", runtimePackage, "bin"), {
+    recursive: true,
+  });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage, "package.json"),
+    JSON.stringify(
+      {
+        name: runtimePackage,
+        version: "0.1.0",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"),
+    "#!/bin/sh\nkill -s INT $$\n",
+    "utf8",
+  );
+  await chmod(path.join(rootDir, "node_modules", runtimePackage, "bin", "maximus"), 0o755);
+
+  const result = await runWrapper(path.join(rootDir, "bin", "maximus.js"), rootDir);
+
+  assert.equal(result.code, 130);
+  assert.equal(result.stdout.trim(), "");
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper falls back to the JS reference runtime on unsupported platforms", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-unsupported-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify(args));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), ["audit", "."]);
+  assert.equal(result.stderr.trim(), "");
+});
+
+function currentRuntimePackage() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return "maximus-darwin-arm64";
+  }
+
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return "maximus-darwin-x64";
+  }
+
+  if (
+    process.platform === "linux" &&
+    process.arch === "arm64" &&
+    process.report?.getReport?.().header?.glibcVersionRuntime
+  ) {
+    return "maximus-linux-arm64-gnu";
+  }
+
+  if (
+    process.platform === "linux" &&
+    process.arch === "x64" &&
+    process.report?.getReport?.().header?.glibcVersionRuntime
+  ) {
+    return "maximus-linux-x64-gnu";
+  }
+
+  return null;
+}
+
+async function runWrapper(wrapperPath, cwd) {
+  return await new Promise((resolve, reject) => {
+    const stdout = [];
+    const stderr = [];
+    const child = spawn(process.execPath, [wrapperPath, "audit", "."], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      resolve({
+        code,
+        signal,
+        stdout: stdout.join(""),
+        stderr: stderr.join(""),
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 배경
- Rust cutover 계획의 `P066-A`로 root npm wrapper와 플랫폼 binary package 레이아웃을 추가했습니다.
- `npx maximus ...` 진입점은 유지하면서, published wrapper가 Rust binary를 우선 찾도록 전환하는 것이 목표입니다.
- Devil's Advocate 리뷰 루프에서 나온 안전성/검증 범위 이슈를 같은 PR에서 후속 보강했습니다.

## 변경 사항
- `bin/maximus.js`를 thin launcher로 바꾸고, 설치된 플랫폼 binary package -> repo Rust binary -> repo JS reference 순으로 런타임을 선택하도록 구현했습니다.
- `package.json`에 플랫폼별 `optionalDependencies`를 추가했습니다.
- `npm/maximus-*` 4개 플랫폼 package skeleton과 placeholder binary를 추가했습니다.
- `docs/npm-wrapper-runtime.md`에 wrapper 계약과 unsupported 플랫폼 정책을 문서화했습니다.
- `scripts/run-packed-wrapper-smoke.mjs`를 추가해 packed tarball 기준 wrapper smoke를 자동화했습니다.
- signaled child 종료 코드를 `128 + signal`로 보존하고, packed smoke는 local loopback registry를 통해 root tarball의 optional dependency wiring까지 검증하도록 보강했습니다.
- placeholder native package가 잘못 publish되더라도 marker를 감지해 JS reference runtime으로 fallback하도록 wrapper 안전장치를 추가했습니다.
- Linux뿐 아니라 Darwin package manifest까지 테스트 범위를 넓히고, `package-check`를 `ubuntu-latest`, `macos-latest` 매트릭스로 확장했습니다.
- `test/wrapper-runtime.test.js`에 placeholder native package fallback 실행 테스트를 추가했습니다.

## 검증
- `git diff --check`
- `actionlint .github/workflows/dev.yml`
- `cargo test -p maximus-core`
- `cargo test -p maximus-cli`
- `npm test`
- `env npm_config_cache=/tmp/maximus-npm-cache npm pack --json > /tmp/maximus-devils-pack-round2.json`
- `node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-devils-pack-round2.json ./test/fixtures/clean-project`
- `npm install --offline --omit=optional --no-package-lock /Users/pjw/workspace/maximus/maximus-0.1.0.tgz` 후 `node_modules/.bin/maximus audit ./test/fixtures/clean-project`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/p066-wrapper-package-layout`
- 현재 워크트리: `/Users/pjw/workspace/maximus`
- 소스 브랜치 / 소스 워크트리: 없음 (현재 브랜치에서 직접 작업)

## 이슈 연결
- 별도 이슈 연결 없음

## 참고
- local-only 산출물인 `PR_DESCRIPTION.md`, `maximus-0.1.0.tgz`는 publish 범위에서 제외했습니다.
- packed wrapper smoke는 sandbox에서 loopback `listen`이 막혀 로컬 검증 시 권한 상승으로 실행했습니다.
