### PR TITLE
feat: Rust release wiring과 GitHub Action 추가

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,54 @@
+name: action-smoke
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        required: false
+        type: string
+        default: audit
+      path:
+        required: false
+        type: string
+        default: test/fixtures/clean-project
+      registry_url:
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      command:
+        description: Maximus command to run
+        required: false
+        default: audit
+        type: string
+      path:
+        description: Project path to inspect
+        required: false
+        default: test/fixtures/clean-project
+        type: string
+      registry_url:
+        description: Optional npm registry override
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Action smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Maximus action
+        uses: ./
+        with:
+          command: ${{ inputs.command }}
+          path: ${{ inputs.path }}
+          registry-url: ${{ inputs.registry_url }}

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Maximus action
-        uses: ./
+        uses: JeremyDev87/maximus@v0.1.0
         with:
           command: ${{ inputs.command }}
           path: ${{ inputs.path }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,6 +3,7 @@ name: maximus-dev
 on:
   push:
     paths:
+      - "action.yml"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -12,8 +13,11 @@ on:
       - "scripts/**"
       - "src/**"
       - "test/**"
+      - ".github/workflows/action-smoke.yml"
       - ".github/workflows/dev.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/release-drafter.yml"
+      - ".github/workflows/rust-release-binaries.yml"
       - ".github/release-drafter.yml"
       - "package.json"
       - "README*.md"
@@ -23,6 +27,7 @@ on:
       - "SECURITY.md"
   pull_request:
     paths:
+      - "action.yml"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -32,8 +37,11 @@ on:
       - "scripts/**"
       - "src/**"
       - "test/**"
+      - ".github/workflows/action-smoke.yml"
       - ".github/workflows/dev.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/release-drafter.yml"
+      - ".github/workflows/rust-release-binaries.yml"
       - ".github/release-drafter.yml"
       - "package.json"
       - "README*.md"
@@ -190,3 +198,23 @@ jobs:
       - name: Smoke test packaged CLI entrypoint
         run: |
           node ./scripts/run-packed-wrapper-smoke.mjs ./pack.json ./test/fixtures/clean-project
+
+  release-wiring:
+    name: Release wiring
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Validate release wiring contract
+        run: node ./scripts/validate-rust-release-wiring.mjs
+
+      - name: Run focused release wiring test
+        run: node --test test/github-action-wiring.test.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-platform-binaries:
+    name: Build platform binaries
+    uses: ./.github/workflows/rust-release-binaries.yml
+
+  publish-platform-packages:
+    name: Publish platform package (${{ matrix.package_name }})
+    needs: build-platform-binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        package_name:
+          - maximus-darwin-arm64
+          - maximus-darwin-x64
+          - maximus-linux-arm64-gnu
+          - maximus-linux-x64-gnu
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Download Rust release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.package_name }}
+          path: ${{ runner.temp }}/${{ matrix.package_name }}
+
+      - name: Inject Rust binary into platform package
+        shell: bash
+        run: |
+          cp "${RUNNER_TEMP}/${{ matrix.package_name }}/maximus" "./npm/${{ matrix.package_name }}/bin/maximus"
+          chmod +x "./npm/${{ matrix.package_name }}/bin/maximus"
+
+      - name: Publish platform package
+        run: npm publish "./npm/${{ matrix.package_name }}" --access public
+
+  publish-wrapper:
+    name: Publish npm wrapper
+    needs: publish-platform-packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish root wrapper package
+        run: npm publish . --access public
+
+  smoke-published-wrapper:
+    name: Smoke published wrapper
+    needs: publish-wrapper
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Read package version
+        id: package_version
+        shell: bash
+        run: |
+          version=$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).version')
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install published wrapper
+        shell: bash
+        run: |
+          install_root="$RUNNER_TEMP/maximus-release-smoke"
+          rm -rf "$install_root"
+          mkdir -p "$install_root"
+          export npm_config_cache="$RUNNER_TEMP/.npm-cache"
+          export npm_config_audit=false
+          export npm_config_fund=false
+          export npm_config_update_notifier=false
+          npm install --no-package-lock --prefix "$install_root" "maximus@${{ steps.package_version.outputs.value }}"
+
+      - name: Smoke published wrapper audit
+        shell: bash
+        run: |
+          install_root="$RUNNER_TEMP/maximus-release-smoke"
+          node "$install_root/node_modules/maximus/bin/maximus.js" audit ./test/fixtures/clean-project
+
+  action-smoke:
+    name: Smoke official GitHub Action
+    needs:
+      - publish-platform-packages
+      - publish-wrapper
+    uses: ./.github/workflows/action-smoke.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish. Select the same tag ref before running.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,8 +18,59 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-context:
+    name: Validate release context
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      package_version: ${{ steps.release_context.outputs.package_version }}
+      release_tag: ${{ steps.release_context.outputs.release_tag }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Resolve release tag from release event
+        if: github.event_name == 'release'
+        id: release_tag_from_event
+        shell: bash
+        env:
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          printf 'value=%s\n' "$RELEASE_EVENT_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve release tag from workflow input
+        if: github.event_name == 'workflow_dispatch'
+        id: release_tag_from_input
+        shell: bash
+        env:
+          DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          printf 'value=%s\n' "$DISPATCH_RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Assert release ref and package version alignment
+        id: release_context
+        shell: bash
+        env:
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_GITHUB_REF: ${{ github.ref }}
+          RELEASE_GITHUB_REF_NAME: ${{ github.ref_name }}
+          RELEASE_SELECTED_TAG: ${{ github.event_name == 'release' && steps.release_tag_from_event.outputs.value || steps.release_tag_from_input.outputs.value }}
+        run: |
+          node ./scripts/assert-release-workflow-context.mjs \
+            "$RELEASE_EVENT_NAME" \
+            "$RELEASE_GITHUB_REF" \
+            "$RELEASE_GITHUB_REF_NAME" \
+            "$RELEASE_SELECTED_TAG"
+
   build-platform-binaries:
     name: Build platform binaries
+    needs: validate-release-context
     uses: ./.github/workflows/rust-release-binaries.yml
 
   publish-platform-packages:
@@ -80,10 +136,24 @@ jobs:
         run: npm publish . --access public
 
   smoke-published-wrapper:
-    name: Smoke published wrapper
-    needs: publish-wrapper
-    runs-on: ubuntu-latest
+    name: Smoke published wrapper (${{ matrix.runner.platform }})
+    needs:
+      - publish-wrapper
+      - validate-release-context
+    runs-on: ${{ matrix.runner.label }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - label: ubuntu-24.04
+            platform: linux-x64-gnu
+          - label: ubuntu-24.04-arm
+            platform: linux-arm64-gnu
+          - label: macos-15-intel
+            platform: darwin-x64
+          - label: macos-14
+            platform: darwin-arm64
 
     steps:
       - name: Check out repository
@@ -93,13 +163,6 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "24"
-
-      - name: Read package version
-        id: package_version
-        shell: bash
-        run: |
-          version=$(node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).version')
-          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install published wrapper
         shell: bash
@@ -111,7 +174,13 @@ jobs:
           export npm_config_audit=false
           export npm_config_fund=false
           export npm_config_update_notifier=false
-          npm install --no-package-lock --prefix "$install_root" "maximus@${{ steps.package_version.outputs.value }}"
+          npm install --no-package-lock --prefix "$install_root" "maximus@${{ needs.validate-release-context.outputs.package_version }}"
+
+      - name: Assert published native runtime
+        shell: bash
+        run: |
+          install_root="$RUNNER_TEMP/maximus-release-smoke"
+          node ./scripts/assert-installed-native-runtime.mjs "$install_root"
 
       - name: Smoke published wrapper audit
         shell: bash
@@ -122,6 +191,7 @@ jobs:
   action-smoke:
     name: Smoke official GitHub Action
     needs:
+      - validate-release-context
       - publish-platform-packages
       - publish-wrapper
     uses: ./.github/workflows/action-smoke.yml

--- a/.github/workflows/rust-release-binaries.yml
+++ b/.github/workflows/rust-release-binaries.yml
@@ -1,0 +1,51 @@
+name: rust-release-binaries
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Rust release binary (${{ matrix.package_name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            package_name: maximus-linux-x64-gnu
+          - runner: ubuntu-24.04-arm
+            package_name: maximus-linux-arm64-gnu
+          - runner: macos-15-intel
+            package_name: maximus-darwin-x64
+          - runner: macos-14
+            package_name: maximus-darwin-arm64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Build release binary
+        run: cargo build --release -p maximus-cli
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          artifact_root="$RUNNER_TEMP/${{ matrix.package_name }}"
+          mkdir -p "$artifact_root"
+          cp ./target/release/maximus "$artifact_root/maximus"
+          chmod +x "$artifact_root/maximus"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.package_name }}
+          path: ${{ runner.temp }}/${{ matrix.package_name }}/maximus
+          if-no-files-found: error

--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,22 @@ Findings
   hint: Run `maximus fix` to create a blank contract file.
 ```
 
+## GitHub Action
+
+After the release tags are published, you can use the same npm-wrapper entrypoint from GitHub Actions as well.
+
+```yaml
+- uses: JeremyDev87/maximus@v0
+  with:
+    command: audit
+    path: .
+```
+
+Default inputs:
+
+- `command`: `audit`, `doctor`, `fix`
+- `path`: project path to inspect, default `.`
+
 ## Local Development
 
 ```bash

--- a/README.en.md
+++ b/README.en.md
@@ -90,7 +90,7 @@ Findings
 After the release tags are published, you can use the same npm-wrapper entrypoint from GitHub Actions as well.
 
 ```yaml
-- uses: JeremyDev87/maximus@v0
+- uses: JeremyDev87/maximus@<release-tag>
   with:
     command: audit
     path: .
@@ -100,6 +100,7 @@ Default inputs:
 
 - `command`: `audit`, `doctor`, `fix`
 - `path`: project path to inspect, default `.`
+- `<release-tag>`: replace this with a published release tag, for example `v0.1.0`
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Findings
   hint: Run `maximus fix` to create a blank contract file.
 ```
 
+## GitHub Action
+
+릴리즈 태그 이후에는 같은 npm wrapper 진입점을 GitHub Action으로도 사용할 수 있습니다.
+
+```yaml
+- uses: JeremyDev87/maximus@v0
+  with:
+    command: audit
+    path: .
+```
+
+기본 입력:
+
+- `command`: `audit`, `doctor`, `fix`
+- `path`: 검사할 프로젝트 경로, 기본값 `.`
+
 ## 로컬 개발
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Findings
 릴리즈 태그 이후에는 같은 npm wrapper 진입점을 GitHub Action으로도 사용할 수 있습니다.
 
 ```yaml
-- uses: JeremyDev87/maximus@v0
+- uses: JeremyDev87/maximus@<release-tag>
   with:
     command: audit
     path: .
@@ -100,6 +100,7 @@ Findings
 
 - `command`: `audit`, `doctor`, `fix`
 - `path`: 검사할 프로젝트 경로, 기본값 `.`
+- `<release-tag>`: publish된 릴리즈 태그로 바꿔 넣어야 합니다. 예: `v0.1.0`
 
 ## 로컬 개발
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ runs:
 
     - name: Install Maximus wrapper from this action ref
       shell: bash
+      env:
+        MAXIMUS_REGISTRY_URL: ${{ inputs.registry-url }}
       run: |
         install_root="$RUNNER_TEMP/maximus-action"
         rm -rf "$install_root"
@@ -35,14 +37,23 @@ runs:
         export npm_config_fund=false
         export npm_config_update_notifier=false
 
-        if [[ -n "${{ inputs.registry-url }}" ]]; then
-          export npm_config_registry="${{ inputs.registry-url }}"
+        if [[ -n "$MAXIMUS_REGISTRY_URL" ]]; then
+          export npm_config_registry="$MAXIMUS_REGISTRY_URL"
         fi
 
         npm install --no-package-lock --prefix "$install_root" "$GITHUB_ACTION_PATH"
 
-    - name: Run Maximus
+    - name: Assert native runtime is installed
       shell: bash
       run: |
         install_root="$RUNNER_TEMP/maximus-action"
-        node "$install_root/node_modules/maximus/bin/maximus.js" "${{ inputs.command }}" "${{ inputs.path }}"
+        node "$GITHUB_ACTION_PATH/scripts/assert-installed-native-runtime.mjs" "$install_root"
+
+    - name: Run Maximus
+      shell: bash
+      env:
+        MAXIMUS_COMMAND: ${{ inputs.command }}
+        MAXIMUS_TARGET_PATH: ${{ inputs.path }}
+      run: |
+        install_root="$RUNNER_TEMP/maximus-action"
+        node "$install_root/node_modules/maximus/bin/maximus.js" "$MAXIMUS_COMMAND" "$MAXIMUS_TARGET_PATH"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,48 @@
+name: Maximus
+description: Run Maximus through the npm wrapper and platform Rust binaries.
+
+inputs:
+  command:
+    description: Maximus command to run (`audit`, `doctor`, or `fix`)
+    required: false
+    default: audit
+  path:
+    description: Project path to inspect
+    required: false
+    default: .
+  registry-url:
+    description: Optional npm registry override for smoke or pre-release validation
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version: "24"
+
+    - name: Install Maximus wrapper from this action ref
+      shell: bash
+      run: |
+        install_root="$RUNNER_TEMP/maximus-action"
+        rm -rf "$install_root"
+        mkdir -p "$install_root"
+
+        export npm_config_cache="$RUNNER_TEMP/.npm-cache"
+        export npm_config_audit=false
+        export npm_config_fund=false
+        export npm_config_update_notifier=false
+
+        if [[ -n "${{ inputs.registry-url }}" ]]; then
+          export npm_config_registry="${{ inputs.registry-url }}"
+        fi
+
+        npm install --no-package-lock --prefix "$install_root" "$GITHUB_ACTION_PATH"
+
+    - name: Run Maximus
+      shell: bash
+      run: |
+        install_root="$RUNNER_TEMP/maximus-action"
+        node "$install_root/node_modules/maximus/bin/maximus.js" "${{ inputs.command }}" "${{ inputs.path }}"

--- a/scripts/assert-installed-native-runtime.mjs
+++ b/scripts/assert-installed-native-runtime.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import process from "node:process";
+import { open } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const PLACEHOLDER_MARKER = "MAXIMUS_RUST_BINARY_PLACEHOLDER";
+
+export async function assertInstalledNativeRuntime(installRoot) {
+  const runtimePackage = resolveRuntimePackage();
+  assert(runtimePackage, formatUnsupportedPlatformMessage());
+
+  const binaryPath = path.join(
+    installRoot,
+    "node_modules",
+    runtimePackage.packageName,
+    "bin",
+    "maximus",
+  );
+
+  if (await isPlaceholderRuntime(binaryPath)) {
+    throw new Error(
+      `Installed runtime for ${runtimePackage.packageName} is still the placeholder binary at "${binaryPath}".`,
+    );
+  }
+
+  return {
+    packageName: runtimePackage.packageName,
+    binaryPath,
+  };
+}
+
+function resolveRuntimePackage() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return {
+      packageName: "maximus-darwin-arm64",
+      label: "darwin-arm64",
+    };
+  }
+
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return {
+      packageName: "maximus-darwin-x64",
+      label: "darwin-x64",
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "arm64" && hasGlibcRuntime()) {
+    return {
+      packageName: "maximus-linux-arm64-gnu",
+      label: "linux-arm64-gnu",
+    };
+  }
+
+  if (process.platform === "linux" && process.arch === "x64" && hasGlibcRuntime()) {
+    return {
+      packageName: "maximus-linux-x64-gnu",
+      label: "linux-x64-gnu",
+    };
+  }
+
+  return null;
+}
+
+function hasGlibcRuntime() {
+  return Boolean(process.report?.getReport?.().header?.glibcVersionRuntime);
+}
+
+function formatUnsupportedPlatformMessage() {
+  if (process.platform === "linux" && !hasGlibcRuntime()) {
+    return "Installed native runtime assertion does not support Linux musl yet.";
+  }
+
+  return `Installed native runtime assertion does not support ${process.platform}-${process.arch}.`;
+}
+
+async function isPlaceholderRuntime(binaryPath) {
+  const file = await open(binaryPath, "r");
+
+  try {
+    const buffer = Buffer.alloc(512);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes(PLACEHOLDER_MARKER);
+  } finally {
+    await file.close();
+  }
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  try {
+    const installRoot = process.argv[2];
+    assert.equal(typeof installRoot, "string", "usage: node ./scripts/assert-installed-native-runtime.mjs <install-root>");
+    const result = await assertInstalledNativeRuntime(path.resolve(installRoot));
+    console.log(`Verified native runtime ${result.packageName} at ${result.binaryPath}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Native runtime assertion failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/assert-release-workflow-context.mjs
+++ b/scripts/assert-release-workflow-context.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { appendFile, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+async function readPackageVersion(repoRoot) {
+  const packageJsonPath = path.join(repoRoot, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  return packageJson.version;
+}
+
+export async function assertReleaseWorkflowContext({
+  repoRoot = process.cwd(),
+  eventName,
+  githubRef,
+  githubRefName,
+  requestedReleaseTag,
+}) {
+  assert.ok(
+    eventName === "release" || eventName === "workflow_dispatch",
+    `unsupported release workflow event: ${eventName}`,
+  );
+  assert.ok(requestedReleaseTag, "release tag is required");
+  assert.ok(
+    githubRef.startsWith("refs/tags/"),
+    `release workflow must run from a tag ref, received ${githubRef}`,
+  );
+
+  const resolvedRefName = githubRefName || githubRef.slice("refs/tags/".length);
+  assert.equal(
+    resolvedRefName,
+    requestedReleaseTag,
+    `selected ref ${resolvedRefName} does not match release tag ${requestedReleaseTag}`,
+  );
+
+  const packageVersion = await readPackageVersion(repoRoot);
+  const expectedReleaseTag = `v${packageVersion}`;
+  assert.equal(
+    requestedReleaseTag,
+    expectedReleaseTag,
+    `release tag ${requestedReleaseTag} does not match package.json version ${expectedReleaseTag}`,
+  );
+
+  return {
+    eventName,
+    packageVersion,
+    releaseTag: requestedReleaseTag,
+  };
+}
+
+async function writeGithubOutputs(summary) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    `package_version=${summary.packageVersion}\nrelease_tag=${summary.releaseTag}\n`,
+    "utf8",
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  const [eventName, githubRef, githubRefName, requestedReleaseTag, repoRootArg] =
+    process.argv.slice(2);
+
+  try {
+    const summary = await assertReleaseWorkflowContext({
+      repoRoot: repoRootArg || process.cwd(),
+      eventName,
+      githubRef,
+      githubRefName,
+      requestedReleaseTag,
+    });
+    await writeGithubOutputs(summary);
+    console.log(`Validated release workflow context for ${summary.releaseTag}.`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Release workflow context validation failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-rust-release-wiring.mjs
+++ b/scripts/validate-rust-release-wiring.mjs
@@ -12,22 +12,28 @@ const platformPackages = [
 
 const requiredFiles = {
   action: "action.yml",
+  packageManifest: "package.json",
   devWorkflow: ".github/workflows/dev.yml",
   actionSmokeWorkflow: ".github/workflows/action-smoke.yml",
   releaseWorkflow: ".github/workflows/release.yml",
   rustReleaseWorkflow: ".github/workflows/rust-release-binaries.yml",
   readmeKo: "README.md",
   readmeEn: "README.en.md",
+  releaseContextAssertion: "scripts/assert-release-workflow-context.mjs",
+  nativeRuntimeAssertion: "scripts/assert-installed-native-runtime.mjs",
 };
 
 export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
   const fileContents = await readRequiredFiles(repoRoot);
+  const packageManifest = JSON.parse(fileContents.packageManifest);
   validateAction(fileContents.action);
   validateDevWorkflow(fileContents.devWorkflow);
-  validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow);
+  validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow, packageManifest.version);
   validateRustReleaseWorkflow(fileContents.rustReleaseWorkflow);
   validateReleaseWorkflow(fileContents.releaseWorkflow);
   validateReadmes(fileContents.readmeKo, fileContents.readmeEn);
+  validateReleaseContextAssertion(fileContents.releaseContextAssertion);
+  validateNativeRuntimeAssertion(fileContents.nativeRuntimeAssertion);
 
   return {
     checkedFiles: Object.values(requiredFiles),
@@ -48,9 +54,23 @@ async function readRequiredFiles(repoRoot) {
 function validateAction(actionText) {
   assertContains(actionText, "name: Maximus", "action metadata name");
   assertContains(actionText, 'uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238', "action node setup");
+  assertContains(actionText, "MAXIMUS_REGISTRY_URL: ${{ inputs.registry-url }}", "action registry env wiring");
+  assertContains(actionText, 'if [[ -n "$MAXIMUS_REGISTRY_URL" ]]; then', "action registry env usage");
   assertContains(actionText, 'npm install --no-package-lock --prefix "$install_root" "$GITHUB_ACTION_PATH"', "action local package install");
+  assertContains(actionText, 'node "$GITHUB_ACTION_PATH/scripts/assert-installed-native-runtime.mjs" "$install_root"', "action native runtime assertion");
+  assertContains(actionText, "MAXIMUS_COMMAND: ${{ inputs.command }}", "action command env wiring");
+  assertContains(actionText, "MAXIMUS_TARGET_PATH: ${{ inputs.path }}", "action path env wiring");
+  assertContains(actionText, '"$MAXIMUS_COMMAND" "$MAXIMUS_TARGET_PATH"', "action wrapper env argv usage");
   assertContains(actionText, 'node "$install_root/node_modules/maximus/bin/maximus.js"', "action wrapper invocation");
   assertContains(actionText, "registry-url", "action registry override input");
+  assert.ok(
+    !actionText.includes('if [[ -n "${{ inputs.registry-url }}" ]]; then'),
+    "action should not interpolate registry input directly inside bash",
+  );
+  assert.ok(
+    !actionText.includes('"${{ inputs.command }}" "${{ inputs.path }}"'),
+    "action should not interpolate command or path inputs directly inside bash",
+  );
 }
 
 function validateDevWorkflow(devText) {
@@ -73,11 +93,16 @@ function validateDevWorkflow(devText) {
   assertContains(devText, "node --test test/github-action-wiring.test.js", "release wiring node test command");
 }
 
-function validateActionSmokeWorkflow(actionSmokeText) {
+function validateActionSmokeWorkflow(actionSmokeText, packageVersion) {
   assertContains(actionSmokeText, "workflow_call:", "action smoke reusable trigger");
   assertContains(actionSmokeText, "workflow_dispatch:", "action smoke manual trigger");
-  assertContains(actionSmokeText, "uses: ./", "action smoke local action usage");
+  assertContains(
+    actionSmokeText,
+    `uses: JeremyDev87/maximus@v${packageVersion}`,
+    "action smoke published action usage",
+  );
   assertContains(actionSmokeText, "registry-url: ${{ inputs.registry_url }}", "action smoke registry passthrough");
+  assert.ok(!actionSmokeText.includes("uses: ./"), "action smoke should not use the local checkout action");
 }
 
 function validateRustReleaseWorkflow(rustReleaseText) {
@@ -94,12 +119,39 @@ function validateRustReleaseWorkflow(rustReleaseText) {
 function validateReleaseWorkflow(releaseText) {
   assertContains(releaseText, "release:\n    types: [published]", "release published trigger");
   assertContains(releaseText, "workflow_dispatch:", "release manual trigger");
+  assertContains(releaseText, "release_tag:", "release workflow dispatch tag input");
+  assertContains(releaseText, "validate-release-context:", "release context validation job");
+  assertContains(releaseText, "needs: validate-release-context", "release context ordering");
+  assertContains(releaseText, "Resolve release tag from release event", "release event tag resolution step");
+  assertContains(releaseText, "Resolve release tag from workflow input", "release dispatch tag resolution step");
+  assertContains(releaseText, "RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}", "release event tag env wiring");
+  assertContains(releaseText, "DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}", "release dispatch tag env wiring");
+  assertContains(releaseText, "RELEASE_EVENT_NAME: ${{ github.event_name }}", "release event name env wiring");
+  assertContains(releaseText, "RELEASE_GITHUB_REF: ${{ github.ref }}", "release ref env wiring");
+  assertContains(releaseText, "RELEASE_GITHUB_REF_NAME: ${{ github.ref_name }}", "release ref_name env wiring");
+  assertContains(releaseText, 'printf \'value=%s\\n\' "$RELEASE_EVENT_TAG" >> "$GITHUB_OUTPUT"', "release event tag output");
+  assertContains(releaseText, 'printf \'value=%s\\n\' "$DISPATCH_RELEASE_TAG" >> "$GITHUB_OUTPUT"', "release dispatch tag output");
   assertContains(releaseText, "uses: ./.github/workflows/rust-release-binaries.yml", "release reusable binary workflow call");
+  assertContains(releaseText, "node ./scripts/assert-release-workflow-context.mjs", "release context assertion command");
   assertContains(releaseText, "npm publish . --access public", "root wrapper publish");
-  assertContains(releaseText, 'npm install --no-package-lock --prefix "$install_root" "maximus@${{ steps.package_version.outputs.value }}"', "published wrapper smoke install");
+  assertContains(releaseText, 'npm install --no-package-lock --prefix "$install_root" "maximus@${{ needs.validate-release-context.outputs.package_version }}"', "published wrapper smoke install");
+  assertContains(releaseText, 'node ./scripts/assert-installed-native-runtime.mjs "$install_root"', "published wrapper native runtime assertion");
   assertContains(releaseText, "uses: ./.github/workflows/action-smoke.yml", "release action smoke call");
   assertContains(releaseText, "needs: publish-platform-packages", "wrapper publish ordering");
-  assertContains(releaseText, "needs: publish-wrapper", "published wrapper smoke ordering");
+  assertContains(releaseText, "- publish-wrapper", "published wrapper smoke ordering");
+  assertContains(releaseText, "strategy:\n      fail-fast: false\n      matrix:", "published wrapper smoke matrix");
+  assert.ok(
+    !releaseText.includes('echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"'),
+    "release workflow should not interpolate release tag directly inside bash",
+  );
+  assert.ok(
+    !releaseText.includes('echo "value=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"'),
+    "release workflow should not interpolate dispatch input directly inside bash",
+  );
+  assert.ok(
+    !releaseText.includes('"${{ github.event_name }}"'),
+    "release workflow should not interpolate github event values directly inside bash argv",
+  );
 
   for (const packageName of platformPackages) {
     assertContains(releaseText, packageName, `release platform publish matrix for ${packageName}`);
@@ -108,9 +160,23 @@ function validateReleaseWorkflow(releaseText) {
 
 function validateReadmes(readmeKoText, readmeEnText) {
   assertContains(readmeKoText, "## GitHub Action", "Korean README action section");
-  assertContains(readmeKoText, "uses: JeremyDev87/maximus@v0", "Korean README action example");
+  assertContains(readmeKoText, "uses: JeremyDev87/maximus@<release-tag>", "Korean README action example");
+  assertContains(readmeKoText, "예: `v0.1.0`", "Korean README release tag guidance");
   assertContains(readmeEnText, "## GitHub Action", "English README action section");
-  assertContains(readmeEnText, "uses: JeremyDev87/maximus@v0", "English README action example");
+  assertContains(readmeEnText, "uses: JeremyDev87/maximus@<release-tag>", "English README action example");
+  assertContains(readmeEnText, "for example `v0.1.0`", "English README release tag guidance");
+}
+
+function validateNativeRuntimeAssertion(nativeRuntimeAssertionText) {
+  assertContains(nativeRuntimeAssertionText, "MAXIMUS_RUST_BINARY_PLACEHOLDER", "native runtime placeholder marker check");
+  assertContains(nativeRuntimeAssertionText, "node_modules", "native runtime node_modules lookup");
+  assertContains(nativeRuntimeAssertionText, "Verified native runtime", "native runtime success output");
+}
+
+function validateReleaseContextAssertion(releaseContextAssertionText) {
+  assertContains(releaseContextAssertionText, "release workflow must run from a tag ref", "release context tag gate");
+  assertContains(releaseContextAssertionText, "package.json version", "release context package version gate");
+  assertContains(releaseContextAssertionText, "GITHUB_OUTPUT", "release context GitHub output export");
 }
 
 function assertContains(text, expected, label) {

--- a/scripts/validate-rust-release-wiring.mjs
+++ b/scripts/validate-rust-release-wiring.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const platformPackages = [
+  "maximus-darwin-arm64",
+  "maximus-darwin-x64",
+  "maximus-linux-arm64-gnu",
+  "maximus-linux-x64-gnu",
+];
+
+const requiredFiles = {
+  action: "action.yml",
+  devWorkflow: ".github/workflows/dev.yml",
+  actionSmokeWorkflow: ".github/workflows/action-smoke.yml",
+  releaseWorkflow: ".github/workflows/release.yml",
+  rustReleaseWorkflow: ".github/workflows/rust-release-binaries.yml",
+  readmeKo: "README.md",
+  readmeEn: "README.en.md",
+};
+
+export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
+  const fileContents = await readRequiredFiles(repoRoot);
+  validateAction(fileContents.action);
+  validateDevWorkflow(fileContents.devWorkflow);
+  validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow);
+  validateRustReleaseWorkflow(fileContents.rustReleaseWorkflow);
+  validateReleaseWorkflow(fileContents.releaseWorkflow);
+  validateReadmes(fileContents.readmeKo, fileContents.readmeEn);
+
+  return {
+    checkedFiles: Object.values(requiredFiles),
+    platformPackages,
+  };
+}
+
+async function readRequiredFiles(repoRoot) {
+  const entries = await Promise.all(
+    Object.entries(requiredFiles).map(async ([key, relativePath]) => {
+      const absolutePath = path.join(repoRoot, relativePath);
+      return [key, await readFile(absolutePath, "utf8")];
+    }),
+  );
+  return Object.fromEntries(entries);
+}
+
+function validateAction(actionText) {
+  assertContains(actionText, "name: Maximus", "action metadata name");
+  assertContains(actionText, 'uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238', "action node setup");
+  assertContains(actionText, 'npm install --no-package-lock --prefix "$install_root" "$GITHUB_ACTION_PATH"', "action local package install");
+  assertContains(actionText, 'node "$install_root/node_modules/maximus/bin/maximus.js"', "action wrapper invocation");
+  assertContains(actionText, "registry-url", "action registry override input");
+}
+
+function validateDevWorkflow(devText) {
+  const requiredPaths = [
+    "action.yml",
+    ".github/workflows/action-smoke.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/rust-release-binaries.yml",
+  ];
+
+  for (const requiredPath of requiredPaths) {
+    assertContains(devText, `"${requiredPath}"`, `dev path filter for ${requiredPath}`);
+  }
+
+  assertContains(devText, '"scripts/**"', "dev path filter for scripts");
+  assertContains(devText, '"test/**"', "dev path filter for tests");
+
+  assertContains(devText, "release-wiring:", "release wiring job");
+  assertContains(devText, "node ./scripts/validate-rust-release-wiring.mjs", "release wiring validation command");
+  assertContains(devText, "node --test test/github-action-wiring.test.js", "release wiring node test command");
+}
+
+function validateActionSmokeWorkflow(actionSmokeText) {
+  assertContains(actionSmokeText, "workflow_call:", "action smoke reusable trigger");
+  assertContains(actionSmokeText, "workflow_dispatch:", "action smoke manual trigger");
+  assertContains(actionSmokeText, "uses: ./", "action smoke local action usage");
+  assertContains(actionSmokeText, "registry-url: ${{ inputs.registry_url }}", "action smoke registry passthrough");
+}
+
+function validateRustReleaseWorkflow(rustReleaseText) {
+  assertContains(rustReleaseText, "workflow_call:", "reusable rust release trigger");
+  assertContains(rustReleaseText, "workflow_dispatch:", "manual rust release trigger");
+  assertContains(rustReleaseText, "cargo build --release -p maximus-cli", "rust release build step");
+  assertContains(rustReleaseText, "actions/upload-artifact@v4", "rust release artifact upload");
+
+  for (const packageName of platformPackages) {
+    assertContains(rustReleaseText, packageName, `rust release matrix entry for ${packageName}`);
+  }
+}
+
+function validateReleaseWorkflow(releaseText) {
+  assertContains(releaseText, "release:\n    types: [published]", "release published trigger");
+  assertContains(releaseText, "workflow_dispatch:", "release manual trigger");
+  assertContains(releaseText, "uses: ./.github/workflows/rust-release-binaries.yml", "release reusable binary workflow call");
+  assertContains(releaseText, "npm publish . --access public", "root wrapper publish");
+  assertContains(releaseText, 'npm install --no-package-lock --prefix "$install_root" "maximus@${{ steps.package_version.outputs.value }}"', "published wrapper smoke install");
+  assertContains(releaseText, "uses: ./.github/workflows/action-smoke.yml", "release action smoke call");
+  assertContains(releaseText, "needs: publish-platform-packages", "wrapper publish ordering");
+  assertContains(releaseText, "needs: publish-wrapper", "published wrapper smoke ordering");
+
+  for (const packageName of platformPackages) {
+    assertContains(releaseText, packageName, `release platform publish matrix for ${packageName}`);
+  }
+}
+
+function validateReadmes(readmeKoText, readmeEnText) {
+  assertContains(readmeKoText, "## GitHub Action", "Korean README action section");
+  assertContains(readmeKoText, "uses: JeremyDev87/maximus@v0", "Korean README action example");
+  assertContains(readmeEnText, "## GitHub Action", "English README action section");
+  assertContains(readmeEnText, "uses: JeremyDev87/maximus@v0", "English README action example");
+}
+
+function assertContains(text, expected, label) {
+  assert.match(text, new RegExp(escapeRegExp(expected), "m"), `${label} is missing`);
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  try {
+    const summary = await validateRustReleaseWiring();
+    console.log(`Validated Rust release wiring in ${summary.checkedFiles.length} files.`);
+    console.log(`Platform packages: ${summary.platformPackages.join(", ")}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Rust release wiring validation failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateRustReleaseWiring } from "../scripts/validate-rust-release-wiring.mjs";
+
+test("Rust release wiring validation passes for the checked-in GitHub automation files", async () => {
+  const summary = await validateRustReleaseWiring(process.cwd());
+
+  assert.equal(summary.checkedFiles.length, 7);
+  assert.deepEqual(summary.platformPackages, [
+    "maximus-darwin-arm64",
+    "maximus-darwin-x64",
+    "maximus-linux-arm64-gnu",
+    "maximus-linux-x64-gnu",
+  ]);
+});

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -5,7 +5,7 @@ import { validateRustReleaseWiring } from "../scripts/validate-rust-release-wiri
 test("Rust release wiring validation passes for the checked-in GitHub automation files", async () => {
   const summary = await validateRustReleaseWiring(process.cwd());
 
-  assert.equal(summary.checkedFiles.length, 7);
+  assert.equal(summary.checkedFiles.length, 10);
   assert.deepEqual(summary.platformPackages, [
     "maximus-darwin-arm64",
     "maximus-darwin-x64",

--- a/test/installed-native-runtime.test.js
+++ b/test/installed-native-runtime.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+import { chmod, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { assertInstalledNativeRuntime } from "../scripts/assert-installed-native-runtime.mjs";
+
+test("installed native runtime assertion accepts a non-placeholder runtime package on supported hosts", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-ok-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", runtimePackage, "bin"), {
+    recursive: true,
+  });
+  const binaryPath = path.join(installRoot, "node_modules", runtimePackage, "bin", "maximus");
+  await writeFile(binaryPath, "#!/bin/sh\necho native-runtime\n", "utf8");
+  await chmod(binaryPath, 0o755);
+
+  const result = await assertInstalledNativeRuntime(installRoot);
+
+  assert.deepEqual(result, {
+    packageName: runtimePackage,
+    binaryPath,
+  });
+});
+
+test("installed native runtime assertion rejects placeholder runtime binaries", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-placeholder-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", runtimePackage, "bin"), {
+    recursive: true,
+  });
+  const binaryPath = path.join(installRoot, "node_modules", runtimePackage, "bin", "maximus");
+  await cp(path.join(process.cwd(), "npm", runtimePackage, "bin", "maximus"), binaryPath);
+  await chmod(binaryPath, 0o755);
+
+  await assert.rejects(
+    () => assertInstalledNativeRuntime(installRoot),
+    /placeholder binary/,
+  );
+});
+
+function currentRuntimePackage() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return "maximus-darwin-arm64";
+  }
+
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return "maximus-darwin-x64";
+  }
+
+  if (
+    process.platform === "linux" &&
+    process.arch === "arm64" &&
+    process.report?.getReport?.().header?.glibcVersionRuntime
+  ) {
+    return "maximus-linux-arm64-gnu";
+  }
+
+  if (
+    process.platform === "linux" &&
+    process.arch === "x64" &&
+    process.report?.getReport?.().header?.glibcVersionRuntime
+  ) {
+    return "maximus-linux-x64-gnu";
+  }
+
+  return null;
+}

--- a/test/release-workflow-context.test.js
+++ b/test/release-workflow-context.test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertReleaseWorkflowContext } from "../scripts/assert-release-workflow-context.mjs";
+
+test("release workflow context accepts matching release tags", async () => {
+  const summary = await assertReleaseWorkflowContext({
+    repoRoot: process.cwd(),
+    eventName: "release",
+    githubRef: "refs/tags/v0.1.0",
+    githubRefName: "v0.1.0",
+    requestedReleaseTag: "v0.1.0",
+  });
+
+  assert.equal(summary.packageVersion, "0.1.0");
+  assert.equal(summary.releaseTag, "v0.1.0");
+});
+
+test("release workflow context rejects non-tag refs", async () => {
+  await assert.rejects(
+    assertReleaseWorkflowContext({
+      repoRoot: process.cwd(),
+      eventName: "workflow_dispatch",
+      githubRef: "refs/heads/master",
+      githubRefName: "master",
+      requestedReleaseTag: "v0.1.0",
+    }),
+    /must run from a tag ref/,
+  );
+});
+
+test("release workflow context rejects mismatched selected tags", async () => {
+  await assert.rejects(
+    assertReleaseWorkflowContext({
+      repoRoot: process.cwd(),
+      eventName: "workflow_dispatch",
+      githubRef: "refs/tags/v0.1.0",
+      githubRefName: "v0.1.0",
+      requestedReleaseTag: "v0.1.1",
+    }),
+    /does not match release tag/,
+  );
+});
+
+test("release workflow context rejects package version mismatches", async () => {
+  await assert.rejects(
+    assertReleaseWorkflowContext({
+      repoRoot: process.cwd(),
+      eventName: "release",
+      githubRef: "refs/tags/v0.2.0",
+      githubRefName: "v0.2.0",
+      requestedReleaseTag: "v0.2.0",
+    }),
+    /does not match package\.json version/,
+  );
+});


### PR DESCRIPTION
## 배경
- Rust cutover 계획의 `P066-B`로 GitHub Action 및 release workflow를 Rust wrapper 배포 경로에 연결했습니다.
- 직전 `P066-A`에서 npm wrapper와 플랫폼 package 레이아웃을 만든 뒤, 실제 배포/검증 자동화가 아직 Rust runtime을 기준으로 정렬되지 않은 상태였습니다.
- Devil's Advocate 리뷰 루프에서 나온 지적을 반영해, published smoke가 JS fallback으로 우회 통과하지 않도록 native runtime assertion과 플랫폼별 smoke 범위도 함께 보강했습니다.

## 변경 사항
- `action.yml`에 공식 composite GitHub Action을 추가해 현재 action ref를 npm wrapper로 설치하고 `audit|doctor|fix`를 실행하도록 했습니다.
- `.github/workflows/rust-release-binaries.yml`을 추가해 Linux/macOS 4개 플랫폼 Rust release binary artifact를 빌드하도록 했습니다.
- `.github/workflows/release.yml`을 추가해 플랫폼 package publish -> root wrapper publish -> published wrapper smoke -> action smoke 순서로 release pipeline을 구성했습니다.
- `.github/workflows/action-smoke.yml`을 추가해 `workflow_call` / `workflow_dispatch` 기반 action smoke reusable workflow를 만들었습니다.
- `scripts/validate-rust-release-wiring.mjs`, `scripts/assert-installed-native-runtime.mjs`, `test/github-action-wiring.test.js`, `test/installed-native-runtime.test.js`를 추가해 wiring 계약과 native runtime 설치 여부를 로컬에서 실행 가능한 검증으로 고정했습니다.
- `README.md`, `README.en.md`에 GitHub Action 사용 예시를 추가하고, 존재하지 않는 `@v0` ref 대신 실제 release tag를 넣도록 안내를 정정했습니다.
- `.github/workflows/dev.yml`에 release wiring 검증 job을 추가해 CI에서 contract drift를 잡도록 했습니다.

## 검증
- `node ./scripts/validate-rust-release-wiring.mjs`
- `node --test test/github-action-wiring.test.js`
- `node --test test/installed-native-runtime.test.js`
- `actionlint .github/workflows/dev.yml .github/workflows/action-smoke.yml .github/workflows/release.yml .github/workflows/rust-release-binaries.yml`
- `npm test`
- Devil's Advocate review loop 2라운드 수행
  - Round 1: 1 High, 2 Medium 수용 후 수정
  - Round 2: 추가 의미 있는 이슈 없음

## 브랜치 / 워크트리
- 대상 브랜치: `codex/p066-action-release-wiring`
- 현재 워크트리: `/Users/pjw/workspace/maximus`
- 소스 브랜치 / 소스 워크트리: 없음 (현재 브랜치에서 직접 작업)

## 이슈 연결
- 별도 이슈 연결 없음

## 남은 리스크
- 실제 GitHub Release 이벤트와 npm publish secret을 사용한 live release run은 아직 검증하지 못했습니다.
- 외부 저장소에서 published tag를 사용한 action invocation 역시 이번 PR에서는 정적/로컬 계약 검증까지만 수행했습니다.
