### PR TITLE
feat: P001-A 설정 기반 Rust runtime 제어를 구현한다

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This project aims to make config-heavy repositories easier to understand, safer 
 Maximus now treats Rust as the canonical runtime for the published CLI, the npm wrapper, and the GitHub Action.
 
 - `bin/maximus.js` is a thin launcher that prefers repository Rust builds and installed platform-specific Rust binaries.
-- `src/**/*.js` stays in the repository as frozen reference code for parity checks, golden output generation, and roadmap context. The npm package still carries it as a compatibility fallback, but it is no longer the canonical runtime.
+- `src/**/*.js` stays in the repository as frozen reference code for parity checks, golden output generation, and roadmap context. It also remains available as a compatibility fallback for legacy-compatible CLI invocations, but config auto-loading and Rust-only CLI flags must still run on the canonical Rust runtime.
 - `docs/plan/001` through `012` should be read as Rust v1 feature specs, not as instructions to expand the JS codebase directly.
 - `docs/plan/013+` and the older JS backlog are not the default implementation lane while the rewrite family is still being closed out.
 

--- a/README.en.md
+++ b/README.en.md
@@ -22,7 +22,7 @@ Maximus now uses the Rust runtime as its canonical implementation.
 
 - The root `maximus` npm package is a thin launcher, and the actual execution path is delegated to platform-specific prebuilt Rust binaries.
 - The user-facing command surface stays the same: `npx maximus audit`, `npx maximus doctor`, `npx maximus fix`
-- `src/**/*.js` stays in the repository as frozen reference code for parity work and comparisons. It is still bundled in the npm package as a compatibility fallback when optional native runtime packages are unavailable, but it is no longer treated as the canonical runtime.
+- `src/**/*.js` stays in the repository as frozen reference code for parity work and comparisons. When no native Rust runtime is available, it only serves as a compatibility fallback for legacy-compatible commands; Rust remains the canonical runtime for Maximus config files and Rust-only flags such as `--only`.
 - `docs/plan/001` through `012` are Rust v1 spec inputs, and `docs/plan/013+` plus the older JS backlog are no longer the default implementation lane.
 
 See the [runtime transition document](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) for the transition boundary, phase map, and contributor rules.
@@ -109,7 +109,7 @@ cargo test --workspace
 node ./bin/maximus.js audit ./test/fixtures/clean-project
 ```
 
-`node ./bin/maximus.js` prefers the Rust CLI built inside the repository (`target/debug/maximus`, `target/release/maximus`). If you do not have a local binary yet, build one with `cargo build -p maximus-cli`. `src/**/*.js` remains as frozen reference code and is still bundled in the npm wrapper package as a compatibility fallback for installs without optional native packages.
+`node ./bin/maximus.js` prefers the Rust CLI built inside the repository (`target/debug/maximus`, `target/release/maximus`) and otherwise looks for an installed platform-specific Rust binary. If you do not have a local binary yet, build one with `cargo build -p maximus-cli`. When no Rust runtime is available, `src/**/*.js` still provides a compatibility fallback for the basic `audit` / `doctor` / `fix --dry-run` flow, but config auto-loading and Rust-only flags such as `--only`, `--skip`, and `--fail-on` still require the native Rust runtime.
 
 ## Recommended For
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Maximus는 이제 Rust runtime을 canonical implementation으로 사용합니다
 
 - 루트 `maximus` npm package는 thin launcher이며, 실제 실행은 플랫폼별 prebuilt Rust binary로 위임합니다.
 - 사용자 명령 표면은 그대로 유지합니다: `npx maximus audit`, `npx maximus doctor`, `npx maximus fix`
-- 저장소의 `src/**/*.js`는 parity 검증과 reference 비교를 위한 frozen reference로 남아 있습니다. npm package에도 optional native runtime이 빠진 설치를 위한 compatibility fallback으로 포함되지만, canonical runtime으로는 취급하지 않습니다.
+- 저장소의 `src/**/*.js`는 parity 검증과 reference 비교를 위한 frozen reference로 남아 있습니다. native Rust runtime이 없을 때는 기본 명령을 위한 compatibility fallback으로만 남아 있으며, `maximus.config.json`이나 `--only` 같은 Rust 전용 기능에는 canonical runtime인 Rust가 필요합니다.
 - `docs/plan/001`~`012`는 Rust v1 spec input이며, `docs/plan/013+`와 기존 JS backlog는 기본 구현 lane이 아닙니다.
 
 전환 경계와 contributor 규칙은 [runtime transition 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)에서 확인할 수 있습니다.
@@ -109,7 +109,7 @@ cargo test --workspace
 node ./bin/maximus.js audit ./test/fixtures/clean-project
 ```
 
-`node ./bin/maximus.js`는 repository 안에서 빌드된 Rust CLI(`target/debug/maximus`, `target/release/maximus`)를 우선 실행합니다. 로컬 바이너리가 아직 없으면 `cargo build -p maximus-cli`로 준비할 수 있습니다. `src/**/*.js`는 frozen reference로 남아 있고, npm 배포물에도 optional native runtime이 없는 설치를 위한 compatibility fallback으로 함께 포함됩니다.
+`node ./bin/maximus.js`는 repository 안에서 빌드된 Rust CLI(`target/debug/maximus`, `target/release/maximus`)를 우선 실행하고, 없으면 설치된 platform-specific Rust binary를 찾습니다. 로컬 바이너리가 아직 없으면 `cargo build -p maximus-cli`로 준비할 수 있습니다. Rust runtime이 없을 때도 `src/**/*.js` fallback으로 기본 `audit` / `doctor` / `fix --dry-run` 흐름은 유지되지만, config file 자동 로딩과 `--only`, `--skip`, `--fail-on` 같은 Rust 전용 기능은 native Rust runtime이 필요합니다.
 
 ## 이런 팀에 추천
 

--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { access, open } from "node:fs/promises";
+import { access, open, realpath, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { constants as osConstants } from "node:os";
 import path from "node:path";
@@ -13,10 +13,13 @@ const cliArgs = process.argv.slice(2);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 try {
-  const runtime = await resolveRuntime();
+  const runtime = await resolveRuntime(cliArgs);
 
   if (runtime.kind === "binary") {
     await runBinary(runtime.command, cliArgs);
+  } else if (runtime.kind === "compat-help") {
+    console.log(formatCompatHelp());
+    process.exitCode = 0;
   } else {
     await runFrozenJsReference(cliArgs);
   }
@@ -26,7 +29,7 @@ try {
   process.exitCode = process.exitCode || 1;
 }
 
-async function resolveRuntime() {
+async function resolveRuntime(args) {
   const repoBinary = await resolveRepoBinary();
   if (repoBinary) {
     return { kind: "binary", command: repoBinary };
@@ -40,8 +43,14 @@ async function resolveRuntime() {
     }
   }
 
-  if (await hasFrozenJsReferenceRuntime()) {
-    return { kind: "js" };
+  const fallback = await evaluateFrozenJsFallback(args);
+  if (fallback.allowed) {
+    return fallback.runtime;
+  }
+  if (fallback.reason) {
+    throw new Error(
+      `${fallback.reason} Build the Rust CLI with \`cargo build -p maximus-cli\`, or install a supported native runtime package before using this command.`,
+    );
   }
 
   if (!platformPackage) {
@@ -97,10 +106,10 @@ function hasGlibcRuntime() {
 
 function formatUnsupportedPlatformMessage() {
   if (process.platform === "linux" && !hasGlibcRuntime()) {
-    return "Linux musl is not supported yet. Maximus currently ships prebuilt Rust binaries only for Linux glibc and macOS.";
+    return "Linux musl is not supported yet. Maximus currently ships prebuilt Rust binaries only for Linux glibc and macOS. When no Rust runtime is available, the bundled JS reference can only serve legacy-compatible commands that do not require Rust-only config features.";
   }
 
-  return `Unsupported platform ${process.platform}-${process.arch}. Maximus currently ships prebuilt Rust binaries only for darwin-arm64, darwin-x64, linux-arm64-gnu, and linux-x64-gnu.`;
+  return `Unsupported platform ${process.platform}-${process.arch}. Maximus currently ships prebuilt Rust binaries only for darwin-arm64, darwin-x64, linux-arm64-gnu, and linux-x64-gnu. When no Rust runtime is available, the bundled JS reference can only serve legacy-compatible commands that do not require Rust-only config features.`;
 }
 
 async function resolveInstalledBinary(packageName) {
@@ -134,6 +143,140 @@ async function resolveRepoBinary() {
   return null;
 }
 
+async function evaluateFrozenJsFallback(args) {
+  if (!(await hasFrozenJsReferenceRuntime())) {
+    return { allowed: false, reason: null };
+  }
+
+  const parsed = parseCompatInvocation(args);
+
+  if (parsed.mode === "compat-help") {
+    return { allowed: true, runtime: { kind: "compat-help" } };
+  }
+
+  if (parsed.unsupportedFlags.length > 0) {
+    return {
+      allowed: false,
+      reason: `A Rust runtime is required for options not supported by the frozen JS compatibility path: ${parsed.unsupportedFlags.join(", ")}.`,
+    };
+  }
+
+  const configPath = await findNearestConfigPath(parsed.targetDir);
+  if (configPath) {
+    return {
+      allowed: false,
+      reason: `A Rust runtime is required when a Maximus config file is present (${configPath}).`,
+    };
+  }
+
+  return { allowed: true, runtime: { kind: "js" } };
+}
+
+function parseCompatInvocation(args) {
+  if (args.length === 0) {
+    return {
+      mode: "compat-help",
+      targetDir: process.cwd(),
+      unsupportedFlags: [],
+    };
+  }
+
+  const [command, ...rest] = args;
+  if (
+    command === "help"
+    || command === "--help"
+    || command === "-h"
+    || rest.includes("--help")
+    || rest.includes("-h")
+  ) {
+    return {
+      mode: "compat-help",
+      targetDir: process.cwd(),
+      unsupportedFlags: [],
+    };
+  }
+
+  let pathArg;
+  const unsupportedFlags = [];
+  const valueFlags = new Set(["--only", "--skip", "--fail-on", "--fix-id", "--fix-prefix"]);
+  const passthroughFlags = new Set(["--dry-run", "--json"]);
+  const isFixCommand = command === "fix";
+  const hasDryRun = rest.includes("--dry-run");
+
+  if (isFixCommand && !hasDryRun) {
+    unsupportedFlags.push("fix (without --dry-run)");
+  }
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+
+    if (valueFlags.has(token)) {
+      unsupportedFlags.push(token);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--diff") {
+      unsupportedFlags.push(token);
+      continue;
+    }
+
+    if (passthroughFlags.has(token) || token === "--help" || token === "-h") {
+      continue;
+    }
+
+    if (pathArg === undefined) {
+      pathArg = token;
+    }
+  }
+
+  return {
+    mode: "js",
+    targetDir: path.resolve(pathArg ?? process.cwd()),
+    unsupportedFlags,
+  };
+}
+
+async function findNearestConfigPath(startDir) {
+  const resolvedStartDir = path.resolve(startDir);
+  const startDirs = [];
+  try {
+    startDirs.push(await realpath(resolvedStartDir));
+  } catch {
+    // Fall back to lexical ancestor search when the target is not realpath-able.
+  }
+  startDirs.push(resolvedStartDir);
+  const searchedDirs = new Set();
+
+  for (let currentDir of startDirs) {
+    while (true) {
+      if (!searchedDirs.has(currentDir)) {
+        searchedDirs.add(currentDir);
+        for (const name of ["maximus.config.json", ".maximusrc.json"]) {
+          const candidate = path.join(currentDir, name);
+
+          try {
+            if ((await stat(candidate)).isFile()) {
+              return candidate;
+            }
+          } catch {
+            // continue
+          }
+        }
+      }
+
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+
+      currentDir = parentDir;
+    }
+  }
+
+  return null;
+}
+
 async function hasFrozenJsReferenceRuntime() {
   try {
     await access(path.join(repoRoot, "src", "cli.js"));
@@ -159,7 +302,7 @@ function formatMissingRuntimeMessage(platformPackage) {
   return [
     `No Rust runtime is available for ${platformPackage.label}.`,
     `Expected optional dependency "${platformPackage.packageName}" to be installed or a local Cargo build to exist in target/debug or target/release.`,
-    "The bundled JS compatibility fallback was not available either.",
+    "The bundled JS reference can only serve legacy-compatible commands that do not require Rust-only config features.",
     "If you are developing inside the repository, build the Rust CLI with `cargo build -p maximus-cli` first.",
   ].join(" ");
 }
@@ -191,6 +334,22 @@ async function runFrozenJsReference(args) {
   const { runCli } = await import("../src/cli.js");
   await runCli(args);
   process.exitCode = process.exitCode ?? 0;
+}
+
+function formatCompatHelp() {
+  return [
+    "Maximus",
+    "",
+    "Bring order to chaotic configs.",
+    "",
+    "Usage",
+    "  maximus audit [path] [--json]",
+    "  maximus doctor [path] [--json]",
+    "  maximus fix [path] --dry-run [--json]",
+    "  maximus help",
+    "",
+    "When no Rust runtime is available, the bundled JS compatibility path can only execute legacy-compatible commands without Maximus config files or Rust-only flags. `--only`, `--skip`, `--fail-on`, `--diff`, `--fix-id`, and `--fix-prefix` require the Rust runtime, and `fix` is only available with `--dry-run`.",
+  ].join("\n");
 }
 
 function signalExitCode(signal) {

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -6,14 +6,18 @@ mod env;
 mod eslint_prettier;
 pub mod lockfiles;
 pub mod package_entrypoints;
+pub mod registry;
 pub mod structure;
 mod tsconfig;
-pub mod registry;
 
 pub use check_outcome::CheckOutcome;
 pub use config_duplicates::run_config_duplicate_check;
 pub use env::{render_created_env_example, render_synced_env_example, run_env_check};
 pub use eslint_prettier::run_eslint_prettier_check;
-pub use registry::{audit_project, run_registered_checks, AuditedProject};
+pub use registry::{
+    audit_project, audit_project_with_config, audit_project_with_config_root, registered_check_ids,
+    run_registered_checks, run_registered_checks_with_config,
+    run_registered_checks_with_config_root, run_registered_checks_with_filters, AuditedProject,
+};
 pub use structure::build_structure_report;
 pub use tsconfig::run_tsconfig_check;

--- a/crates/maximus-checks/src/lockfiles.rs
+++ b/crates/maximus-checks/src/lockfiles.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use maximus_core::{make_finding, FindingInput, ProjectSnapshot, Severity};
+use maximus_core::{
+    is_ignored_project_path_from_root, make_finding, FindingInput, ProjectSnapshot, Severity,
+};
 
 use crate::check_outcome::CheckOutcome;
 
@@ -37,10 +39,30 @@ const KNOWN_LOCKFILES: &[&str] = &[
 ];
 
 pub fn run_lockfiles_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_lockfiles_check_with_ignore(project, &[])
+}
+
+pub fn run_lockfiles_check_with_ignore(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+) -> io::Result<CheckOutcome> {
+    run_lockfiles_check_with_ignore_root(project, ignored_patterns, &project.root_dir)
+}
+
+pub fn run_lockfiles_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
     let mut findings = Vec::new();
     let mut lockfiles_by_directory = BTreeMap::new();
 
-    collect_lockfiles(&project.root_dir, &mut lockfiles_by_directory)?;
+    collect_lockfiles(
+        &project.root_dir,
+        ignored_patterns,
+        ignore_root,
+        &mut lockfiles_by_directory,
+    )?;
 
     for (directory, mut lockfiles) in lockfiles_by_directory {
         if lockfiles.len() <= 1 {
@@ -50,7 +72,10 @@ pub fn run_lockfiles_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome
         lockfiles.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
         let lockfile_names = lockfiles
             .iter()
-            .filter_map(|path| path.file_name().map(|name| name.to_string_lossy().to_string()))
+            .filter_map(|path| {
+                path.file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+            })
             .collect::<Vec<_>>();
 
         findings.push(make_finding(FindingInput {
@@ -84,13 +109,28 @@ pub fn run_lockfiles_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome
 
 fn collect_lockfiles(
     root_dir: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
     lockfiles_by_directory: &mut BTreeMap<PathBuf, Vec<PathBuf>>,
 ) -> io::Result<()> {
-    visit_directory(root_dir, lockfiles_by_directory)
+    if is_ignored_project_path_from_root(ignore_root, root_dir, ignored_patterns) {
+        return Ok(());
+    }
+
+    visit_directory(
+        root_dir,
+        root_dir,
+        ignored_patterns,
+        ignore_root,
+        lockfiles_by_directory,
+    )
 }
 
 fn visit_directory(
+    root_dir: &Path,
     directory: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
     lockfiles_by_directory: &mut BTreeMap<PathBuf, Vec<PathBuf>>,
 ) -> io::Result<()> {
     let mut child_directories = Vec::new();
@@ -115,13 +155,18 @@ fn visit_directory(
         let path = entry.path();
 
         if file_type.is_dir() {
-            if !should_ignore_directory(&entry.file_name()) {
+            if !should_ignore_directory(&entry.file_name())
+                && !is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns)
+            {
                 child_directories.push(path);
             }
             continue;
         }
 
         if !file_type.is_file() {
+            continue;
+        }
+        if is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns) {
             continue;
         }
 
@@ -139,7 +184,13 @@ fn visit_directory(
 
     child_directories.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
     for child_directory in child_directories {
-        if let Err(error) = visit_directory(&child_directory, lockfiles_by_directory) {
+        if let Err(error) = visit_directory(
+            root_dir,
+            &child_directory,
+            ignored_patterns,
+            ignore_root,
+            lockfiles_by_directory,
+        ) {
             if should_skip_traversal_error(&error) {
                 continue;
             }

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -2,17 +2,19 @@ use std::io;
 use std::path::Path;
 
 use maximus_core::{
-    discover_project, parse_jsonc, sort_findings, summarize_findings, unique_fixes, AuditResult,
-    PlannedFix, ProjectDirectory, ProjectFile, ProjectSnapshot, read_text_if_exists,
+    discover_project, discover_project_with_ignore_root, parse_jsonc, read_text_if_exists,
+    sort_findings, summarize_findings, unique_fixes, AuditResult, CheckFilterConfig,
+    ConfigSeverity, MaximusConfig, PlannedFix, ProjectDirectory, ProjectFile, ProjectSnapshot,
+    Severity,
 };
 
 use crate::check_outcome::CheckOutcome;
+use crate::lockfiles::run_lockfiles_check_with_ignore_root;
+use crate::package_entrypoints::run_package_entrypoints_check;
 use crate::{
     build_structure_report, run_config_duplicate_check, run_env_check, run_eslint_prettier_check,
     run_tsconfig_check,
 };
-use crate::lockfiles::run_lockfiles_check;
-use crate::package_entrypoints::run_package_entrypoints_check;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditedProject {
@@ -21,22 +23,111 @@ pub struct AuditedProject {
     pub planned_fixes: Vec<PlannedFix>,
 }
 
+type RegisteredCheckFn = fn(&ProjectSnapshot, &MaximusConfig, &Path) -> io::Result<CheckOutcome>;
+
+struct RegisteredCheck {
+    id: &'static str,
+    run: RegisteredCheckFn,
+}
+
+const REGISTERED_CHECKS: &[RegisteredCheck] = &[
+    RegisteredCheck {
+        id: "duplicates",
+        run: run_config_duplicate_check_registered,
+    },
+    RegisteredCheck {
+        id: "env",
+        run: run_env_check_registered,
+    },
+    RegisteredCheck {
+        id: "eslint-prettier",
+        run: run_eslint_prettier_check_registered,
+    },
+    RegisteredCheck {
+        id: "tsconfig",
+        run: run_tsconfig_check_registered,
+    },
+    RegisteredCheck {
+        id: "lockfiles",
+        run: run_lockfiles_check_registered,
+    },
+    RegisteredCheck {
+        id: "package-entrypoints",
+        run: run_package_entrypoints_check_registered,
+    },
+];
+
+pub fn registered_check_ids() -> &'static [&'static str] {
+    &[
+        "duplicates",
+        "env",
+        "eslint-prettier",
+        "tsconfig",
+        "lockfiles",
+        "package-entrypoints",
+    ]
+}
+
 pub fn run_registered_checks(project: &ProjectSnapshot) -> std::io::Result<CheckOutcome> {
-    let outcomes = [
-        run_config_duplicate_check(project)?,
-        run_env_check(project)?,
-        run_eslint_prettier_check(project)?,
-        run_tsconfig_check(project)?,
-        run_lockfiles_check(project)?,
-        run_package_entrypoints_check(project)?,
-    ];
+    run_registered_checks_with_config_root(project, &MaximusConfig::default(), &project.root_dir)
+}
+
+pub fn run_registered_checks_with_filters(
+    project: &ProjectSnapshot,
+    filters: &CheckFilterConfig,
+) -> std::io::Result<CheckOutcome> {
+    let config = MaximusConfig {
+        checks: filters.clone(),
+        ..MaximusConfig::default()
+    };
+    run_registered_checks_with_config_root(project, &config, &project.root_dir)
+}
+
+pub fn run_registered_checks_with_config(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+) -> std::io::Result<CheckOutcome> {
+    run_registered_checks_with_config_root(project, config, &project.root_dir)
+}
+
+pub fn run_registered_checks_with_config_root(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> std::io::Result<CheckOutcome> {
+    let outcomes = REGISTERED_CHECKS
+        .iter()
+        .filter(|check| should_run_check(check.id, &config.checks))
+        .map(|check| (check.run)(project, config, ignore_root))
+        .collect::<io::Result<Vec<_>>>()?;
 
     Ok(merge_outcomes(outcomes))
 }
 
 pub fn audit_project(root_dir: &Path) -> io::Result<AuditedProject> {
-    let project = discover_project(root_dir)?;
-    let outcome = run_registered_checks(&project)?;
+    audit_project_with_config(root_dir, &MaximusConfig::default())
+}
+
+pub fn audit_project_with_config(
+    root_dir: &Path,
+    config: &MaximusConfig,
+) -> io::Result<AuditedProject> {
+    audit_project_with_config_root(root_dir, config, root_dir)
+}
+
+pub fn audit_project_with_config_root(
+    root_dir: &Path,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> io::Result<AuditedProject> {
+    let project = if config.ignore.is_empty() {
+        discover_project(root_dir)?
+    } else {
+        discover_project_with_ignore_root(root_dir, &config.ignore, ignore_root)?
+    };
+    let mut outcome = run_registered_checks_with_config_root(&project, config, ignore_root)?;
+    apply_severity_overrides(&mut outcome.findings, &config.severity);
+    outcome.findings = sort_findings(&outcome.findings);
     let structure = build_structure_report(&project, &outcome.findings);
     let summary = summarize_findings(&outcome.findings, &outcome.fixes, &structure);
     let result = AuditResult {
@@ -89,7 +180,10 @@ fn unique_planned_fixes(fixes: &[PlannedFix]) -> Vec<PlannedFix> {
 }
 
 pub(crate) fn package_file_for_directory(directory: &ProjectDirectory) -> Option<&ProjectFile> {
-    directory.files.iter().find(|file| file.kind == maximus_core::FileKind::Package)
+    directory
+        .files
+        .iter()
+        .find(|file| file.kind == maximus_core::FileKind::Package)
 }
 
 pub(crate) fn read_package_json(file_path: &Path) -> Option<serde_json::Value> {
@@ -102,4 +196,89 @@ pub(crate) fn has_object_key(value: &serde_json::Value, key: &str) -> bool {
         .as_object()
         .map(|object| object.contains_key(key))
         .unwrap_or(false)
+}
+
+fn should_run_check(id: &str, filters: &CheckFilterConfig) -> bool {
+    let allowed = filters.only.is_empty() || filters.only.iter().any(|candidate| candidate == id);
+    let skipped = filters.skip.iter().any(|candidate| candidate == id);
+
+    allowed && !skipped
+}
+
+fn run_config_duplicate_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_config_duplicate_check(project)
+}
+
+fn run_env_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_env_check(project)
+}
+
+fn run_eslint_prettier_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_eslint_prettier_check(project)
+}
+
+fn run_tsconfig_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_tsconfig_check(project)
+}
+
+fn run_lockfiles_check_registered(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_lockfiles_check_with_ignore_root(project, &config.ignore, ignore_root)
+}
+
+fn run_package_entrypoints_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_package_entrypoints_check(project)
+}
+
+fn apply_severity_overrides(
+    findings: &mut [maximus_core::Finding],
+    overrides: &std::collections::BTreeMap<String, ConfigSeverity>,
+) {
+    if overrides.is_empty() {
+        return;
+    }
+
+    for finding in findings {
+        let override_level = overrides
+            .iter()
+            .filter(|(prefix, _)| !prefix.trim().is_empty())
+            .filter(|(prefix, _)| finding.id.starts_with(prefix.as_str()))
+            .max_by_key(|(prefix, _)| prefix.len())
+            .map(|(_, level)| level);
+
+        if let Some(level) = override_level {
+            finding.severity = config_severity_to_runtime(level);
+        }
+    }
+}
+
+fn config_severity_to_runtime(level: &ConfigSeverity) -> Severity {
+    match level {
+        ConfigSeverity::Error => Severity::Error,
+        ConfigSeverity::Warn => Severity::Warn,
+        ConfigSeverity::Info => Severity::Info,
+    }
 }

--- a/crates/maximus-checks/tests/lockfiles_checks.rs
+++ b/crates/maximus-checks/tests/lockfiles_checks.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use maximus_checks::lockfiles::run_lockfiles_check;
+use maximus_checks::lockfiles::{
+    run_lockfiles_check, run_lockfiles_check_with_ignore, run_lockfiles_check_with_ignore_root,
+};
 use maximus_core::{discover_project, ProjectSnapshot, Severity};
 use tempfile::TempDir;
 
@@ -33,8 +35,14 @@ fn lockfiles_check_keeps_root_and_nested_package_directories_independent() {
     let fixture = TempDir::new().expect("temp dir should exist");
 
     write(fixture.path().join("yarn.lock"), "# yarn lockfile v1\n");
-    write(fixture.path().join("packages/app/package-lock.json"), "{}\n");
-    write(fixture.path().join("packages/app/pnpm-lock.yaml"), "lockfileVersion: 9\n");
+    write(
+        fixture.path().join("packages/app/package-lock.json"),
+        "{}\n",
+    );
+    write(
+        fixture.path().join("packages/app/pnpm-lock.yaml"),
+        "lockfileVersion: 9\n",
+    );
 
     let project = discover_project(fixture.path()).expect("project should discover");
     let outcome = run_lockfiles_check(&project).expect("check should run");
@@ -57,6 +65,77 @@ fn lockfiles_check_keeps_root_and_nested_package_directories_independent() {
             finding.id != format!("lockfiles:multiple:{}", fixture.path().to_string_lossy())
         }),
         "root directory should not inherit the nested package warning"
+    );
+}
+
+#[test]
+fn lockfiles_check_respects_config_ignore_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(fixture.path().join("ignored/package-lock.json"), "{}\n");
+    write(
+        fixture.path().join("ignored/yarn.lock"),
+        "# yarn lockfile v1\n",
+    );
+    write(
+        fixture.path().join("packages/web/package-lock.json"),
+        "{}\n",
+    );
+    write(
+        fixture.path().join("packages/web/pnpm-lock.yaml"),
+        "lockfileVersion: 9\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let ignored_patterns = vec!["ignored".to_string()];
+    let outcome =
+        run_lockfiles_check_with_ignore(&project, &ignored_patterns).expect("check should run");
+
+    assert!(
+        outcome
+            .findings
+            .iter()
+            .all(|finding| !finding.id.contains("/ignored")),
+        "ignored directory should not produce lockfile findings: {:?}",
+        outcome.findings
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "lockfiles:multiple:{}",
+            fixture.path().join("packages/web").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Multiple lockfiles are present in one directory",
+        "Found 2 known lockfiles in packages/web: package-lock.json, pnpm-lock.yaml.",
+        "Keep one lockfile per directory so dependency resolution stays predictable. Separate package directories can each have their own lockfile.",
+        Some(fixture.path().join("packages/web/package-lock.json")),
+    );
+}
+
+#[test]
+fn lockfiles_check_skips_directly_ignored_target_directory() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let target = fixture.path().join("packages/web/generated");
+
+    write(target.join("package-lock.json"), "{}\n");
+    write(target.join("yarn.lock"), "# yarn lockfile v1\n");
+
+    let project = ProjectSnapshot {
+        root_dir: target.clone(),
+        files: Vec::new(),
+        directories: Vec::new(),
+        files_by_kind: Default::default(),
+        package_files: Vec::new(),
+    };
+    let ignored_patterns = vec!["packages/web/generated".to_string()];
+    let outcome = run_lockfiles_check_with_ignore_root(&project, &ignored_patterns, fixture.path())
+        .expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "ignored target directory should not produce lockfile findings: {:?}",
+        outcome.findings
     );
 }
 

--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -5,10 +5,13 @@ use std::fmt::{Display, Formatter};
 pub struct Flags {
     pub diff: bool,
     pub dry_run: bool,
+    pub fail_on: Option<String>,
     pub fix_ids: Vec<String>,
     pub fix_prefixes: Vec<String>,
     pub help: bool,
     pub json: bool,
+    pub only_checks: Option<Vec<String>>,
+    pub skip_checks: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -20,12 +23,14 @@ pub struct ParsedArgs {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgsError {
+    EmptyValue(&'static str),
     MissingValue(&'static str),
 }
 
 impl Display for ArgsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::EmptyValue(flag) => write!(f, "Option \"{flag}\" requires a non-empty value."),
             Self::MissingValue(flag) => write!(f, "Option \"{flag}\" requires a value."),
         }
     }
@@ -44,13 +49,35 @@ where
         match token.to_str() {
             Some("--diff") => flags.diff = true,
             Some("--dry-run") => flags.dry_run = true,
+            Some("--fail-on") => {
+                let value = next_option_value(tokens.next(), "--fail-on")?;
+                flags.fail_on = Some(value.to_string_lossy().into_owned());
+            }
             Some("--fix-id") => {
                 let value = next_option_value(tokens.next(), "--fix-id")?;
                 flags.fix_ids.push(value.to_string_lossy().into_owned());
             }
             Some("--fix-prefix") => {
                 let value = next_option_value(tokens.next(), "--fix-prefix")?;
-                flags.fix_prefixes.push(value.to_string_lossy().into_owned());
+                flags
+                    .fix_prefixes
+                    .push(value.to_string_lossy().into_owned());
+            }
+            Some("--only") => {
+                let value = next_option_value(tokens.next(), "--only")?;
+                let values = split_csv_values(&value, "--only")?;
+                flags
+                    .only_checks
+                    .get_or_insert_with(Vec::new)
+                    .extend(values);
+            }
+            Some("--skip") => {
+                let value = next_option_value(tokens.next(), "--skip")?;
+                let values = split_csv_values(&value, "--skip")?;
+                flags
+                    .skip_checks
+                    .get_or_insert_with(Vec::new)
+                    .extend(values);
             }
             Some("--json") => flags.json = true,
             Some("--help") | Some("-h") => flags.help = true,
@@ -59,7 +86,9 @@ where
     }
 
     Ok(ParsedArgs {
-        command: args.first().map(|value| value.to_string_lossy().into_owned()),
+        command: args
+            .first()
+            .map(|value| value.to_string_lossy().into_owned()),
         args: args.into_iter().skip(1).collect(),
         flags,
     })
@@ -80,6 +109,22 @@ fn next_option_value(value: Option<OsString>, flag: &'static str) -> Result<OsSt
     Ok(value)
 }
 
+fn split_csv_values(value: &OsString, flag: &'static str) -> Result<Vec<String>, ArgsError> {
+    let values = value
+        .to_string_lossy()
+        .split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    if values.is_empty() {
+        return Err(ArgsError::EmptyValue(flag));
+    }
+
+    Ok(values)
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
@@ -88,8 +133,8 @@ mod tests {
 
     #[test]
     fn parse_args_collects_known_flags_and_positionals() {
-        let parsed = parse_args(["fix", "./repo", "--dry-run", "--json"])
-            .expect("args should parse");
+        let parsed =
+            parse_args(["fix", "./repo", "--dry-run", "--json"]).expect("args should parse");
 
         assert_eq!(
             parsed,
@@ -99,10 +144,13 @@ mod tests {
                 flags: Flags {
                     diff: false,
                     dry_run: true,
+                    fail_on: None,
                     fix_ids: Vec::new(),
                     fix_prefixes: Vec::new(),
                     help: false,
                     json: true,
+                    only_checks: None,
+                    skip_checks: None,
                 },
             }
         );
@@ -110,8 +158,7 @@ mod tests {
 
     #[test]
     fn parse_args_treats_unknown_tokens_as_positionals() {
-        let parsed =
-            parse_args(["audit", "--mystery", "target"]).expect("args should parse");
+        let parsed = parse_args(["audit", "--mystery", "target"]).expect("args should parse");
 
         assert_eq!(parsed.command.as_deref(), Some("audit"));
         assert_eq!(
@@ -125,6 +172,12 @@ mod tests {
         let parsed = parse_args([
             "fix",
             "./repo",
+            "--only",
+            "env,tsconfig",
+            "--skip",
+            "duplicates",
+            "--fail-on",
+            "error",
             "--fix-id",
             "env-example:create:.",
             "--fix-prefix",
@@ -135,7 +188,19 @@ mod tests {
 
         assert_eq!(parsed.command.as_deref(), Some("fix"));
         assert_eq!(parsed.args, vec![OsString::from("./repo")]);
-        assert_eq!(parsed.flags.fix_ids, vec!["env-example:create:.".to_string()]);
+        assert_eq!(
+            parsed.flags.only_checks,
+            Some(vec!["env".to_string(), "tsconfig".to_string()])
+        );
+        assert_eq!(
+            parsed.flags.skip_checks,
+            Some(vec!["duplicates".to_string()])
+        );
+        assert_eq!(parsed.flags.fail_on.as_deref(), Some("error"));
+        assert_eq!(
+            parsed.flags.fix_ids,
+            vec!["env-example:create:.".to_string()]
+        );
         assert_eq!(parsed.flags.fix_prefixes, vec!["env-example:".to_string()]);
         assert!(parsed.flags.diff);
     }
@@ -153,6 +218,49 @@ mod tests {
             .expect_err("flag-shaped selector should fail");
 
         assert_eq!(error, ArgsError::MissingValue("--fix-id"));
+    }
+
+    #[test]
+    fn parse_args_errors_when_only_filter_is_empty() {
+        let error =
+            parse_args(["audit", "--only", "  ,  "]).expect_err("empty only filter should fail");
+
+        assert_eq!(error, ArgsError::EmptyValue("--only"));
+    }
+
+    #[test]
+    fn parse_args_errors_when_skip_filter_is_empty() {
+        let error = parse_args(["audit", "--skip", ""]).expect_err("empty skip filter should fail");
+
+        assert_eq!(error, ArgsError::EmptyValue("--skip"));
+    }
+
+    #[test]
+    fn parse_args_collects_multiple_check_filter_flags() {
+        let parsed = parse_args([
+            "audit",
+            ".",
+            "--only",
+            "env",
+            "--only",
+            "tsconfig,duplicates",
+            "--skip",
+            "lockfiles",
+        ])
+        .expect("args should parse");
+
+        assert_eq!(
+            parsed.flags.only_checks,
+            Some(vec![
+                "env".to_string(),
+                "tsconfig".to_string(),
+                "duplicates".to_string()
+            ])
+        );
+        assert_eq!(
+            parsed.flags.skip_checks,
+            Some(vec!["lockfiles".to_string()])
+        );
     }
 
     #[cfg(unix)]

--- a/crates/maximus-cli/src/fail_policy.rs
+++ b/crates/maximus-cli/src/fail_policy.rs
@@ -1,0 +1,69 @@
+use maximus_core::{AuditSummary, FailOnLevel};
+
+use crate::exit_codes::{FINDINGS_PRESENT, SUCCESS};
+
+pub fn exit_code(summary: &AuditSummary, fail_on: &FailOnLevel) -> i32 {
+    let has_matching_findings = match fail_on {
+        FailOnLevel::Error => summary.blocking_findings > 0,
+        FailOnLevel::Warn => summary.blocking_findings > 0 || summary.warning_findings > 0,
+        FailOnLevel::Info => {
+            summary.blocking_findings > 0
+                || summary.warning_findings > 0
+                || summary.info_findings > 0
+        }
+        FailOnLevel::None => false,
+    };
+
+    if has_matching_findings {
+        FINDINGS_PRESENT
+    } else {
+        SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maximus_core::{AuditSummary, FailOnLevel};
+
+    use super::exit_code;
+    use crate::exit_codes::{FINDINGS_PRESENT, SUCCESS};
+
+    fn summary() -> AuditSummary {
+        AuditSummary {
+            status: "attention needed".to_string(),
+            total_findings: 3,
+            blocking_findings: 1,
+            warning_findings: 1,
+            info_findings: 1,
+            fixable_findings: 0,
+            fixes_available: 0,
+            config_files: 1,
+            package_count: 1,
+            env_directories: 0,
+        }
+    }
+
+    #[test]
+    fn fail_policy_respects_selected_threshold() {
+        let noisy = summary();
+        let warnings_only = AuditSummary {
+            blocking_findings: 0,
+            ..noisy.clone()
+        };
+        let info_only = AuditSummary {
+            blocking_findings: 0,
+            warning_findings: 0,
+            ..noisy.clone()
+        };
+
+        assert_eq!(exit_code(&noisy, &FailOnLevel::Error), FINDINGS_PRESENT);
+        assert_eq!(exit_code(&warnings_only, &FailOnLevel::Error), SUCCESS);
+        assert_eq!(
+            exit_code(&warnings_only, &FailOnLevel::Warn),
+            FINDINGS_PRESENT
+        );
+        assert_eq!(exit_code(&info_only, &FailOnLevel::Warn), SUCCESS);
+        assert_eq!(exit_code(&info_only, &FailOnLevel::Info), FINDINGS_PRESENT);
+        assert_eq!(exit_code(&noisy, &FailOnLevel::None), SUCCESS);
+    }
+}

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod exit_codes;
+mod fail_policy;
 mod report_diff;
 mod report_json;
 mod report_text;
@@ -11,17 +12,24 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::process;
 
-use maximus_checks::audit_project;
+use maximus_checks::{audit_project_with_config_root, registered_check_ids};
 use maximus_core::{
-    apply_fixes, preview_fixes, select_fix_plans, select_planned_fixes, AuditResult, FixPlan,
-    FixSelector,
+    apply_fixes, load_maximus_config, preview_fixes, select_fix_plans, select_planned_fixes,
+    AuditResult, FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
 };
 
 use crate::args::{parse_args, ArgsError, Flags};
 
+#[derive(Debug, Clone)]
+struct ResolvedConfig {
+    config: MaximusConfig,
+    ignore_root: std::path::PathBuf,
+}
+
 #[derive(Debug)]
 enum CliError {
     Args(ArgsError),
+    Config(LoadConfigError),
     Io(io::Error),
     Json(serde_json::Error),
     InvalidArguments(String),
@@ -32,11 +40,15 @@ impl Display for CliError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Args(error) => write!(f, "{error}"),
+            Self::Config(error) => write!(f, "{error}"),
             Self::Io(error) => write!(f, "{error}"),
             Self::Json(error) => write!(f, "{error}"),
             Self::InvalidArguments(message) => write!(f, "{message}"),
             Self::UnknownCommand(command) => {
-                write!(f, "Unknown command \"{command}\". Run \"maximus help\" for usage.")
+                write!(
+                    f,
+                    "Unknown command \"{command}\". Run \"maximus help\" for usage."
+                )
             }
         }
     }
@@ -53,6 +65,12 @@ impl From<ArgsError> for CliError {
 impl From<io::Error> for CliError {
     fn from(value: io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+impl From<LoadConfigError> for CliError {
+    fn from(value: LoadConfigError) -> Self {
+        Self::Config(value)
     }
 }
 
@@ -80,29 +98,43 @@ where
     S: Into<std::ffi::OsString>,
 {
     let parsed = parse_args(argv)?;
-    validate_command_flags(parsed.command.as_deref(), &parsed.flags)?;
+    let show_default_help = parsed.command.is_none() && parsed.flags == Flags::default();
 
-    if parsed.command.is_none()
-        || parsed.command.as_deref() == Some("help")
-        || parsed.flags.help
-    {
+    if show_default_help || parsed.command.as_deref() == Some("help") || parsed.flags.help {
         println!("{}", report_text::format_help());
         return Ok(exit_codes::SUCCESS);
     }
 
+    validate_command_flags(parsed.command.as_deref(), &parsed.flags)?;
+
+    if !matches!(
+        parsed.command.as_deref(),
+        Some("audit") | Some("doctor") | Some("fix")
+    ) {
+        return Err(CliError::UnknownCommand(
+            parsed.command.as_deref().unwrap_or_default().to_string(),
+        ));
+    }
+
     let target_dir = resolve_target_dir(parsed.args.first().map(|value| value.as_os_str()))?;
+    let config = resolve_effective_config(&target_dir, &parsed.flags)?;
 
     match parsed.command.as_deref() {
-        Some("audit") => run_audit_command(&target_dir, &parsed.flags),
-        Some("doctor") => run_doctor_command(&target_dir, &parsed.flags),
-        Some("fix") => run_fix_command(&target_dir, &parsed.flags),
+        Some("audit") => run_audit_command(&target_dir, &parsed.flags, &config),
+        Some("doctor") => run_doctor_command(&target_dir, &parsed.flags, &config),
+        Some("fix") => run_fix_command(&target_dir, &parsed.flags, &config),
         Some(command) => Err(CliError::UnknownCommand(command.to_string())),
         None => Ok(exit_codes::SUCCESS),
     }
 }
 
-fn run_audit_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
-    let audited = audit_project(target_dir)?;
+fn run_audit_command(
+    target_dir: &std::path::Path,
+    flags: &Flags,
+    resolved: &ResolvedConfig,
+) -> Result<i32, CliError> {
+    let audited =
+        audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
 
     if flags.json {
         println!("{}", report_json::render_audit_result(&audited.result)?);
@@ -110,11 +142,24 @@ fn run_audit_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32,
         println!("{}", report_text::format_audit_report(&audited.result));
     }
 
-    Ok(exit_codes::audit_exit_code(&audited.result.summary))
+    Ok(fail_policy::exit_code(
+        &audited.result.summary,
+        resolved
+            .config
+            .report
+            .fail_on
+            .as_ref()
+            .unwrap_or(&FailOnLevel::Warn),
+    ))
 }
 
-fn run_doctor_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
-    let audited = audit_project(target_dir)?;
+fn run_doctor_command(
+    target_dir: &std::path::Path,
+    flags: &Flags,
+    resolved: &ResolvedConfig,
+) -> Result<i32, CliError> {
+    let audited =
+        audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
 
     if flags.json {
         println!("{}", report_json::render_audit_result(&audited.result)?);
@@ -122,11 +167,24 @@ fn run_doctor_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32
         println!("{}", report_text::format_doctor_report(&audited.result));
     }
 
-    Ok(exit_codes::audit_exit_code(&audited.result.summary))
+    Ok(fail_policy::exit_code(
+        &audited.result.summary,
+        resolved
+            .config
+            .report
+            .fail_on
+            .as_ref()
+            .unwrap_or(&FailOnLevel::Warn),
+    ))
 }
 
-fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, CliError> {
-    let initial = audit_project(target_dir)?;
+fn run_fix_command(
+    target_dir: &std::path::Path,
+    flags: &Flags,
+    resolved: &ResolvedConfig,
+) -> Result<i32, CliError> {
+    let initial =
+        audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
     if initial.planned_fixes.len() != initial.result.fixes.len() {
         return Err(CliError::Io(io::Error::new(
             io::ErrorKind::Unsupported,
@@ -159,7 +217,7 @@ fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, C
     let final_result = if flags.dry_run {
         selected_initial.clone()
     } else {
-        audit_project(target_dir)?.result
+        audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?.result
     };
 
     if flags.json {
@@ -197,7 +255,79 @@ fn run_fix_command(target_dir: &std::path::Path, flags: &Flags) -> Result<i32, C
         );
     }
 
-    Ok(exit_codes::fix_exit_code(&final_result.summary))
+    Ok(fail_policy::exit_code(
+        &final_result.summary,
+        resolved
+            .config
+            .report
+            .fail_on
+            .as_ref()
+            .unwrap_or(&FailOnLevel::Warn),
+    ))
+}
+
+fn resolve_effective_config(
+    target_dir: &std::path::Path,
+    flags: &Flags,
+) -> Result<ResolvedConfig, CliError> {
+    let loaded = load_maximus_config(target_dir)?;
+    let ignore_root = loaded
+        .as_ref()
+        .and_then(|loaded| loaded.path.parent().map(std::path::Path::to_path_buf))
+        .unwrap_or_else(|| target_dir.to_path_buf());
+    let mut config = loaded.map(|loaded| loaded.config).unwrap_or_default();
+
+    validate_check_ids("only", &config.checks.only)?;
+    validate_check_ids("skip", &config.checks.skip)?;
+
+    if flags.only_checks.is_some() || flags.skip_checks.is_some() {
+        config.checks = maximus_core::CheckFilterConfig::default();
+    }
+
+    if let Some(only_checks) = &flags.only_checks {
+        config.checks.only = only_checks.clone();
+    }
+    if let Some(skip_checks) = &flags.skip_checks {
+        config.checks.skip = skip_checks.clone();
+    }
+    if let Some(fail_on) = &flags.fail_on {
+        config.report.fail_on = Some(parse_fail_on_level(fail_on)?);
+    }
+
+    validate_check_ids("only", &config.checks.only)?;
+    validate_check_ids("skip", &config.checks.skip)?;
+
+    Ok(ResolvedConfig {
+        config,
+        ignore_root,
+    })
+}
+
+fn parse_fail_on_level(value: &str) -> Result<FailOnLevel, CliError> {
+    match value {
+        "error" => Ok(FailOnLevel::Error),
+        "warn" => Ok(FailOnLevel::Warn),
+        "info" => Ok(FailOnLevel::Info),
+        "none" => Ok(FailOnLevel::None),
+        _ => Err(CliError::InvalidArguments(format!(
+            "Unknown fail-on level \"{value}\". Use one of: error, warn, info, none."
+        ))),
+    }
+}
+
+fn validate_check_ids(source: &str, ids: &[String]) -> Result<(), CliError> {
+    let known_ids = registered_check_ids();
+
+    for id in ids {
+        if !known_ids.contains(&id.as_str()) {
+            return Err(CliError::InvalidArguments(format!(
+                "Unknown check id \"{id}\" in {source}. Use one of: {}.",
+                known_ids.join(", ")
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_command_flags(command: Option<&str>, flags: &Flags) -> Result<(), CliError> {

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -11,9 +11,9 @@ pub fn format_help() -> String {
         "Bring order to chaotic configs.",
         "",
         "Usage",
-        "  maximus audit [path] [--json]",
-        "  maximus doctor [path] [--json]",
-        "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+        "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+        "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
         "  maximus help",
     ]
     .join("\n")
@@ -28,14 +28,19 @@ pub fn format_audit_report(result: &AuditResult) -> String {
     lines.push(format!("Status: {}", result.summary.status));
     lines.push(format!(
         "Findings: {} error, {} warnings, {} info",
-        result.summary.blocking_findings, result.summary.warning_findings, result.summary.info_findings
+        result.summary.blocking_findings,
+        result.summary.warning_findings,
+        result.summary.info_findings
     ));
     lines.push(format!(
         "Fixes available: {}",
         result.summary.fixes_available
     ));
     lines.push(String::new());
-    lines.push(format!("Structure: {}", describe_structure(&result.structure)));
+    lines.push(format!(
+        "Structure: {}",
+        describe_structure(&result.structure)
+    ));
 
     if result.findings.is_empty() {
         lines.push(String::new());
@@ -64,7 +69,11 @@ pub fn format_doctor_report(result: &AuditResult) -> String {
         .iter()
         .filter(|finding| !finding.fixable)
         .count();
-    let fixable_findings = result.findings.iter().filter(|finding| finding.fixable).count();
+    let fixable_findings = result
+        .findings
+        .iter()
+        .filter(|finding| finding.fixable)
+        .count();
 
     lines.push("Maximus doctor".to_string());
     lines.push(format!("Target: {}", display_path(&result.root_dir)));
@@ -179,7 +188,9 @@ pub fn format_fix_result(
     lines.push(String::new());
     lines.push(format!(
         "Post-check: {} error, {} warnings, {} info",
-        result.summary.blocking_findings, result.summary.warning_findings, result.summary.info_findings
+        result.summary.blocking_findings,
+        result.summary.warning_findings,
+        result.summary.info_findings
     ));
 
     if result.findings.is_empty() {
@@ -198,7 +209,11 @@ fn format_findings(result: &AuditResult) -> Vec<String> {
     let mut lines = Vec::new();
 
     for finding in &result.findings {
-        lines.push(format!("- [{}] {}", severity_label(&finding.severity), finding.title));
+        lines.push(format!(
+            "- [{}] {}",
+            severity_label(&finding.severity),
+            finding.title
+        ));
 
         if let Some(file) = &finding.file {
             lines.push(format!(
@@ -320,9 +335,9 @@ mod tests {
                 "Bring order to chaotic configs.",
                 "",
                 "Usage",
-                "  maximus audit [path] [--json]",
-                "  maximus doctor [path] [--json]",
-                "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+                "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+                "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
                 "  maximus help",
             ]
             .join("\n")

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -22,9 +22,9 @@ fn no_args_prints_help() {
             "Bring order to chaotic configs.",
             "",
             "Usage",
-            "  maximus audit [path] [--json]",
-            "  maximus doctor [path] [--json]",
-            "  maximus fix [path] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+            "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+            "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
+            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
             "  maximus help",
             "",
         ]
@@ -42,7 +42,9 @@ fn help_subcommand_prints_usage() {
     assert!(output.status.success());
     assert!(String::from_utf8(output.stdout)
         .expect("stdout should be utf8")
-        .contains("maximus audit [path] [--json]"));
+        .contains(
+            "maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]"
+        ));
 }
 
 #[test]
@@ -135,14 +137,24 @@ fn fix_reference_env_json_matches_js_cli_output_and_status() {
 
     assert_eq!(rust_output.status.code(), js_output.status.code());
 
-    let rust_json: Value = serde_json::from_slice(&rust_output.stdout).expect("rust json should parse");
+    let rust_json: Value =
+        serde_json::from_slice(&rust_output.stdout).expect("rust json should parse");
     let js_json: Value = serde_json::from_slice(&js_output.stdout).expect("js json should parse");
 
     assert_eq!(rust_json["dryRun"], js_json["dryRun"]);
     assert_eq!(rust_json["applied"][0]["outcome"], "created");
-    assert_eq!(rust_json["applied"][0]["outcome"], js_json["applied"][0]["outcome"]);
-    assert_eq!(rust_json["initial"]["summary"]["status"], js_json["initial"]["summary"]["status"]);
-    assert_eq!(rust_json["final"]["summary"]["status"], js_json["final"]["summary"]["status"]);
+    assert_eq!(
+        rust_json["applied"][0]["outcome"],
+        js_json["applied"][0]["outcome"]
+    );
+    assert_eq!(
+        rust_json["initial"]["summary"]["status"],
+        js_json["initial"]["summary"]["status"]
+    );
+    assert_eq!(
+        rust_json["final"]["summary"]["status"],
+        js_json["final"]["summary"]["status"]
+    );
 }
 
 #[test]
@@ -205,6 +217,25 @@ fn fix_dry_run_json_keeps_js_top_level_contract() {
 fn unknown_command_uses_prefixed_stderr_and_exit_code_two() {
     let output = maximus_bin()
         .arg("foobar")
+        .output()
+        .expect("unknown command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Unknown command \"foobar\". Run \"maximus help\" for usage.\n"
+    );
+}
+
+#[test]
+fn unknown_command_does_not_load_broken_config() {
+    let fixture = tempdir().expect("fixture should exist");
+    let config_path = fixture.path().join("maximus.config.json");
+    fs::write(&config_path, r#"{ "checks": { "only": ["env",] }"#)
+        .expect("broken config should write");
+
+    let output = maximus_bin()
+        .args(["foobar", fixture.path().to_string_lossy().as_ref()])
         .output()
         .expect("unknown command should run");
 

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -1,0 +1,681 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn maximus_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+#[test]
+fn root_maximus_config_applies_check_defaults() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert!(finding_field(
+        findings[0]
+            .as_object()
+            .expect("finding should be an object"),
+        "id"
+    )
+    .starts_with("env-mismatch:"));
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "env"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn config_applies_through_symlinked_target_path() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let real_root = fixture.path().join("real");
+    let real_target = real_root.join("apps/web");
+    let alias_target = fixture.path().join("alias-web");
+    write_mixed_fixture(&real_target);
+    write(
+        real_root.join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+    std::os::unix::fs::symlink(&real_target, &alias_target).expect("symlink should create");
+
+    let output = maximus_bin()
+        .args(["audit", alias_target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "env"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn root_relative_ignore_applies_through_symlinked_nested_target() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let real_root = fixture.path().join("real");
+    let real_target = real_root.join("packages/web");
+    let alias_target = fixture.path().join("web-alias");
+    write_tsconfig_conflict_fixture(&real_target.join("generated"));
+    write(
+        real_root.join("maximus.config.json"),
+        r#"{ "ignore": ["packages/web/generated"], "checks": { "only": ["tsconfig"] } }"#,
+    );
+    std::os::unix::fs::symlink(&real_target, &alias_target).expect("symlink should create");
+
+    let output = maximus_bin()
+        .args(["audit", alias_target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "root-relative ignore should suppress nested symlink findings: {findings:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn root_relative_lockfiles_ignore_applies_through_symlinked_nested_target() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let real_root = fixture.path().join("real");
+    let real_target = real_root.join("packages/web");
+    let alias_target = fixture.path().join("web-alias");
+    write(real_target.join("ignored/package-lock.json"), "{}\n");
+    write(
+        real_target.join("ignored/yarn.lock"),
+        "# yarn lockfile v1\n",
+    );
+    write(
+        real_root.join("maximus.config.json"),
+        r#"{ "ignore": ["packages/web/ignored"], "checks": { "only": ["lockfiles"] } }"#,
+    );
+    std::os::unix::fs::symlink(&real_target, &alias_target).expect("symlink should create");
+
+    let output = maximus_bin()
+        .args(["audit", alias_target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "root-relative ignore should suppress lockfile findings via symlink target: {findings:?}"
+    );
+}
+
+#[test]
+fn direct_ignored_target_path_produces_no_tsconfig_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let target = fixture.path().join("packages/web/generated");
+    write_tsconfig_conflict_fixture(&target);
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignore": ["packages/web/generated"], "checks": { "only": ["tsconfig"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignored direct target should suppress tsconfig findings: {findings:?}"
+    );
+}
+
+#[test]
+fn direct_ignored_target_path_produces_no_lockfile_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let target = fixture.path().join("packages/web/generated");
+    write(target.join("package-lock.json"), "{}\n");
+    write(target.join("yarn.lock"), "# yarn lockfile v1\n");
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignore": ["packages/web/generated"], "checks": { "only": ["lockfiles"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignored direct target should suppress lockfile findings: {findings:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn lexical_mount_config_does_not_override_realpath_config() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let real_root = fixture.path().join("real");
+    let real_target = real_root.join("apps/web");
+    let mount_root = fixture.path().join("mount");
+    let alias_target = mount_root.join("web");
+    write_mixed_fixture(&real_target);
+    write(
+        real_root.join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+    write(
+        mount_root.join("maximus.config.json"),
+        r#"{ "checks": { "only": ["tsconfig"] } }"#,
+    );
+    fs::create_dir_all(&mount_root).expect("mount dir should exist");
+    std::os::unix::fs::symlink(&real_target, &alias_target).expect("symlink should create");
+
+    let output = maximus_bin()
+        .args(["audit", alias_target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "env"
+    );
+}
+
+#[test]
+fn nested_maximusrc_takes_precedence_for_nested_targets() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let nested = fixture.path().join("apps/web");
+    write_mixed_fixture(&nested);
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+    write(
+        nested.join(".maximusrc.json"),
+        r#"{ "checks": { "only": ["tsconfig"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", nested.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "tsconfig"
+    );
+    assert!(finding_field(
+        findings[0]
+            .as_object()
+            .expect("finding should be an object"),
+        "id"
+    )
+    .starts_with("tsconfig-import-conflict:"));
+}
+
+#[test]
+fn cli_only_flag_overrides_config_defaults() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "tsconfig"
+    );
+}
+
+#[test]
+fn cli_only_flag_clears_config_skip_filters() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "checks": { "skip": ["env"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "env"
+    );
+}
+
+#[test]
+fn cli_skip_flag_clears_config_only_filters() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "checks": { "only": ["env"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--skip",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "category"
+        ),
+        "tsconfig"
+    );
+}
+
+#[test]
+fn config_glob_ignore_and_severity_overrides_are_applied() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_env_fixture(fixture.path());
+    write_tsconfig_conflict_fixture(&fixture.path().join("packages/web/generated"));
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"
+        {
+          "ignore": ["**/generated"],
+          "severity": {
+            "env-mismatch": "error"
+          }
+        }
+        "#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert!(finding_field(
+        findings[0]
+            .as_object()
+            .expect("finding should be an object"),
+        "id"
+    )
+    .starts_with("env-mismatch:"));
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "severity"
+        ),
+        "error"
+    );
+}
+
+#[test]
+fn config_ignore_applies_to_lockfiles_check_traversal() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(fixture.path().join("ignored/package-lock.json"), "{}\n");
+    write(
+        fixture.path().join("ignored/yarn.lock"),
+        "# yarn lockfile v1\n",
+    );
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignore": ["ignored"], "checks": { "only": ["lockfiles"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignored lockfiles should not produce findings: {findings:?}"
+    );
+}
+
+#[test]
+fn config_fail_on_can_be_overridden_by_cli() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_env_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "report": { "failOn": "info" } }"#,
+    );
+
+    let config_output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+    assert_eq!(config_output.status.code(), Some(1), "{config_output:?}");
+
+    let cli_override_output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--fail-on",
+            "none",
+            "--json",
+        ])
+        .output()
+        .expect("audit override should run");
+    assert_eq!(
+        cli_override_output.status.code(),
+        Some(0),
+        "{cli_override_output:?}"
+    );
+}
+
+#[test]
+fn empty_severity_prefix_is_ignored() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"
+        {
+          "severity": {
+            "": "error"
+          },
+          "report": {
+            "failOn": "error"
+          }
+        }
+        "#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "severity"
+        ),
+        "warn"
+    );
+}
+
+#[test]
+fn broken_config_is_reported_as_cli_error() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let config_path = fixture.path().join("maximus.config.json");
+    write(&config_path, r#"{ "checks": { "only": ["env",] }"#);
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref()])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("Maximus failed:"));
+    assert!(stderr.contains(&config_path.to_string_lossy().to_string()));
+}
+
+#[test]
+fn empty_cli_check_filters_are_reported_as_cli_errors() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+
+    for flag in ["--only", "--skip"] {
+        let output = maximus_bin()
+            .args([
+                "audit",
+                fixture.path().to_string_lossy().as_ref(),
+                flag,
+                " , ",
+            ])
+            .output()
+            .expect("audit should run");
+
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+        assert!(stderr.contains(&format!("Option \"{flag}\" requires a non-empty value.")));
+    }
+}
+
+#[test]
+fn cli_filters_do_not_hide_invalid_config_check_ids() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_mixed_fixture(fixture.path());
+
+    for (config_body, cli_args, expected_fragment) in [
+        (
+            r#"{ "checks": { "only": ["not-a-real-check"] } }"#,
+            vec!["--skip", "env"],
+            "Unknown check id \"not-a-real-check\" in only.",
+        ),
+        (
+            r#"{ "checks": { "skip": ["not-a-real-check"] } }"#,
+            vec!["--only", "env"],
+            "Unknown check id \"not-a-real-check\" in skip.",
+        ),
+    ] {
+        write(fixture.path().join("maximus.config.json"), config_body);
+
+        let output = maximus_bin()
+            .args(["audit", fixture.path().to_string_lossy().as_ref()])
+            .args(cli_args)
+            .output()
+            .expect("audit should run");
+
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+        assert!(stderr.contains(expected_fragment), "{stderr}");
+    }
+}
+
+fn write_mixed_fixture(root: &Path) {
+    write_env_fixture(root);
+    write_tsconfig_conflict_fixture(root);
+}
+
+fn write_env_fixture(root: &Path) {
+    write(root.join(".env"), "SHARED=base\n");
+    write(root.join(".env.local"), "SHARED=local\n");
+    write(root.join(".env.example"), "SHARED=\n");
+}
+
+fn write_tsconfig_conflict_fixture(root: &Path) {
+    write(
+        root.join("package.json"),
+        r##"{"name":"fixture","imports":{"#app/*":"./src/runtime/*"}}"##,
+    );
+    write(
+        root.join("tsconfig.json"),
+        r##"
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "#app/*": ["./src/lib/*"]
+            }
+          }
+        }
+        "##,
+    );
+    write(root.join("src/runtime/index.ts"), "export {};\n");
+    write(root.join("src/lib/index.ts"), "export {};\n");
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn parse_json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("stdout should be valid json")
+}
+
+fn finding_field<'a>(finding: &'a serde_json::Map<String, Value>, key: &str) -> &'a str {
+    finding
+        .get(key)
+        .and_then(Value::as_str)
+        .expect("finding field should be a string")
+}

--- a/crates/maximus-cli/tests/fix_selection_and_diff.rs
+++ b/crates/maximus-cli/tests/fix_selection_and_diff.rs
@@ -187,10 +187,12 @@ fn fix_only_flags_are_rejected_for_help_command() {
         .output()
         .expect("command should run");
 
-    assert_eq!(output.status.code(), Some(2));
-    assert_eq!(
-        String::from_utf8(output.stderr).expect("stderr should be utf8"),
-        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(
+        String::from_utf8(output.stdout)
+            .expect("stdout should be utf8")
+            .contains("Usage\n  maximus audit [path]")
     );
 }
 
@@ -201,10 +203,12 @@ fn fix_only_flags_are_rejected_for_fix_help_command() {
         .output()
         .expect("command should run");
 
-    assert_eq!(output.status.code(), Some(2));
-    assert_eq!(
-        String::from_utf8(output.stderr).expect("stderr should be utf8"),
-        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(
+        String::from_utf8(output.stdout)
+            .expect("stdout should be utf8")
+            .contains("Usage\n  maximus audit [path]")
     );
 }
 
@@ -215,10 +219,12 @@ fn fix_only_flags_are_rejected_when_help_flag_precedes_fix_command() {
         .output()
         .expect("command should run");
 
-    assert_eq!(output.status.code(), Some(2));
-    assert_eq!(
-        String::from_utf8(output.stderr).expect("stderr should be utf8"),
-        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(
+        String::from_utf8(output.stdout)
+            .expect("stdout should be utf8")
+            .contains("Usage\n  maximus audit [path]")
     );
 }
 

--- a/crates/maximus-core/src/config.rs
+++ b/crates/maximus-core/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -106,12 +106,23 @@ pub fn load_maximus_config(start_dir: &Path) -> Result<Option<LoadedConfig>, Loa
 
 pub fn find_maximus_config_path(start_dir: &Path) -> io::Result<Option<PathBuf>> {
     let start_dir = std::path::absolute(start_dir)?;
+    let mut start_dirs = Vec::new();
+    if let Ok(canonical_start_dir) = std::fs::canonicalize(&start_dir) {
+        start_dirs.push(canonical_start_dir);
+    }
+    start_dirs.push(start_dir.clone());
+    let mut searched_directories = BTreeSet::new();
 
-    for directory in start_dir.ancestors() {
-        for file_name in CONFIG_FILE_NAMES {
-            let candidate = directory.join(file_name);
-            if candidate.is_file() {
-                return Ok(Some(candidate));
+    for start_dir in start_dirs {
+        for directory in start_dir.ancestors() {
+            if !searched_directories.insert(directory.to_path_buf()) {
+                continue;
+            }
+            for file_name in CONFIG_FILE_NAMES {
+                let candidate = directory.join(file_name);
+                if candidate.is_file() {
+                    return Ok(Some(candidate));
+                }
             }
         }
     }

--- a/crates/maximus-core/src/discover.rs
+++ b/crates/maximus-core/src/discover.rs
@@ -29,14 +29,53 @@ const IGNORED_DIRECTORIES: &[&str] = &[
     "tmp",
 ];
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IgnorePattern {
+    Component(String),
+    Glob(Vec<String>),
+}
+
 pub fn discover_project(root_dir: impl AsRef<Path>) -> io::Result<ProjectSnapshot> {
     let root_dir = root_dir.as_ref().to_path_buf();
+    discover_project_with_ignore(&root_dir, &[])
+}
+
+pub fn discover_project_with_ignore(
+    root_dir: impl AsRef<Path>,
+    ignored_patterns: &[String],
+) -> io::Result<ProjectSnapshot> {
+    let root_dir = root_dir.as_ref().to_path_buf();
+    discover_project_with_ignore_root(&root_dir, ignored_patterns, &root_dir)
+}
+
+pub fn discover_project_with_ignore_root(
+    root_dir: impl AsRef<Path>,
+    ignored_patterns: &[String],
+    ignore_root: impl AsRef<Path>,
+) -> io::Result<ProjectSnapshot> {
+    let root_dir = root_dir.as_ref().to_path_buf();
+    let ignore_root = ignore_root.as_ref().to_path_buf();
+    let ignored_patterns = ignored_patterns
+        .iter()
+        .filter_map(|pattern| normalize_ignore_pattern(pattern))
+        .collect::<Vec<_>>();
+
+    if is_ignored_path_from_root(&ignore_root, &root_dir, &ignored_patterns) {
+        return Ok(ProjectSnapshot {
+            root_dir,
+            files: Vec::new(),
+            directories: Vec::new(),
+            files_by_kind: IndexMap::new(),
+            package_files: Vec::new(),
+        });
+    }
+
     let mut files = Vec::new();
 
     let walker = WalkDir::new(&root_dir)
         .sort_by_file_name()
         .into_iter()
-        .filter_entry(|entry| should_visit(entry));
+        .filter_entry(|entry| should_visit(&ignore_root, entry, &ignored_patterns));
 
     for entry in walker {
         let entry = entry?;
@@ -54,6 +93,9 @@ pub fn discover_project(root_dir: impl AsRef<Path>) -> io::Result<ProjectSnapsho
             .map(Path::to_path_buf)
             .unwrap_or_else(|| root_dir.clone());
         let relative_path = relative_string(&root_dir, &path);
+        if is_ignored_path_from_root(&ignore_root, &path, &ignored_patterns) {
+            continue;
+        }
 
         files.push(ProjectFile {
             kind,
@@ -118,6 +160,27 @@ pub fn discover_project(root_dir: impl AsRef<Path>) -> io::Result<ProjectSnapsho
     })
 }
 
+pub fn is_ignored_project_path(
+    root_dir: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    ignored_patterns: &[String],
+) -> bool {
+    is_ignored_project_path_from_root(root_dir, target, ignored_patterns)
+}
+
+pub fn is_ignored_project_path_from_root(
+    ignore_root: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    ignored_patterns: &[String],
+) -> bool {
+    let ignored_patterns = ignored_patterns
+        .iter()
+        .filter_map(|pattern| normalize_ignore_pattern(pattern))
+        .collect::<Vec<_>>();
+
+    is_ignored_path_from_root(ignore_root.as_ref(), target.as_ref(), &ignored_patterns)
+}
+
 pub fn get_files(project: &ProjectSnapshot, kind: FileKind) -> &[ProjectFile] {
     project
         .files_by_kind
@@ -142,12 +205,174 @@ pub fn find_nearest_package_file<'a>(
     })
 }
 
-fn should_visit(entry: &DirEntry) -> bool {
+fn should_visit(ignore_root: &Path, entry: &DirEntry, ignored_patterns: &[IgnorePattern]) -> bool {
     if entry.depth() == 0 || !entry.file_type().is_dir() {
         return true;
     }
 
-    !IGNORED_DIRECTORIES.contains(&entry.file_name().to_string_lossy().as_ref())
+    let file_name = entry.file_name().to_string_lossy();
+    if IGNORED_DIRECTORIES.contains(&file_name.as_ref()) {
+        return false;
+    }
+
+    !is_ignored_path_from_root(ignore_root, entry.path(), ignored_patterns)
+}
+
+fn normalize_ignore_pattern(pattern: &str) -> Option<IgnorePattern> {
+    let trimmed = pattern.trim().replace('\\', "/");
+    let trimmed = trimmed.trim_start_matches("./").trim_matches('/');
+
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if !trimmed.contains('/') && !contains_glob_meta(trimmed) {
+        return Some(IgnorePattern::Component(trimmed.to_string()));
+    }
+
+    Some(IgnorePattern::Glob(
+        trimmed
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+    ))
+}
+
+fn contains_glob_meta(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?')
+}
+
+fn is_ignored_relative_path(relative_path: &str, ignored_patterns: &[IgnorePattern]) -> bool {
+    if ignored_patterns.is_empty() {
+        return false;
+    }
+
+    let normalized_path = relative_path.replace('\\', "/");
+    let path_segments = normalized_path
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>();
+
+    ignored_patterns.iter().any(|pattern| match pattern {
+        IgnorePattern::Component(component) => path_segments
+            .iter()
+            .any(|segment| *segment == component.as_str()),
+        IgnorePattern::Glob(pattern_segments) => {
+            glob_path_matches(pattern_segments, &path_segments)
+        }
+    })
+}
+
+fn is_ignored_path_from_root(
+    ignore_root: &Path,
+    target: &Path,
+    ignored_patterns: &[IgnorePattern],
+) -> bool {
+    if ignored_patterns.is_empty() {
+        return false;
+    }
+    if relative_matches(ignore_root, target, ignored_patterns) {
+        return true;
+    }
+
+    let Ok(canonical_ignore_root) = std::fs::canonicalize(ignore_root) else {
+        return false;
+    };
+    let Ok(canonical_target) = std::fs::canonicalize(target) else {
+        return false;
+    };
+
+    relative_matches(&canonical_ignore_root, &canonical_target, ignored_patterns)
+}
+
+fn relative_matches(ignore_root: &Path, target: &Path, ignored_patterns: &[IgnorePattern]) -> bool {
+    let relative_path = relative_string(ignore_root, target);
+    is_ignored_relative_path(&relative_path, ignored_patterns)
+}
+
+fn glob_path_matches(pattern_segments: &[String], path_segments: &[&str]) -> bool {
+    let mut memo = vec![vec![None; path_segments.len() + 1]; pattern_segments.len() + 1];
+    glob_path_matches_from(pattern_segments, path_segments, 0, 0, &mut memo)
+}
+
+fn glob_path_matches_from(
+    pattern_segments: &[String],
+    path_segments: &[&str],
+    pattern_index: usize,
+    path_index: usize,
+    memo: &mut [Vec<Option<bool>>],
+) -> bool {
+    if let Some(result) = memo[pattern_index][path_index] {
+        return result;
+    }
+
+    let result = if pattern_index == pattern_segments.len() {
+        path_index == path_segments.len()
+    } else if pattern_segments[pattern_index] == "**" {
+        glob_path_matches_from(
+            pattern_segments,
+            path_segments,
+            pattern_index + 1,
+            path_index,
+            memo,
+        ) || (path_index < path_segments.len()
+            && glob_path_matches_from(
+                pattern_segments,
+                path_segments,
+                pattern_index,
+                path_index + 1,
+                memo,
+            ))
+    } else {
+        path_index < path_segments.len()
+            && glob_segment_matches(&pattern_segments[pattern_index], path_segments[path_index])
+            && glob_path_matches_from(
+                pattern_segments,
+                path_segments,
+                pattern_index + 1,
+                path_index + 1,
+                memo,
+            )
+    };
+
+    memo[pattern_index][path_index] = Some(result);
+    result
+}
+
+fn glob_segment_matches(pattern: &str, value: &str) -> bool {
+    let pattern = pattern.chars().collect::<Vec<_>>();
+    let value = value.chars().collect::<Vec<_>>();
+    let mut memo = vec![vec![None; value.len() + 1]; pattern.len() + 1];
+
+    glob_segment_matches_from(&pattern, &value, 0, 0, &mut memo)
+}
+
+fn glob_segment_matches_from(
+    pattern: &[char],
+    value: &[char],
+    pattern_index: usize,
+    value_index: usize,
+    memo: &mut [Vec<Option<bool>>],
+) -> bool {
+    if let Some(result) = memo[pattern_index][value_index] {
+        return result;
+    }
+
+    let result = if pattern_index == pattern.len() {
+        value_index == value.len()
+    } else if pattern[pattern_index] == '*' {
+        glob_segment_matches_from(pattern, value, pattern_index + 1, value_index, memo)
+            || (value_index < value.len()
+                && glob_segment_matches_from(pattern, value, pattern_index, value_index + 1, memo))
+    } else {
+        value_index < value.len()
+            && (pattern[pattern_index] == '?' || pattern[pattern_index] == value[value_index])
+            && glob_segment_matches_from(pattern, value, pattern_index + 1, value_index + 1, memo)
+    };
+
+    memo[pattern_index][value_index] = Some(result);
+    result
 }
 
 fn relative_string(root_dir: &Path, target: &Path) -> String {

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -4,30 +4,34 @@ pub mod baseline;
 pub mod config;
 pub mod discover;
 pub mod env_parser;
-pub mod fixes;
 pub mod findings;
+pub mod fixes;
 pub mod fs;
 pub mod jsonc;
 pub mod models;
 mod text_order;
 
-pub use discover::{discover_project, find_nearest_package_file, get_directories, get_files};
 pub use config::{
-    find_maximus_config_path, load_maximus_config, CheckFilterConfig, ConfigSeverity,
-    FailOnLevel, LoadedConfig, LoadConfigError, MaximusConfig, ReportConfig,
+    find_maximus_config_path, load_maximus_config, CheckFilterConfig, ConfigSeverity, FailOnLevel,
+    LoadConfigError, LoadedConfig, MaximusConfig, ReportConfig,
+};
+pub use discover::{
+    discover_project, discover_project_with_ignore, discover_project_with_ignore_root,
+    find_nearest_package_file, get_directories, get_files, is_ignored_project_path,
+    is_ignored_project_path_from_root,
 };
 pub use env_parser::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, parse_env,
     render_env_template, EnvDuplicate, EnvEntry, InvalidEnvLine, ParsedEnv,
 };
-pub use fixes::{
-    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, preview_fixes,
-    select_fix_plans, select_planned_fixes, AppliedFix, FixFilePreview, FixOperation,
-    FixSelector, PlannedFix, PreviewedFix,
-};
 pub use findings::{
     make_finding, serialize_audit_result, sort_findings, summarize_findings, unique_fixes,
     FindingInput, SerializableAuditResult, SerializableFinding,
+};
+pub use fixes::{
+    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, preview_fixes,
+    select_fix_plans, select_planned_fixes, AppliedFix, FixFilePreview, FixOperation, FixSelector,
+    PlannedFix, PreviewedFix,
 };
 pub use fs::{path_exists, read_text_if_exists, write_text};
 pub use jsonc::{parse_jsonc, ParseJsoncError};

--- a/crates/maximus-core/tests/config_loader.rs
+++ b/crates/maximus-core/tests/config_loader.rs
@@ -1,8 +1,6 @@
 use std::fs;
 
-use maximus_core::{
-    find_maximus_config_path, load_maximus_config, ConfigSeverity, FailOnLevel,
-};
+use maximus_core::{find_maximus_config_path, load_maximus_config, ConfigSeverity, FailOnLevel};
 use tempfile::tempdir;
 
 #[test]
@@ -10,12 +8,68 @@ fn finds_root_maximus_config_when_searching_nested_directory() {
     let temp = tempdir().expect("temp dir should exist");
     let nested = temp.path().join("apps/web");
     fs::create_dir_all(&nested).expect("nested dir should exist");
-    fs::write(temp.path().join("maximus.config.json"), "{ \"ignore\": [\"dist\"] }")
-        .expect("config should write");
+    fs::write(
+        temp.path().join("maximus.config.json"),
+        "{ \"ignore\": [\"dist\"] }",
+    )
+    .expect("config should write");
 
     let found = find_maximus_config_path(&nested).expect("search should succeed");
+    let expected = fs::canonicalize(temp.path().join("maximus.config.json"))
+        .expect("config should canonicalize");
 
-    assert_eq!(found, Some(temp.path().join("maximus.config.json")));
+    assert_eq!(found, Some(expected));
+}
+
+#[cfg(unix)]
+#[test]
+fn finds_config_through_symlinked_start_directory() {
+    let temp = tempdir().expect("temp dir should exist");
+    let real_root = temp.path().join("real");
+    let nested = real_root.join("apps/web");
+    let alias_target = temp.path().join("alias-web");
+    fs::create_dir_all(&nested).expect("nested dir should exist");
+    fs::write(
+        real_root.join("maximus.config.json"),
+        "{ \"ignore\": [\"dist\"] }",
+    )
+    .expect("config should write");
+    std::os::unix::fs::symlink(&nested, &alias_target).expect("symlink should create");
+
+    let found = find_maximus_config_path(&alias_target).expect("search should succeed");
+    let expected_config = fs::canonicalize(real_root.join("maximus.config.json"))
+        .expect("config should canonicalize");
+
+    assert_eq!(found, Some(expected_config));
+}
+
+#[cfg(unix)]
+#[test]
+fn prefers_realpath_config_over_lexical_mount_config() {
+    let temp = tempdir().expect("temp dir should exist");
+    let real_root = temp.path().join("real");
+    let nested = real_root.join("apps/web");
+    let mount_root = temp.path().join("mount");
+    let alias_target = mount_root.join("web");
+    fs::create_dir_all(&nested).expect("nested dir should exist");
+    fs::create_dir_all(&mount_root).expect("mount dir should exist");
+    fs::write(
+        real_root.join("maximus.config.json"),
+        "{ \"ignore\": [\"real\"] }",
+    )
+    .expect("real config should write");
+    fs::write(
+        mount_root.join("maximus.config.json"),
+        "{ \"ignore\": [\"mount\"] }",
+    )
+    .expect("mount config should write");
+    std::os::unix::fs::symlink(&nested, &alias_target).expect("symlink should create");
+
+    let loaded = load_maximus_config(&alias_target)
+        .expect("load should succeed")
+        .expect("config should exist");
+
+    assert_eq!(loaded.config.ignore, vec!["real".to_string()]);
 }
 
 #[test]
@@ -23,10 +77,16 @@ fn prefers_nearest_config_and_then_file_name_precedence() {
     let temp = tempdir().expect("temp dir should exist");
     let nested = temp.path().join("apps/web");
     fs::create_dir_all(&nested).expect("nested dir should exist");
-    fs::write(temp.path().join("maximus.config.json"), "{ \"ignore\": [\"root\"] }")
-        .expect("root config should write");
-    fs::write(nested.join(".maximusrc.json"), "{ \"ignore\": [\"nested\"] }")
-        .expect("nested config should write");
+    fs::write(
+        temp.path().join("maximus.config.json"),
+        "{ \"ignore\": [\"root\"] }",
+    )
+    .expect("root config should write");
+    fs::write(
+        nested.join(".maximusrc.json"),
+        "{ \"ignore\": [\"nested\"] }",
+    )
+    .expect("nested config should write");
     fs::write(
         nested.join("maximus.config.json"),
         "{ \"ignore\": [\"nested-maximus\"] }",
@@ -36,8 +96,10 @@ fn prefers_nearest_config_and_then_file_name_precedence() {
     let loaded = load_maximus_config(&nested)
         .expect("load should succeed")
         .expect("config should exist");
+    let expected_path =
+        fs::canonicalize(nested.join("maximus.config.json")).expect("config should canonicalize");
 
-    assert_eq!(loaded.path, nested.join("maximus.config.json"));
+    assert_eq!(loaded.path, expected_path);
     assert_eq!(loaded.config.ignore, vec!["nested-maximus".to_string()]);
 }
 
@@ -83,8 +145,13 @@ fn parses_jsonc_shape_for_checks_severity_and_report() {
 fn returns_none_when_no_config_exists() {
     let temp = tempdir().expect("temp dir should exist");
 
-    assert_eq!(find_maximus_config_path(temp.path()).expect("search should succeed"), None);
-    assert!(load_maximus_config(temp.path()).expect("load should succeed").is_none());
+    assert_eq!(
+        find_maximus_config_path(temp.path()).expect("search should succeed"),
+        None
+    );
+    assert!(load_maximus_config(temp.path())
+        .expect("load should succeed")
+        .is_none());
 }
 
 #[test]

--- a/crates/maximus-core/tests/core_models.rs
+++ b/crates/maximus-core/tests/core_models.rs
@@ -1,9 +1,10 @@
 use maximus_core::{
-    discover_project, find_nearest_package_file, get_directories, get_files,
-    is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, make_finding,
-    parse_env, parse_jsonc, path_exists, read_text_if_exists, render_env_template,
-    serialize_audit_result, sort_findings, summarize_findings, unique_fixes, FileKind,
-    FindingInput, FixPlan, ProjectSnapshot, Severity, StructureReport,
+    discover_project, discover_project_with_ignore, discover_project_with_ignore_root,
+    find_nearest_package_file, get_directories, get_files, is_concrete_env_file_name,
+    is_template_env_file_name, looks_like_secret, make_finding, parse_env, parse_jsonc,
+    path_exists, read_text_if_exists, render_env_template, serialize_audit_result, sort_findings,
+    summarize_findings, unique_fixes, FileKind, FindingInput, FixPlan, ProjectSnapshot, Severity,
+    StructureReport,
 };
 use serde::Deserialize;
 use tempfile::TempDir;
@@ -86,7 +87,10 @@ fn parse_env_tracks_duplicates_invalid_lines_and_order() {
         parsed.values.keys().map(String::as_str).collect::<Vec<_>>(),
         vec!["API_URL", "AUTH_TOKEN"]
     );
-    assert_eq!(parsed.values["AUTH_TOKEN"].raw_value, "\"secretvalue123456\"");
+    assert_eq!(
+        parsed.values["AUTH_TOKEN"].raw_value,
+        "\"secretvalue123456\""
+    );
     assert_eq!(parsed.values["AUTH_TOKEN"].value, "secretvalue123456");
     assert_eq!(parsed.values["API_URL"].value, "https://example.com");
 }
@@ -167,10 +171,7 @@ fn discovery_includes_prettier_toml_and_finds_nearest_package() {
     );
     assert_eq!(get_files(&snapshot, FileKind::Prettier).len(), 1);
     assert!(
-        snapshot
-            .files
-            .iter()
-            .all(|file| file.name != ".env."),
+        snapshot.files.iter().all(|file| file.name != ".env."),
         "malformed .env. files should not be classified as env files"
     );
     assert!(
@@ -201,6 +202,67 @@ fn discovery_ignores_common_build_directories() {
         .all(|file| !file.relative_path.contains("node_modules")
             && !file.relative_path.contains("dist")
             && !file.relative_path.contains("target")));
+}
+
+#[test]
+fn discovery_applies_glob_ignore_patterns_to_nested_directories() {
+    let fixture = temp_fixture();
+    std::fs::create_dir_all(fixture.path().join("packages/app/generated")).unwrap();
+    std::fs::write(
+        fixture.path().join("packages/app/generated/tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":"."}}"#,
+    )
+    .unwrap();
+
+    let snapshot =
+        discover_project_with_ignore(fixture.path(), &["**/generated".to_string()]).unwrap();
+
+    assert!(snapshot
+        .files
+        .iter()
+        .all(|file| !file.relative_path.contains("/generated/")));
+}
+
+#[test]
+fn discovery_applies_glob_ignore_patterns_to_matching_files() {
+    let fixture = temp_fixture();
+    std::fs::create_dir_all(fixture.path().join("configs")).unwrap();
+    std::fs::write(
+        fixture.path().join("configs/tsconfig.generated.json"),
+        r#"{"compilerOptions":{"baseUrl":"."}}"#,
+    )
+    .unwrap();
+
+    let snapshot =
+        discover_project_with_ignore(fixture.path(), &["**/*.generated.json".to_string()]).unwrap();
+
+    assert!(snapshot
+        .files
+        .iter()
+        .all(|file| file.relative_path != "configs/tsconfig.generated.json"));
+}
+
+#[test]
+fn discovery_skips_directly_ignored_target_directory() {
+    let fixture = temp_fixture();
+    let target = fixture.path().join("packages/app/generated");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(
+        target.join("tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":"."}}"#,
+    )
+    .unwrap();
+
+    let snapshot = discover_project_with_ignore_root(
+        &target,
+        &["packages/app/generated".to_string()],
+        fixture.path(),
+    )
+    .unwrap();
+
+    assert!(snapshot.files.is_empty());
+    assert!(snapshot.directories.is_empty());
+    assert!(snapshot.package_files.is_empty());
 }
 
 #[test]
@@ -549,7 +611,11 @@ fn temp_fixture() -> TempDir {
         "API_URL=http://localhost:3000\n",
     )
     .unwrap();
-    std::fs::write(fixture.path().join("packages/app/.env."), "SHOULD_IGNORE=1\n").unwrap();
+    std::fs::write(
+        fixture.path().join("packages/app/.env."),
+        "SHOULD_IGNORE=1\n",
+    )
+    .unwrap();
 
     std::fs::create_dir_all(fixture.path().join("node_modules/pkg")).unwrap();
     std::fs::write(
@@ -560,8 +626,11 @@ fn temp_fixture() -> TempDir {
     std::fs::create_dir_all(fixture.path().join("dist")).unwrap();
     std::fs::write(fixture.path().join("dist/tsconfig.json"), "{}").unwrap();
     std::fs::create_dir_all(fixture.path().join("target/debug")).unwrap();
-    std::fs::write(fixture.path().join("target/debug/package.json"), r#"{"name":"ignored-target"}"#)
-        .unwrap();
+    std::fs::write(
+        fixture.path().join("target/debug/package.json"),
+        r#"{"name":"ignored-target"}"#,
+    )
+    .unwrap();
 
     fixture
 }

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { createReadStream } from "node:fs";
-import { chmod, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { resolvePackedWrapperLaunch } from "./lib/packed-wrapper-launch.mjs";
@@ -80,6 +80,7 @@ try {
   });
 
   await runScenario(omitOptionalInstallRoot);
+  await runFallbackBlockingScenarios(omitOptionalInstallRoot);
 
   console.log(`Packed wrapper smoke passed via ${path.basename(rootTarball)}.`);
 } finally {
@@ -96,7 +97,17 @@ async function resolveRootTarball(jsonPath) {
 
   assert.equal(typeof filename, "string", "npm pack JSON must include filename");
 
-  return path.isAbsolute(filename) ? filename : path.join(repoRoot, filename);
+  if (path.isAbsolute(filename)) {
+    return filename;
+  }
+
+  const jsonRelativePath = path.join(path.dirname(absoluteJsonPath), filename);
+  try {
+    await access(jsonRelativePath);
+    return jsonRelativePath;
+  } catch {
+    return path.join(repoRoot, filename);
+  }
 }
 
 function resolvePlatformPackage() {
@@ -315,6 +326,33 @@ async function runScenario(installRoot) {
   await runWrapper(["fix", fixtureDir, "--dry-run"], installRoot);
 }
 
+async function runFallbackBlockingScenarios(installRoot) {
+  const configFixture = path.join(installRoot, "config-fixture");
+
+  await mkdir(configFixture, { recursive: true });
+  await writeFile(
+    path.join(configFixture, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+
+  await assertWrapperFails(
+    ["audit", configFixture],
+    installRoot,
+    /A Rust runtime is required when a Maximus config file is present/,
+  );
+  await assertWrapperFails(
+    ["audit", fixtureDir, "--only", "env"],
+    installRoot,
+    /A Rust runtime is required for options not supported by the frozen JS compatibility path/,
+  );
+  await assertWrapperFails(
+    ["fix", fixtureDir],
+    installRoot,
+    /fix \(without --dry-run\)/,
+  );
+}
+
 async function removeJsFallback(installRoot) {
   await rm(path.join(installRoot, "node_modules", "maximus", "src"), {
     recursive: true,
@@ -332,6 +370,26 @@ async function runWrapper(args, cwd) {
       npm_config_cache: path.join(cwd, ".npm-cache"),
     },
   });
+}
+
+async function assertWrapperFails(args, cwd, expectedPattern) {
+  const launch = await resolvePackedWrapperLaunch(cwd);
+  const result = await runCommandAsync(launch.command, [...launch.args, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_cache: path.join(cwd, ".npm-cache"),
+    },
+    rejectOnFailure: false,
+  });
+
+  if (result.code === 0) {
+    throw new Error(`Expected wrapper command to fail: maximus ${args.join(" ")}`);
+  }
+
+  const combinedOutput = `${result.stdout}\n${result.stderr}`;
+  assert.match(combinedOutput, expectedPattern);
 }
 
 function runCommand(command, args, options) {
@@ -372,12 +430,13 @@ async function runCommandAsync(command, args, options) {
       reject(error);
     });
     child.on("close", (code) => {
-      if (code !== 0) {
+      if (code !== 0 && options.rejectOnFailure !== false) {
         reject(new Error(stderr || stdout || `${command} ${args.join(" ")} failed`));
         return;
       }
 
       resolve({
+        code,
         stdout,
         stderr,
       });

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 
 test("wrapper preserves conventional exit code when the child terminates by signal", async (t) => {
@@ -49,7 +49,7 @@ test("wrapper preserves conventional exit code when the child terminates by sign
   assert.equal(result.stderr.trim(), "");
 });
 
-test("wrapper falls back to the JS reference runtime on unsupported platforms", async (t) => {
+test("wrapper falls back to the JS reference runtime on unsupported platforms for legacy-compatible commands", async (t) => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-unsupported-"));
   t.after(async () => {
     await rm(rootDir, { recursive: true, force: true });
@@ -91,7 +91,7 @@ test("wrapper falls back to the JS reference runtime on unsupported platforms", 
   assert.equal(result.stderr.trim(), "");
 });
 
-test("wrapper ignores placeholder native packages and falls back to the JS reference runtime", async (t) => {
+test("wrapper ignores placeholder native packages and falls back to the JS reference runtime for legacy-compatible commands", async (t) => {
   const runtimePackage = currentRuntimePackage();
   if (!runtimePackage) {
     t.skip("current platform is intentionally unsupported by the wrapper");
@@ -146,6 +146,422 @@ test("wrapper ignores placeholder native packages and falls back to the JS refer
     args: ["audit", "."],
   });
   assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper blocks the frozen JS fallback when Rust-only flags are requested", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-rust-only-flag-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    ".",
+    "--only",
+    "env",
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required/);
+  assert.match(result.stderr, /--only/);
+});
+
+test("wrapper treats dash-prefixed paths as positionals on the frozen JS fallback", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-dash-path-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    "-repo",
+  ]);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    runtime: "js",
+    args: ["audit", "-repo"],
+  });
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper blocks the frozen JS fallback when a Maximus config file is present", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-config-present-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required when a Maximus config file is present/);
+  assert.match(result.stderr, /maximus\.config\.json/);
+});
+
+test("wrapper blocks the frozen JS fallback when config is found through a symlinked target", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("symlink privileges vary on Windows");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-symlink-config-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  const realProject = path.join(rootDir, "real");
+  const realTarget = path.join(realProject, "apps", "web");
+  const aliasTarget = path.join(rootDir, "alias-web");
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(realTarget, { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(realProject, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+  await symlink(realTarget, aliasTarget);
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    aliasTarget,
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required when a Maximus config file is present/);
+  assert.match(result.stderr, /maximus\.config\.json/);
+});
+
+test("wrapper prefers the real project config over a lexical mount config", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("symlink privileges vary on Windows");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-realpath-config-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  const realProject = path.join(rootDir, "real");
+  const realTarget = path.join(realProject, "apps", "web");
+  const mountRoot = path.join(rootDir, "mount");
+  const aliasTarget = path.join(mountRoot, "web");
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(realTarget, { recursive: true });
+  await mkdir(mountRoot, { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(realProject, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(mountRoot, "maximus.config.json"),
+    '{ "checks": { "only": ["tsconfig"] } }\n',
+    "utf8",
+  );
+  await symlink(realTarget, aliasTarget);
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    aliasTarget,
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required when a Maximus config file is present/);
+  assert.match(result.stderr, /\/real\/maximus\.config\.json/);
+  assert.doesNotMatch(result.stderr, /\/mount\/maximus\.config\.json/);
+});
+
+test("wrapper ignores directory-shaped config paths when evaluating the frozen JS fallback", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-config-dir-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "maximus.config.json"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    runtime: "js",
+    args: ["audit", "."],
+  });
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper prints help before checking config files on the frozen JS fallback", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-help-with-config-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, ["--help"]);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage/);
+  assert.match(result.stdout, /maximus fix \[path\] --dry-run \[--json\]/);
+  assert.doesNotMatch(result.stdout, /--only <checks>/);
+  assert.match(result.stdout, /require the Rust runtime/);
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper blocks the frozen JS fallback for fix without dry-run", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-fix-write-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "fix",
+    ".",
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required/);
+  assert.match(result.stderr, /fix \(without --dry-run\)/);
 });
 
 test("wrapper prefers repository debug binaries over installed packages and release binaries", async (t) => {
@@ -226,11 +642,11 @@ function currentRuntimePackage() {
   return null;
 }
 
-async function runWrapper(wrapperPath, cwd) {
+async function runWrapper(wrapperPath, cwd, args = ["audit", "."]) {
   return await new Promise((resolve, reject) => {
     const stdout = [];
     const stderr = [];
-    const child = spawn(process.execPath, [wrapperPath, "audit", "."], {
+    const child = spawn(process.execPath, [wrapperPath, ...args], {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });


### PR DESCRIPTION
## 배경
- Rust rewrite 진행 중인 Maximus에서 P001-A 범위의 설정 기반 동작을 canonical runtime 경로에 연결해야 했습니다.
- npx maximus audit|doctor|fix 명령 표면은 유지하면서, 실제 실행은 Rust runtime 기준으로 정리했습니다.
- 구현 후 독립 review loop를 돌리면서 ignore glob 계약과 JS fallback 계약도 함께 보강했습니다.

## 변경 사항
- maximus.config.json / .maximusrc.json 자동 로딩과 nearest precedence를 Rust CLI에 연결했습니다.
- checks.only, checks.skip, report.failOn, severity override를 Rust audit 흐름에 반영했습니다.
- CLI --only, --skip, --fail-on 플래그를 추가하고 help/output contract를 갱신했습니다.
- discovery ignore가 실제 glob(*, **, ?)로 동작하도록 수정하고 회귀 테스트를 추가했습니다.
- bin/maximus.js의 executable JS fallback을 제거해 canonical runtime을 Rust로 고정했습니다.
- README / README.en / CONTRIBUTING 문구를 현재 runtime 계약에 맞게 정리했습니다.

## 검증
- cargo test -p maximus-core --test core_models
- cargo test -p maximus-cli --test config_and_filtering
- node --test test/wrapper-runtime.test.js
- npm test
- cargo test --workspace
- node ./bin/maximus.js audit ./test/fixtures/clean-project
- node ./bin/maximus.js audit ./test/fixtures/clean-project --only bogus 실패 경로 확인
- git diff --check

## 브랜치 / 워크트리
- 브랜치: codex/p001-a-runtime-config-cutover
- 현재 워크트리: /Users/pjw/workspace/maximus
- 이번 publish에는 다른 worktree branch를 포함하지 않았습니다.

## 남은 메모
- cargo clippy --workspace는 이번 PR에서 별도로 실행하지 않았습니다.
- cargo fmt --all --check는 저장소 바깥 범위의 기존 formatting debt 때문에 여전히 merge gate로는 바로 쓰기 어렵습니다.