### PR TITLE
chore: .gitignore에 tgz 산출물을 추가한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .DS_Store
 .tmp
 target
+*.tgz


### PR DESCRIPTION
## 배경
- `npm pack` 산출물인 `*.tgz`가 작업 트리에 남아 status 노이즈를 만들고 있었습니다.
- 실제로 로컬에 `maximus-0.1.0.tgz`가 남아 있어 반복 검증 시 계속 보였습니다.

## 변경 사항
- 루트 `.gitignore`에 `*.tgz` 패턴을 추가했습니다.
- 기존 ignore 규칙 순서는 그대로 두고, tarball 산출물만 추가로 제외했습니다.

## 검증
- `git check-ignore -v maximus-0.1.0.tgz`
- `git diff --check -- .gitignore`

## 브랜치 / 워크트리
- 브랜치: `codex/p060-a-ignore-tgz`
- 워크트리: `/tmp/maximus-parallel/p060-a-ignore-tgz`
