### PR TITLE
test: 프레임워크 fixture를 확장한다

### DIFF
--- a/test/fixtures/next-app-clean/package.json
+++ b/test/fixtures/next-app-clean/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "next-app-clean",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^15.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/test/fixtures/pnpm-workspace-clean/pnpm-workspace.yaml
+++ b/test/fixtures/pnpm-workspace-clean/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*

--- a/test/fixtures/turborepo-clean/turbo.json
+++ b/test/fixtures/turborepo-clean/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {}
+  }
+}

--- a/test/fixtures/vite-app-clean/package.json
+++ b/test/fixtures/vite-app-clean/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vite-app-clean",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^6.3.0"
+  }
+}

--- a/test/framework-fixture-expansion.test.js
+++ b/test/framework-fixture-expansion.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+import { auditProject } from "../src/core/audit-project.js";
+import { discoverProject, getFiles } from "../src/core/discover.js";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "..");
+
+test("next app clean fixture keeps a realistic app manifest and stays clean", async () => {
+  const fixtureDir = path.join(repoRoot, "test", "fixtures", "next-app-clean");
+  const packageJson = JSON.parse(await readFile(path.join(fixtureDir, "package.json"), "utf8"));
+  const audit = await auditProject(fixtureDir);
+
+  assert.equal(packageJson.name, "next-app-clean");
+  assert.equal(packageJson.private, true);
+  assert.equal(packageJson.scripts.dev, "next dev");
+  assert.equal(packageJson.scripts.build, "next build");
+  assert.equal(packageJson.scripts.start, "next start");
+  assert.equal(packageJson.dependencies.next, "^15.3.0");
+  assert.equal(packageJson.dependencies.react, "^19.0.0");
+  assert.equal(packageJson.dependencies["react-dom"], "^19.0.0");
+  assert.equal(audit.summary.blockingFindings, 0);
+  assert.equal(audit.summary.warningFindings, 0);
+  assert.equal(audit.fixes.length, 0);
+});
+
+test("vite app clean fixture keeps a realistic app manifest and stays clean", async () => {
+  const fixtureDir = path.join(repoRoot, "test", "fixtures", "vite-app-clean");
+  const packageJson = JSON.parse(await readFile(path.join(fixtureDir, "package.json"), "utf8"));
+  const audit = await auditProject(fixtureDir);
+
+  assert.equal(packageJson.name, "vite-app-clean");
+  assert.equal(packageJson.private, true);
+  assert.equal(packageJson.scripts.dev, "vite");
+  assert.equal(packageJson.scripts.build, "vite build");
+  assert.equal(packageJson.scripts.preview, "vite preview");
+  assert.equal(packageJson.devDependencies.vite, "^6.3.0");
+  assert.equal(audit.summary.blockingFindings, 0);
+  assert.equal(audit.summary.warningFindings, 0);
+  assert.equal(audit.fixes.length, 0);
+});
+
+test("pnpm workspace clean fixture is discovered as workspace config and stays clean", async () => {
+  const fixtureDir = path.join(repoRoot, "test", "fixtures", "pnpm-workspace-clean");
+  const project = await discoverProject(fixtureDir);
+  const audit = await auditProject(fixtureDir);
+  const workspaceFiles = getFiles(project, "workspace").map((file) => file.name);
+  const content = await readFile(path.join(fixtureDir, "pnpm-workspace.yaml"), "utf8");
+
+  assert.deepEqual(workspaceFiles, ["pnpm-workspace.yaml"]);
+  assert.match(content, /packages:/u);
+  assert.match(content, /apps\/\*/u);
+  assert.match(content, /packages\/\*/u);
+  assert.equal(audit.summary.blockingFindings, 0);
+  assert.equal(audit.summary.warningFindings, 0);
+  assert.equal(audit.fixes.length, 0);
+});
+
+test("turborepo clean fixture is discovered as workspace config and stays clean", async () => {
+  const fixtureDir = path.join(repoRoot, "test", "fixtures", "turborepo-clean");
+  const project = await discoverProject(fixtureDir);
+  const audit = await auditProject(fixtureDir);
+  const workspaceFiles = getFiles(project, "workspace").map((file) => file.name);
+  const turboJson = JSON.parse(await readFile(path.join(fixtureDir, "turbo.json"), "utf8"));
+
+  assert.deepEqual(workspaceFiles, ["turbo.json"]);
+  assert.equal(turboJson.$schema, "https://turbo.build/schema.json");
+  assert.equal(turboJson.tasks.build.dependsOn[0], "^build");
+  assert.deepEqual(turboJson.tasks.build.outputs, [".next/**", "dist/**"]);
+  assert.equal(audit.summary.blockingFindings, 0);
+  assert.equal(audit.summary.warningFindings, 0);
+  assert.equal(audit.fixes.length, 0);
+});


### PR DESCRIPTION
## 배경
- 새 테스트 문서들이 공유해서 쓸 수 있는 현실적인 framework fixture가 부족했습니다.
- `clean-project` 하나만으로는 Next.js, Vite, pnpm workspace, Turborepo 성격을 대표하기 어려웠습니다.

## 변경 사항
- Next.js, Vite, pnpm workspace, Turborepo용 clean fixture를 추가했습니다.
- 새 fixture들이 실제 audit/discovery 흐름에서 깨끗하게 인식되는지 확인하는 테스트를 추가했습니다.

## 검증
- `node --test test/framework-fixture-expansion.test.js`
- `npm test`

## 브랜치 / 워크트리
- 브랜치: `codex/p047-a-framework-fixtures`
- 워크트리: `/tmp/maximus-parallel/p047-a-framework-fixtures`
