### PR TITLE
test: Windows 경로와 CRLF 회귀를 고정한다

### DIFF
--- a/test/fixtures/windows-crlf/.env
+++ b/test/fixtures/windows-crlf/.env
@@ -1,0 +1,3 @@
+# Windows CRLF fixture
+API_URL=http://127.0.0.1:3000
+AUTH_TOKEN=supersecretvalue12345

--- a/test/fixtures/windows-crlf/tsconfig.json
+++ b/test/fixtures/windows-crlf/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // Windows CRLF fixture
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["src/*"],
+    },
+  },
+}

--- a/test/jsonc.test.js
+++ b/test/jsonc.test.js
@@ -21,3 +21,14 @@ test("parseJsonc supports comments and trailing commas", () => {
     extends: "./tsconfig.base.json",
   });
 });
+
+test("parseJsonc supports CRLF line endings", () => {
+  const parsed = parseJsonc("{\r\n  // comment\r\n  \"compilerOptions\": {\r\n    \"baseUrl\": \".\",\r\n  },\r\n  \"extends\": \"./tsconfig.base.json\",\r\n}\r\n");
+
+  assert.deepEqual(parsed, {
+    compilerOptions: {
+      baseUrl: ".",
+    },
+    extends: "./tsconfig.base.json",
+  });
+});

--- a/test/tsconfig-check.test.js
+++ b/test/tsconfig-check.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 
@@ -221,4 +222,24 @@ test("imports comparison catches conditional wildcard suffix drift", async (t) =
   const audit = await auditProject(rootDir);
 
   assert.ok(audit.findings.some((finding) => finding.id.startsWith("tsconfig-import-conflict:")));
+});
+
+test("Windows CRLF tsconfig fixture is audited with normalized absolute paths", async () => {
+  const fixtureRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "fixtures", "windows-crlf");
+  const audit = await auditProject(fixtureRoot);
+
+  assert.ok(
+    audit.findings.some(
+      (finding) =>
+        finding.id.startsWith("env-example-missing:") &&
+        finding.file === path.join(fixtureRoot, ".env"),
+    ),
+  );
+  assert.ok(
+    audit.findings.some(
+      (finding) =>
+        finding.id.startsWith("tsconfig-paths-missing:") &&
+        finding.file === path.join(fixtureRoot, "tsconfig.json"),
+    ),
+  );
 });

--- a/test/windows-and-crlf.test.js
+++ b/test/windows-and-crlf.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { auditProject } from "../src/core/audit-project.js";
+
+const fixtureRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "fixtures", "windows-crlf");
+
+test("Windows CRLF fixture keeps env and tsconfig checks working", async () => {
+  const audit = await auditProject(fixtureRoot);
+
+  assert.equal(audit.summary.fixesAvailable, 1);
+  assert.ok(
+    audit.findings.some(
+      (finding) =>
+        finding.id.startsWith("env-example-missing:") &&
+        finding.file === path.join(fixtureRoot, ".env"),
+    ),
+  );
+  assert.ok(
+    audit.findings.some(
+      (finding) =>
+        finding.id.startsWith("tsconfig-paths-missing:") &&
+        finding.file === path.join(fixtureRoot, "tsconfig.json"),
+    ),
+  );
+});


### PR DESCRIPTION
## 배경
- 현재 테스트는 macOS/Linux 스타일 경로와 LF 줄바꿈 중심이라 Windows/CRLF 회귀를 충분히 고정하지 못하고 있었습니다.
- JSONC, tsconfig, env parsing이 줄바꿈이나 경로 표현 차이로 다시 흔들리지 않도록 안전망이 필요했습니다.

## 변경 사항
- 실제 CRLF 바이트를 가진 `.env`, `tsconfig.json` fixture를 추가했습니다.
- `parseJsonc`에 CRLF 입력 케이스를 추가했습니다.
- `tsconfig` audit와 통합 fixture 테스트에서 경로와 finding이 OS 독립적으로 유지되는지 확인했습니다.

## 검증
- `od -An -tx1 -N 96 test/fixtures/windows-crlf/.env`
- `od -An -tx1 -N 160 test/fixtures/windows-crlf/tsconfig.json`
- `node --test test/windows-and-crlf.test.js test/jsonc.test.js test/tsconfig-check.test.js`
- `npm test`

## 브랜치 / 워크트리
- 브랜치: `codex/p048-a-windows-crlf-tests`
- 워크트리: `/tmp/maximus-parallel/p048-a-windows-crlf-tests`
