### PR TITLE
ci: 태그 중심 release workflow를 하드닝한다

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+# Draft notes only. Actual npm publication and smoke verification are tag-driven
+# in .github/workflows/release.yml.
 name-template: "v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
 

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -3,6 +3,13 @@ name: action-smoke
 on:
   workflow_call:
     inputs:
+      release_tag:
+        required: true
+        type: string
+      release_sha:
+        required: false
+        type: string
+        default: ""
       command:
         required: false
         type: string
@@ -17,6 +24,15 @@ on:
         default: ""
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Published release tag to smoke
+        required: true
+        type: string
+      release_sha:
+        description: Optional release commit SHA to lock the smoke target
+        required: false
+        default: ""
+        type: string
       command:
         description: Maximus command to run
         required: false
@@ -45,9 +61,26 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_sha || inputs.release_tag }}
 
-      - name: Run Maximus action
-        uses: JeremyDev87/maximus@v0.1.0
+      - name: Assert checked out release target
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.release_sha }}" ]]; then
+            test "$(git rev-parse HEAD)" = "${{ inputs.release_sha }}"
+            git fetch --depth=1 origin "refs/tags/${{ inputs.release_tag }}:refs/tags/${{ inputs.release_tag }}"
+            test "$(git rev-list -n 1 "${{ inputs.release_tag }}")" = "${{ inputs.release_sha }}"
+          else
+            checked_ref="$(git describe --tags --exact-match HEAD)"
+            test "$checked_ref" = "${{ inputs.release_tag }}"
+          fi
+
+      # GitHub Actions does not allow dynamic expressions in step-level `uses:`.
+      # To smoke the same consumer contract, we checkout the requested release tag
+      # and run the local action from that exact tagged snapshot.
+      - name: Run Maximus action from checked-out release tag
+        uses: ./
         with:
           command: ${{ inputs.command }}
           path: ${{ inputs.path }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -217,4 +217,4 @@ jobs:
         run: node ./scripts/validate-rust-release-wiring.mjs
 
       - name: Run focused release wiring test
-        run: node --test test/github-action-wiring.test.js
+        run: node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/npm-error-classifiers.test.js

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,8 @@
 name: Release Drafter
 
+# This workflow only maintains draft notes on master. Tag-driven publication runs
+# through .github/workflows/release.yml after a verified release tag exists.
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: release
 
+# Source of truth is the verified release tag itself. Publishing a GitHub Release
+# does not trigger npm publication again; Release Drafter only prepares notes.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to publish. Select the same tag ref before running.
+        description: Existing release tag to rerun. Run workflow_dispatch against the same tag ref, for example `gh workflow run release.yml --ref <tag> -f release_tag=<tag>`.
         required: true
         type: string
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
@@ -19,63 +23,60 @@ concurrency:
 
 jobs:
   validate-release-context:
-    name: Validate release context
+    name: Validate release plan
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      package_version: ${{ steps.release_context.outputs.package_version }}
-      release_tag: ${{ steps.release_context.outputs.release_tag }}
+      package_version: ${{ steps.release_plan.outputs.package_version }}
+      release_tag: ${{ steps.release_plan.outputs.release_tag }}
+      dist_tag: ${{ steps.release_plan.outputs.dist_tag }}
+      is_prerelease: ${{ steps.release_plan.outputs.is_prerelease }}
+      release_commit_sha: ${{ steps.capture_release_commit.outputs.release_commit_sha }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "24"
 
-      - name: Resolve release tag from release event
-        if: github.event_name == 'release'
-        id: release_tag_from_event
-        shell: bash
-        env:
-          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          printf 'value=%s\n' "$RELEASE_EVENT_TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve release tag from workflow input
-        if: github.event_name == 'workflow_dispatch'
-        id: release_tag_from_input
-        shell: bash
-        env:
-          DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          printf 'value=%s\n' "$DISPATCH_RELEASE_TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Assert release ref and package version alignment
-        id: release_context
+      - name: Build release plan
+        id: release_plan
         shell: bash
         env:
           RELEASE_EVENT_NAME: ${{ github.event_name }}
           RELEASE_GITHUB_REF: ${{ github.ref }}
           RELEASE_GITHUB_REF_NAME: ${{ github.ref_name }}
-          RELEASE_SELECTED_TAG: ${{ github.event_name == 'release' && steps.release_tag_from_event.outputs.value || steps.release_tag_from_input.outputs.value }}
+          RELEASE_SELECTED_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}
         run: |
-          node ./scripts/assert-release-workflow-context.mjs \
+          node ./scripts/release-plan.mjs \
             "$RELEASE_EVENT_NAME" \
             "$RELEASE_GITHUB_REF" \
             "$RELEASE_GITHUB_REF_NAME" \
             "$RELEASE_SELECTED_TAG"
 
+      - name: Capture release commit
+        id: capture_release_commit
+        shell: bash
+        run: |
+          printf 'release_commit_sha=%s\n' "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build-platform-binaries:
     name: Build platform binaries
     needs: validate-release-context
     uses: ./.github/workflows/rust-release-binaries.yml
+    with:
+      release_ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}
 
   publish-platform-packages:
     name: Publish platform package (${{ matrix.package_name }})
-    needs: build-platform-binaries
+    needs:
+      - build-platform-binaries
+      - validate-release-context
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -90,12 +91,11 @@ jobs:
             package_name: "@jeremyfellaz/maximus-linux-arm64-gnu"
           - package_dir: maximus-linux-x64-gnu
             package_name: "@jeremyfellaz/maximus-linux-x64-gnu"
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -115,20 +115,97 @@ jobs:
           cp "${RUNNER_TEMP}/${{ matrix.package_dir }}/maximus" "./npm/${{ matrix.package_dir }}/bin/maximus"
           chmod +x "./npm/${{ matrix.package_dir }}/bin/maximus"
 
+      - name: Check npm package state
+        id: package_state
+        shell: bash
+        env:
+          PACKAGE_NAME: ${{ matrix.package_name }}
+          PACKAGE_VERSION: ${{ needs.validate-release-context.outputs.package_version }}
+        run: |
+          lookup_log="$RUNNER_TEMP/npm-view-${{ matrix.package_dir }}.log"
+          set +e
+          npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >"$lookup_log" 2>&1
+          lookup_status=$?
+          set -e
+
+          if [[ $lookup_status -eq 0 ]]; then
+            printf 'state=already-published\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          lookup_state="$(node ./scripts/classify-npm-lookup-error.mjs "$lookup_log")"
+          if [[ "$lookup_state" == "not-found" ]]; then
+            printf 'state=missing\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cat "$lookup_log" >&2
+          exit 1
+
       - name: Publish platform package
-        run: npm publish "./npm/${{ matrix.package_dir }}" --access public
+        if: steps.package_state.outputs.state == 'missing'
+        shell: bash
+        env:
+          PACKAGE_DIR: ${{ matrix.package_dir }}
+          PACKAGE_NAME: ${{ matrix.package_name }}
+          PACKAGE_VERSION: ${{ needs.validate-release-context.outputs.package_version }}
+          RELEASE_DIST_TAG: ${{ needs.validate-release-context.outputs.dist_tag }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          trusted_log="$RUNNER_TEMP/npm-publish-${PACKAGE_DIR}-trusted.log"
+          set +e
+          npm publish "./npm/$PACKAGE_DIR" --provenance --access public --tag "$RELEASE_DIST_TAG" >"$trusted_log" 2>&1
+          trusted_status=$?
+          set -e
+
+          if [[ $trusted_status -eq 0 ]]; then
+            exit 0
+          fi
+
+          trusted_state="$(node ./scripts/classify-npm-publish-error.mjs "$trusted_log")"
+          if [[ "$trusted_state" == "already-published" ]]; then
+            echo "::notice title=npm publish skipped::$PACKAGE_NAME@$PACKAGE_VERSION is already published."
+            exit 0
+          fi
+
+          if [[ -z "$NPM_TOKEN" ]]; then
+            cat "$trusted_log" >&2
+            exit 1
+          fi
+
+          echo "::notice title=npm publish fallback::Trusted publishing failed for $PACKAGE_NAME@$PACKAGE_VERSION. Retrying with NPM_TOKEN."
+          fallback_log="$RUNNER_TEMP/npm-publish-${PACKAGE_DIR}-fallback.log"
+          set +e
+          NODE_AUTH_TOKEN="$NPM_TOKEN" npm publish "./npm/$PACKAGE_DIR" --access public --tag "$RELEASE_DIST_TAG" >"$fallback_log" 2>&1
+          fallback_status=$?
+          set -e
+
+          if [[ $fallback_status -eq 0 ]]; then
+            exit 0
+          fi
+
+          fallback_state="$(node ./scripts/classify-npm-publish-error.mjs "$fallback_log")"
+          if [[ "$fallback_state" == "already-published" ]]; then
+            echo "::notice title=npm publish skipped::$PACKAGE_NAME@$PACKAGE_VERSION is already published."
+            exit 0
+          fi
+
+          cat "$fallback_log" >&2
+          exit 1
 
   publish-wrapper:
     name: Publish npm wrapper
-    needs: publish-platform-packages
+    needs:
+      - publish-platform-packages
+      - validate-release-context
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -136,8 +213,82 @@ jobs:
           node-version: "24"
           registry-url: https://registry.npmjs.org
 
+      - name: Check root wrapper state
+        id: wrapper_state
+        shell: bash
+        env:
+          PACKAGE_NAME: "@jeremyfellaz/maximus"
+          PACKAGE_VERSION: ${{ needs.validate-release-context.outputs.package_version }}
+        run: |
+          lookup_log="$RUNNER_TEMP/npm-view-root-wrapper.log"
+          set +e
+          npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >"$lookup_log" 2>&1
+          lookup_status=$?
+          set -e
+
+          if [[ $lookup_status -eq 0 ]]; then
+            printf 'state=already-published\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          lookup_state="$(node ./scripts/classify-npm-lookup-error.mjs "$lookup_log")"
+          if [[ "$lookup_state" == "not-found" ]]; then
+            printf 'state=missing\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cat "$lookup_log" >&2
+          exit 1
+
       - name: Publish root wrapper package
-        run: npm publish . --access public
+        if: steps.wrapper_state.outputs.state == 'missing'
+        shell: bash
+        env:
+          PACKAGE_NAME: "@jeremyfellaz/maximus"
+          PACKAGE_VERSION: ${{ needs.validate-release-context.outputs.package_version }}
+          RELEASE_DIST_TAG: ${{ needs.validate-release-context.outputs.dist_tag }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          trusted_log="$RUNNER_TEMP/npm-publish-root-wrapper-trusted.log"
+          set +e
+          npm publish . --provenance --access public --tag "$RELEASE_DIST_TAG" >"$trusted_log" 2>&1
+          trusted_status=$?
+          set -e
+
+          if [[ $trusted_status -eq 0 ]]; then
+            exit 0
+          fi
+
+          trusted_state="$(node ./scripts/classify-npm-publish-error.mjs "$trusted_log")"
+          if [[ "$trusted_state" == "already-published" ]]; then
+            echo "::notice title=npm publish skipped::$PACKAGE_NAME@$PACKAGE_VERSION is already published."
+            exit 0
+          fi
+
+          if [[ -z "$NPM_TOKEN" ]]; then
+            cat "$trusted_log" >&2
+            exit 1
+          fi
+
+          echo "::notice title=npm publish fallback::Trusted publishing failed for $PACKAGE_NAME@$PACKAGE_VERSION. Retrying with NPM_TOKEN."
+          fallback_log="$RUNNER_TEMP/npm-publish-root-wrapper-fallback.log"
+          set +e
+          NODE_AUTH_TOKEN="$NPM_TOKEN" npm publish . --access public --tag "$RELEASE_DIST_TAG" >"$fallback_log" 2>&1
+          fallback_status=$?
+          set -e
+
+          if [[ $fallback_status -eq 0 ]]; then
+            exit 0
+          fi
+
+          fallback_state="$(node ./scripts/classify-npm-publish-error.mjs "$fallback_log")"
+          if [[ "$fallback_state" == "already-published" ]]; then
+            echo "::notice title=npm publish skipped::$PACKAGE_NAME@$PACKAGE_VERSION is already published."
+            exit 0
+          fi
+
+          cat "$fallback_log" >&2
+          exit 1
 
   smoke-published-wrapper:
     name: Smoke published wrapper (${{ matrix.runner.platform }})
@@ -162,6 +313,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -199,3 +352,6 @@ jobs:
       - publish-platform-packages
       - publish-wrapper
     uses: ./.github/workflows/action-smoke.yml
+    with:
+      release_tag: ${{ needs.validate-release-context.outputs.release_tag }}
+      release_sha: ${{ needs.validate-release-context.outputs.release_commit_sha }}

--- a/.github/workflows/rust-release-binaries.yml
+++ b/.github/workflows/rust-release-binaries.yml
@@ -2,7 +2,16 @@ name: rust-release-binaries
 
 on:
   workflow_call:
+    inputs:
+      release_ref:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Release commit SHA or tag to build
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,6 +41,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_ref }}
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/scripts/assert-release-workflow-context.mjs
+++ b/scripts/assert-release-workflow-context.mjs
@@ -17,7 +17,7 @@ export async function assertReleaseWorkflowContext({
   requestedReleaseTag,
 }) {
   assert.ok(
-    eventName === "release" || eventName === "workflow_dispatch",
+    eventName === "push" || eventName === "workflow_dispatch",
     `unsupported release workflow event: ${eventName}`,
   );
   assert.ok(requestedReleaseTag, "release tag is required");

--- a/scripts/classify-npm-lookup-error.mjs
+++ b/scripts/classify-npm-lookup-error.mjs
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const NOT_FOUND_PATTERNS = [
+  /\bE404\b/,
+  /\b404 Not Found\b/i,
+  /\bnpm ERR! 404\b/i,
+];
+
+export function classifyNpmLookupError(stderrText) {
+  for (const pattern of NOT_FOUND_PATTERNS) {
+    if (pattern.test(stderrText)) {
+      return "not-found";
+    }
+  }
+
+  return "registry-or-auth-failure";
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  const [logPath] = process.argv.slice(2);
+
+  if (!logPath) {
+    console.error("Usage: node ./scripts/classify-npm-lookup-error.mjs <log-path>");
+    process.exitCode = 1;
+  } else {
+    const stderrText = await readFile(logPath, "utf8");
+    console.log(classifyNpmLookupError(stderrText));
+  }
+}

--- a/scripts/classify-npm-publish-error.mjs
+++ b/scripts/classify-npm-publish-error.mjs
@@ -1,0 +1,35 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const ALREADY_PUBLISHED_PATTERNS = [
+  /\bEPUBLISHCONFLICT\b/,
+  /cannot publish over the previously published versions/i,
+  /cannot publish over existing version/i,
+  /previously published version/i,
+];
+
+export function classifyNpmPublishError(stderrText) {
+  for (const pattern of ALREADY_PUBLISHED_PATTERNS) {
+    if (pattern.test(stderrText)) {
+      return "already-published";
+    }
+  }
+
+  return "publish-failure";
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  const [logPath] = process.argv.slice(2);
+
+  if (!logPath) {
+    console.error("Usage: node ./scripts/classify-npm-publish-error.mjs <log-path>");
+    process.exitCode = 1;
+  } else {
+    const stderrText = await readFile(logPath, "utf8");
+    console.log(classifyNpmPublishError(stderrText));
+  }
+}

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { appendFile } from "node:fs/promises";
+import { assertReleaseWorkflowContext } from "./assert-release-workflow-context.mjs";
+
+export async function buildReleasePlan({
+  repoRoot = process.cwd(),
+  eventName,
+  githubRef,
+  githubRefName,
+  requestedReleaseTag,
+}) {
+  const context = await assertReleaseWorkflowContext({
+    repoRoot,
+    eventName,
+    githubRef,
+    githubRefName,
+    requestedReleaseTag,
+  });
+
+  const isPrerelease = context.packageVersion.includes("-");
+  const distTag = isPrerelease ? "next" : "latest";
+
+  return {
+    ...context,
+    distTag,
+    isPrerelease,
+  };
+}
+
+async function writeGithubOutputs(plan) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    [
+      `package_version=${plan.packageVersion}`,
+      `release_tag=${plan.releaseTag}`,
+      `dist_tag=${plan.distTag}`,
+      `is_prerelease=${plan.isPrerelease}`,
+    ].join("\n") + "\n",
+    "utf8",
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  const [eventName, githubRef, githubRefName, requestedReleaseTag, repoRootArg] =
+    process.argv.slice(2);
+
+  try {
+    const plan = await buildReleasePlan({
+      repoRoot: repoRootArg || process.cwd(),
+      eventName,
+      githubRef,
+      githubRefName,
+      requestedReleaseTag,
+    });
+    await writeGithubOutputs(plan);
+    console.log(
+      `Validated release plan for ${plan.releaseTag} (dist-tag: ${plan.distTag}, prerelease: ${plan.isPrerelease}).`,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Release plan validation failed: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-rust-release-wiring.mjs
+++ b/scripts/validate-rust-release-wiring.mjs
@@ -18,9 +18,14 @@ const requiredFiles = {
   actionSmokeWorkflow: ".github/workflows/action-smoke.yml",
   releaseWorkflow: ".github/workflows/release.yml",
   rustReleaseWorkflow: ".github/workflows/rust-release-binaries.yml",
+  releaseDrafterWorkflow: ".github/workflows/release-drafter.yml",
+  releaseDrafterConfig: ".github/release-drafter.yml",
   readmeKo: "README.md",
   readmeEn: "README.en.md",
   releaseContextAssertion: "scripts/assert-release-workflow-context.mjs",
+  releasePlan: "scripts/release-plan.mjs",
+  npmLookupClassifier: "scripts/classify-npm-lookup-error.mjs",
+  npmPublishClassifier: "scripts/classify-npm-publish-error.mjs",
   nativeRuntimeAssertion: "scripts/assert-installed-native-runtime.mjs",
 };
 
@@ -29,11 +34,16 @@ export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
   const packageManifest = JSON.parse(fileContents.packageManifest);
   validateAction(fileContents.action);
   validateDevWorkflow(fileContents.devWorkflow);
-  validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow, packageManifest.version);
+  validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow);
   validateRustReleaseWorkflow(fileContents.rustReleaseWorkflow);
   validateReleaseWorkflow(fileContents.releaseWorkflow);
+  validateReleaseDrafterWorkflow(fileContents.releaseDrafterWorkflow);
+  validateReleaseDrafterConfig(fileContents.releaseDrafterConfig);
   validateReadmes(fileContents.readmeKo, fileContents.readmeEn);
   validateReleaseContextAssertion(fileContents.releaseContextAssertion);
+  validateReleasePlanScript(fileContents.releasePlan);
+  validateNpmLookupClassifier(fileContents.npmLookupClassifier);
+  validateNpmPublishClassifier(fileContents.npmPublishClassifier);
   validateNativeRuntimeAssertion(fileContents.nativeRuntimeAssertion);
 
   return {
@@ -91,24 +101,33 @@ function validateDevWorkflow(devText) {
 
   assertContains(devText, "release-wiring:", "release wiring job");
   assertContains(devText, "node ./scripts/validate-rust-release-wiring.mjs", "release wiring validation command");
-  assertContains(devText, "node --test test/github-action-wiring.test.js", "release wiring node test command");
+  assertContains(devText, "node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/npm-error-classifiers.test.js", "release wiring node test command");
 }
 
-function validateActionSmokeWorkflow(actionSmokeText, packageVersion) {
+function validateActionSmokeWorkflow(actionSmokeText) {
   assertContains(actionSmokeText, "workflow_call:", "action smoke reusable trigger");
   assertContains(actionSmokeText, "workflow_dispatch:", "action smoke manual trigger");
-  assertContains(
-    actionSmokeText,
-    `uses: JeremyDev87/maximus@v${packageVersion}`,
-    "action smoke published action usage",
-  );
+  assertContains(actionSmokeText, "release_tag:", "action smoke release tag input");
+  assertContains(actionSmokeText, "release_sha:", "action smoke release sha input");
+  assertContains(actionSmokeText, "ref: ${{ inputs.release_sha || inputs.release_tag }}", "action smoke checkout ref");
+  assertContains(actionSmokeText, 'test "$(git rev-parse HEAD)" = "${{ inputs.release_sha }}"', "action smoke sha comparison");
+  assertContains(actionSmokeText, 'git fetch --depth=1 origin "refs/tags/${{ inputs.release_tag }}:refs/tags/${{ inputs.release_tag }}"', "action smoke tag fetch");
+  assertContains(actionSmokeText, 'test "$(git rev-list -n 1 "${{ inputs.release_tag }}")" = "${{ inputs.release_sha }}"', "action smoke tag to sha comparison");
+  assertContains(actionSmokeText, 'git describe --tags --exact-match HEAD', "action smoke exact tag assertion");
+  assertContains(actionSmokeText, "uses: ./", "action smoke local tag checkout usage");
+  assertContains(actionSmokeText, "dynamic expressions in step-level `uses:`", "action smoke dynamic uses rationale");
   assertContains(actionSmokeText, "registry-url: ${{ inputs.registry_url }}", "action smoke registry passthrough");
-  assert.ok(!actionSmokeText.includes("uses: ./"), "action smoke should not use the local checkout action");
+  assert.ok(
+    !actionSmokeText.includes("uses: JeremyDev87/maximus@v0.1.0"),
+    "action smoke should not pin a static published action tag",
+  );
 }
 
 function validateRustReleaseWorkflow(rustReleaseText) {
   assertContains(rustReleaseText, "workflow_call:", "reusable rust release trigger");
   assertContains(rustReleaseText, "workflow_dispatch:", "manual rust release trigger");
+  assertContains(rustReleaseText, "release_ref:", "rust release ref input");
+  assertContains(rustReleaseText, "ref: ${{ inputs.release_ref }}", "rust release checkout ref");
   assertContains(rustReleaseText, "cargo build --release -p maximus-cli", "rust release build step");
   assertContains(rustReleaseText, "actions/upload-artifact@v4", "rust release artifact upload");
 
@@ -118,37 +137,44 @@ function validateRustReleaseWorkflow(rustReleaseText) {
 }
 
 function validateReleaseWorkflow(releaseText) {
-  assertContains(releaseText, "release:\n    types: [published]", "release published trigger");
+  assertContains(releaseText, 'push:\n    tags:\n      - "v*"', "release tag push trigger");
   assertContains(releaseText, "workflow_dispatch:", "release manual trigger");
   assertContains(releaseText, "release_tag:", "release workflow dispatch tag input");
   assertContains(releaseText, "validate-release-context:", "release context validation job");
   assertContains(releaseText, "needs: validate-release-context", "release context ordering");
-  assertContains(releaseText, "Resolve release tag from release event", "release event tag resolution step");
-  assertContains(releaseText, "Resolve release tag from workflow input", "release dispatch tag resolution step");
-  assertContains(releaseText, "RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}", "release event tag env wiring");
-  assertContains(releaseText, "DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}", "release dispatch tag env wiring");
+  assertContains(releaseText, "id-token: write", "release trusted publishing permission");
+  assertContains(releaseText, "Build release plan", "release plan step");
+  assertContains(releaseText, "node ./scripts/release-plan.mjs", "release plan command");
+  assertContains(releaseText, "dist_tag: ${{ steps.release_plan.outputs.dist_tag }}", "release dist-tag output");
+  assertContains(releaseText, "is_prerelease: ${{ steps.release_plan.outputs.is_prerelease }}", "release prerelease output");
+  assertContains(releaseText, "release_commit_sha: ${{ steps.capture_release_commit.outputs.release_commit_sha }}", "release commit sha output");
+  assertContains(releaseText, "git rev-parse HEAD", "release commit capture command");
   assertContains(releaseText, "RELEASE_EVENT_NAME: ${{ github.event_name }}", "release event name env wiring");
   assertContains(releaseText, "RELEASE_GITHUB_REF: ${{ github.ref }}", "release ref env wiring");
   assertContains(releaseText, "RELEASE_GITHUB_REF_NAME: ${{ github.ref_name }}", "release ref_name env wiring");
-  assertContains(releaseText, 'printf \'value=%s\\n\' "$RELEASE_EVENT_TAG" >> "$GITHUB_OUTPUT"', "release event tag output");
-  assertContains(releaseText, 'printf \'value=%s\\n\' "$DISPATCH_RELEASE_TAG" >> "$GITHUB_OUTPUT"', "release dispatch tag output");
+  assertContains(releaseText, "RELEASE_SELECTED_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}", "release selected tag env wiring");
   assertContains(releaseText, "uses: ./.github/workflows/rust-release-binaries.yml", "release reusable binary workflow call");
-  assertContains(releaseText, "node ./scripts/assert-release-workflow-context.mjs", "release context assertion command");
-  assertContains(releaseText, "npm publish . --access public", "root wrapper publish");
+  assertContains(releaseText, "release_ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}", "release reusable binary ref input");
+  assertContains(releaseText, "node ./scripts/classify-npm-lookup-error.mjs", "npm lookup classifier usage");
+  assertContains(releaseText, "node ./scripts/classify-npm-publish-error.mjs", "npm publish classifier usage");
+  assertContains(releaseText, "npm publish . --provenance --access public --tag \"$RELEASE_DIST_TAG\"", "root wrapper trusted publish");
+  assertContains(releaseText, "NODE_AUTH_TOKEN=\"$NPM_TOKEN\" npm publish . --access public --tag \"$RELEASE_DIST_TAG\"", "root wrapper token fallback publish");
+  assertContains(releaseText, "--provenance --access public --tag \"$RELEASE_DIST_TAG\"", "platform trusted publish");
   assertContains(releaseText, `npm install --no-package-lock --prefix "$install_root" "${rootPackageName}@\${{ needs.validate-release-context.outputs.package_version }}"`, "published wrapper smoke install");
   assertContains(releaseText, 'node ./scripts/assert-installed-native-runtime.mjs "$install_root"', "published wrapper native runtime assertion");
   assertContains(releaseText, 'node "$install_root/node_modules/@jeremyfellaz/maximus/bin/maximus.js" audit ./test/fixtures/clean-project', "published wrapper smoke audit");
   assertContains(releaseText, "uses: ./.github/workflows/action-smoke.yml", "release action smoke call");
-  assertContains(releaseText, "needs: publish-platform-packages", "wrapper publish ordering");
+  assertContains(releaseText, "release_tag: ${{ needs.validate-release-context.outputs.release_tag }}", "release action smoke tag input");
+  assertContains(releaseText, "release_sha: ${{ needs.validate-release-context.outputs.release_commit_sha }}", "release action smoke sha input");
+  assertContains(releaseText, "ref: ${{ github.ref }}", "release validation checkout ref");
+  assertContains(releaseText, "ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}", "release downstream sha checkout");
+  assertContains(releaseText, "gh workflow run release.yml --ref <tag> -f release_tag=<tag>", "release workflow dispatch guidance");
+  assertContains(releaseText, "publish-platform-packages", "wrapper publish ordering");
   assertContains(releaseText, "- publish-wrapper", "published wrapper smoke ordering");
   assertContains(releaseText, "strategy:\n      fail-fast: false\n      matrix:", "published wrapper smoke matrix");
   assert.ok(
-    !releaseText.includes('echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"'),
-    "release workflow should not interpolate release tag directly inside bash",
-  );
-  assert.ok(
-    !releaseText.includes('echo "value=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"'),
-    "release workflow should not interpolate dispatch input directly inside bash",
+    !releaseText.includes("types: [published]"),
+    "release workflow should not use release.published as the source of truth",
   );
   assert.ok(
     !releaseText.includes('"${{ github.event_name }}"'),
@@ -171,6 +197,21 @@ function validateReadmes(readmeKoText, readmeEnText) {
   assertContains(readmeEnText, "for example `v0.1.0`", "English README release tag guidance");
 }
 
+function validateReleaseDrafterWorkflow(releaseDrafterWorkflowText) {
+  assertContains(releaseDrafterWorkflowText, "push:", "release drafter push trigger");
+  assertContains(releaseDrafterWorkflowText, "workflow_dispatch:", "release drafter manual trigger");
+  assertContains(releaseDrafterWorkflowText, "config-name: release-drafter.yml", "release drafter config wiring");
+  assertContains(releaseDrafterWorkflowText, "release-drafter/release-drafter@", "release drafter action usage");
+  assertContains(releaseDrafterWorkflowText, "only maintains draft notes on master", "release drafter notes-only comment");
+}
+
+function validateReleaseDrafterConfig(releaseDrafterConfigText) {
+  assertContains(releaseDrafterConfigText, "Actual npm publication and smoke verification are tag-driven", "release drafter config notes-only comment");
+  assertContains(releaseDrafterConfigText, 'name-template: "v$NEXT_PATCH_VERSION"', "release drafter name template");
+  assertContains(releaseDrafterConfigText, 'tag-template: "v$NEXT_PATCH_VERSION"', "release drafter tag template");
+  assertContains(releaseDrafterConfigText, "## Changes", "release drafter notes template");
+}
+
 function validateNativeRuntimeAssertion(nativeRuntimeAssertionText) {
   assertContains(nativeRuntimeAssertionText, "MAXIMUS_RUST_BINARY_PLACEHOLDER", "native runtime placeholder marker check");
   assertContains(nativeRuntimeAssertionText, "node_modules", "native runtime node_modules lookup");
@@ -181,6 +222,24 @@ function validateReleaseContextAssertion(releaseContextAssertionText) {
   assertContains(releaseContextAssertionText, "release workflow must run from a tag ref", "release context tag gate");
   assertContains(releaseContextAssertionText, "package.json version", "release context package version gate");
   assertContains(releaseContextAssertionText, "GITHUB_OUTPUT", "release context GitHub output export");
+  assertContains(releaseContextAssertionText, "eventName === \"push\" || eventName === \"workflow_dispatch\"", "release context supported events");
+}
+
+function validateReleasePlanScript(releasePlanText) {
+  assertContains(releasePlanText, "distTag", "release plan dist-tag logic");
+  assertContains(releasePlanText, "next", "release plan prerelease dist-tag");
+  assertContains(releasePlanText, "latest", "release plan stable dist-tag");
+  assertContains(releasePlanText, "isPrerelease", "release plan prerelease flag");
+}
+
+function validateNpmLookupClassifier(lookupClassifierText) {
+  assertContains(lookupClassifierText, "not-found", "npm lookup not-found classification");
+  assertContains(lookupClassifierText, "registry-or-auth-failure", "npm lookup registry failure classification");
+}
+
+function validateNpmPublishClassifier(publishClassifierText) {
+  assertContains(publishClassifierText, "already-published", "npm publish already-published classification");
+  assertContains(publishClassifierText, "publish-failure", "npm publish failure classification");
 }
 
 function assertContains(text, expected, label) {

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -5,7 +5,7 @@ import { validateRustReleaseWiring } from "../scripts/validate-rust-release-wiri
 test("Rust release wiring validation passes for the checked-in GitHub automation files", async () => {
   const summary = await validateRustReleaseWiring(process.cwd());
 
-  assert.equal(summary.checkedFiles.length, 10);
+  assert.equal(summary.checkedFiles.length, 15);
   assert.deepEqual(summary.platformPackages, [
     "@jeremyfellaz/maximus-darwin-arm64",
     "@jeremyfellaz/maximus-darwin-x64",

--- a/test/npm-error-classifiers.test.js
+++ b/test/npm-error-classifiers.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyNpmLookupError } from "../scripts/classify-npm-lookup-error.mjs";
+import { classifyNpmPublishError } from "../scripts/classify-npm-publish-error.mjs";
+
+test("npm lookup classifier distinguishes not-found from registry failures", () => {
+  assert.equal(
+    classifyNpmLookupError("npm ERR! code E404\nnpm ERR! 404 Not Found - GET https://registry.npmjs.org/pkg"),
+    "not-found",
+  );
+  assert.equal(
+    classifyNpmLookupError("npm ERR! code E401\nnpm ERR! Unable to authenticate, your authentication token seems to be invalid."),
+    "registry-or-auth-failure",
+  );
+});
+
+test("npm publish classifier distinguishes already-published from other failures", () => {
+  assert.equal(
+    classifyNpmPublishError("npm ERR! code EPUBLISHCONFLICT\nnpm ERR! cannot publish over existing version."),
+    "already-published",
+  );
+  assert.equal(
+    classifyNpmPublishError("npm ERR! code EOTP\nnpm ERR! This operation requires a one-time password."),
+    "publish-failure",
+  );
+});

--- a/test/release-plan.test.js
+++ b/test/release-plan.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { buildReleasePlan } from "../scripts/release-plan.mjs";
+
+async function writePackageJson(dir, version) {
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "@jeremyfellaz/maximus", version }, null, 2),
+    "utf8",
+  );
+}
+
+test("release plan resolves stable tags to latest", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-plan-stable-"));
+  await writePackageJson(repoRoot, "1.2.3");
+
+  const plan = await buildReleasePlan({
+    repoRoot,
+    eventName: "push",
+    githubRef: "refs/tags/v1.2.3",
+    githubRefName: "v1.2.3",
+    requestedReleaseTag: "v1.2.3",
+  });
+
+  assert.equal(plan.releaseTag, "v1.2.3");
+  assert.equal(plan.packageVersion, "1.2.3");
+  assert.equal(plan.distTag, "latest");
+  assert.equal(plan.isPrerelease, false);
+});
+
+test("release plan resolves prerelease tags to next", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-plan-prerelease-"));
+  await writePackageJson(repoRoot, "1.2.3-alpha.1");
+
+  const plan = await buildReleasePlan({
+    repoRoot,
+    eventName: "workflow_dispatch",
+    githubRef: "refs/tags/v1.2.3-alpha.1",
+    githubRefName: "v1.2.3-alpha.1",
+    requestedReleaseTag: "v1.2.3-alpha.1",
+  });
+
+  assert.equal(plan.releaseTag, "v1.2.3-alpha.1");
+  assert.equal(plan.packageVersion, "1.2.3-alpha.1");
+  assert.equal(plan.distTag, "next");
+  assert.equal(plan.isPrerelease, true);
+});

--- a/test/release-workflow-context.test.js
+++ b/test/release-workflow-context.test.js
@@ -5,7 +5,20 @@ import { assertReleaseWorkflowContext } from "../scripts/assert-release-workflow
 test("release workflow context accepts matching release tags", async () => {
   const summary = await assertReleaseWorkflowContext({
     repoRoot: process.cwd(),
-    eventName: "release",
+    eventName: "push",
+    githubRef: "refs/tags/v0.1.0",
+    githubRefName: "v0.1.0",
+    requestedReleaseTag: "v0.1.0",
+  });
+
+  assert.equal(summary.packageVersion, "0.1.0");
+  assert.equal(summary.releaseTag, "v0.1.0");
+});
+
+test("release workflow context accepts workflow dispatch when the selected tag ref is provided", async () => {
+  const summary = await assertReleaseWorkflowContext({
+    repoRoot: process.cwd(),
+    eventName: "workflow_dispatch",
     githubRef: "refs/tags/v0.1.0",
     githubRefName: "v0.1.0",
     requestedReleaseTag: "v0.1.0",
@@ -45,7 +58,7 @@ test("release workflow context rejects package version mismatches", async () => 
   await assert.rejects(
     assertReleaseWorkflowContext({
       repoRoot: process.cwd(),
-      eventName: "release",
+      eventName: "push",
       githubRef: "refs/tags/v0.2.0",
       githubRefName: "v0.2.0",
       requestedReleaseTag: "v0.2.0",


### PR DESCRIPTION
## 배경
- `P067-A`로 npm namespace는 정렬됐지만, release workflow는 아직 `release.published` 기반이고 action smoke도 정적 `v0.1.0` 태그를 바라보고 있었습니다.
- 이번 slice는 릴리즈 source of truth를 tag로 고정하고, rerun-safe publish와 auth fallback을 workflow와 validator/test에 함께 반영하는 범위입니다.

## 변경 사항
- `release.yml`을 tag push/manual tag rerun 기준으로 전환하고, `release-plan` helper를 통해 `package_version`, `release_tag`, `dist_tag`, prerelease 여부를 한 곳에서 계산하도록 정리했습니다.
- npm lookup/publish 오류를 분류하는 helper를 추가해 already-published rerun은 skip하고, trusted publishing 우선 후 `NPM_TOKEN` fallback으로 재시도하도록 구성했습니다.
- `action-smoke.yml`은 정적 예시 태그 대신 입력받은 `release_tag` checkout 기준으로 현재 릴리즈 태그를 smoke하게 바꿨습니다.
- release wiring validator와 관련 테스트, dev workflow의 focused release-wiring test를 새 계약에 맞게 업데이트했습니다.

## 검증
- `node ./scripts/validate-rust-release-wiring.mjs`
- `node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js`
- `npm test`
- `actionlint .github/workflows/dev.yml .github/workflows/action-smoke.yml .github/workflows/release.yml .github/workflows/rust-release-binaries.yml .github/workflows/release-drafter.yml`
- `git diff --check`

## 브랜치 / 워크트리
- 브랜치: `codex/p067-b-release-workflow-hardening`
- 워크트리: `/Users/pjw/workspace/maximus`
- source worktree 병합 없음

## 이슈 연결
- 별도 이슈 없음
