### PR TITLE
test: packed install fallback 회귀를 고정한다

### DIFF
--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
 import { access, open, realpath, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { constants as osConstants } from "node:os";
@@ -119,7 +120,15 @@ async function resolveInstalledBinary(packageName) {
     const packageJsonPath = require.resolve(`${packageName}/package.json`);
     const binaryPath = path.join(path.dirname(packageJsonPath), "bin", "maximus");
 
-    await access(binaryPath);
+    await access(binaryPath, fsConstants.X_OK);
+    if (!(await isAccessible(binaryPath, fsConstants.R_OK))) {
+      if (!(await probeExecutable(binaryPath))) {
+        return null;
+      }
+
+      return binaryPath;
+    }
+
     if (await isPlaceholderRuntime(binaryPath)) {
       return null;
     }
@@ -357,4 +366,43 @@ function formatCompatHelp() {
 function signalExitCode(signal) {
   const signalNumber = osConstants.signals?.[signal];
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}
+
+async function isAccessible(targetPath, mode) {
+  try {
+    await access(targetPath, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function probeExecutable(binaryPath) {
+  return await new Promise((resolve) => {
+    const child = spawn(binaryPath, ["--help"], {
+      stdio: "ignore",
+    });
+    let settled = false;
+    const settle = (result) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle(false);
+    }, 1000);
+
+    child.on("error", () => {
+      clearTimeout(timeout);
+      settle(false);
+    });
+
+    child.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      settle(!signal && code === 0);
+    });
+  });
 }

--- a/scripts/assert-installed-native-runtime.mjs
+++ b/scripts/assert-installed-native-runtime.mjs
@@ -1,14 +1,55 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
-import { open } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { access, open } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const PLACEHOLDER_MARKER = "MAXIMUS_RUST_BINARY_PLACEHOLDER";
 
 export async function assertInstalledNativeRuntime(installRoot) {
+  const runtime = await inspectInstalledNativeRuntime(installRoot);
+
+  if (runtime.state === "unsupported") {
+    throw new Error(runtime.message);
+  }
+
+  if (runtime.state === "missing") {
+    throw new Error(
+      `Expected installed runtime ${runtime.packageName} at "${runtime.binaryPath}", but no binary was installed.`,
+    );
+  }
+
+  if (runtime.state === "not-runnable") {
+    throw new Error(
+      `Installed runtime for ${runtime.packageName} exists at "${runtime.binaryPath}", but it is not executable.`,
+    );
+  }
+
+  if (runtime.state === "placeholder") {
+    throw new Error(
+      `Installed runtime for ${runtime.packageName} is still the placeholder binary at "${runtime.binaryPath}".`,
+    );
+  }
+
+  return {
+    packageName: runtime.packageName,
+    binaryPath: runtime.binaryPath,
+  };
+}
+
+export async function inspectInstalledNativeRuntime(installRoot) {
   const runtimePackage = resolveRuntimePackage();
-  assert(runtimePackage, formatUnsupportedPlatformMessage());
+
+  if (!runtimePackage) {
+    return {
+      state: "unsupported",
+      packageName: null,
+      binaryPath: null,
+      message: formatUnsupportedPlatformMessage(),
+    };
+  }
 
   const binaryPath = path.join(
     installRoot,
@@ -18,13 +59,48 @@ export async function assertInstalledNativeRuntime(installRoot) {
     "maximus",
   );
 
+  if (!(await isAccessible(binaryPath, fsConstants.F_OK))) {
+    return {
+      state: "missing",
+      packageName: runtimePackage.packageName,
+      binaryPath,
+    };
+  }
+
+  if (!(await isAccessible(binaryPath, fsConstants.X_OK))) {
+    return {
+      state: "not-runnable",
+      packageName: runtimePackage.packageName,
+      binaryPath,
+    };
+  }
+
+  if (!(await isAccessible(binaryPath, fsConstants.R_OK))) {
+    if (!(await probeExecutable(binaryPath))) {
+      return {
+        state: "not-runnable",
+        packageName: runtimePackage.packageName,
+        binaryPath,
+      };
+    }
+
+    return {
+      state: "installed",
+      packageName: runtimePackage.packageName,
+      binaryPath,
+    };
+  }
+
   if (await isPlaceholderRuntime(binaryPath)) {
-    throw new Error(
-      `Installed runtime for ${runtimePackage.packageName} is still the placeholder binary at "${binaryPath}".`,
-    );
+    return {
+      state: "placeholder",
+      packageName: runtimePackage.packageName,
+      binaryPath,
+    };
   }
 
   return {
+    state: "installed",
     packageName: runtimePackage.packageName,
     binaryPath,
   };
@@ -84,6 +160,45 @@ async function isPlaceholderRuntime(binaryPath) {
   } finally {
     await file.close();
   }
+}
+
+async function isAccessible(binaryPath, mode) {
+  try {
+    await access(binaryPath, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function probeExecutable(binaryPath) {
+  return await new Promise((resolve) => {
+    const child = spawn(binaryPath, ["--help"], {
+      stdio: "ignore",
+    });
+    let settled = false;
+    const settle = (result) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle(false);
+    }, 1000);
+
+    child.on("error", () => {
+      clearTimeout(timeout);
+      settle(false);
+    });
+
+    child.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      settle(!signal && code === 0);
+    });
+  });
 }
 
 const isDirectExecution =

--- a/scripts/run-packed-wrapper-smoke.mjs
+++ b/scripts/run-packed-wrapper-smoke.mjs
@@ -6,6 +6,10 @@ import { createReadStream } from "node:fs";
 import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
+import {
+  assertInstalledNativeRuntime,
+  inspectInstalledNativeRuntime,
+} from "./assert-installed-native-runtime.mjs";
 import { resolvePackedWrapperLaunch } from "./lib/packed-wrapper-launch.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -76,6 +80,7 @@ try {
     registryUrl: localRegistry.url,
   });
 
+  await assertInstalledNativeRuntime(installRoot);
   await removeJsFallback(installRoot);
   await runScenario(installRoot);
 
@@ -84,6 +89,12 @@ try {
     omitOptional: true,
   });
 
+  const omittedRuntime = await inspectInstalledNativeRuntime(omitOptionalInstallRoot);
+  assert.equal(
+    omittedRuntime.state,
+    "missing",
+    `Expected omit=optional install to exclude the native runtime package, but observed "${omittedRuntime.state}".`,
+  );
   await runScenario(omitOptionalInstallRoot);
   await runFallbackBlockingScenarios(omitOptionalInstallRoot);
 

--- a/test/installed-native-runtime.test.js
+++ b/test/installed-native-runtime.test.js
@@ -4,7 +4,10 @@ import path from "node:path";
 import process from "node:process";
 import test from "node:test";
 import { chmod, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { assertInstalledNativeRuntime } from "../scripts/assert-installed-native-runtime.mjs";
+import {
+  assertInstalledNativeRuntime,
+  inspectInstalledNativeRuntime,
+} from "../scripts/assert-installed-native-runtime.mjs";
 
 test("installed native runtime assertion accepts a non-placeholder runtime package on supported hosts", async (t) => {
   const runtimePackage = currentRuntimePackage();
@@ -55,6 +58,144 @@ test("installed native runtime assertion rejects placeholder runtime binaries", 
   await assert.rejects(
     () => assertInstalledNativeRuntime(installRoot),
     /placeholder binary/,
+  );
+});
+
+test("installed native runtime inspection reports a missing optional runtime package", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-missing-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  const binaryPath = path.join(
+    installRoot,
+    "node_modules",
+    runtimePackage.packageName,
+    "bin",
+    "maximus",
+  );
+
+  const result = await inspectInstalledNativeRuntime(installRoot);
+
+  assert.deepEqual(result, {
+    state: "missing",
+    packageName: runtimePackage.packageName,
+    binaryPath,
+  });
+  await assert.rejects(
+    () => assertInstalledNativeRuntime(installRoot),
+    /no binary was installed/,
+  );
+});
+
+test("installed native runtime assertion rejects non-executable runtime binaries", async (t) => {
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-not-runnable-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", runtimePackage.packageName, "bin"), {
+    recursive: true,
+  });
+  const binaryPath = path.join(installRoot, "node_modules", runtimePackage.packageName, "bin", "maximus");
+  await writeFile(binaryPath, "#!/bin/sh\necho native-runtime\n", "utf8");
+  await chmod(binaryPath, 0o644);
+
+  const result = await inspectInstalledNativeRuntime(installRoot);
+
+  assert.deepEqual(result, {
+    state: "not-runnable",
+    packageName: runtimePackage.packageName,
+    binaryPath,
+  });
+  await assert.rejects(
+    () => assertInstalledNativeRuntime(installRoot),
+    /not executable/,
+  );
+});
+
+test("installed native runtime assertion accepts execute-only runtime binaries", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Windows does not model execute-only file permissions");
+    return;
+  }
+
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-exec-only-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", runtimePackage.packageName, "bin"), {
+    recursive: true,
+  });
+  const binaryPath = path.join(installRoot, "node_modules", runtimePackage.packageName, "bin", "maximus");
+  await cp("/usr/bin/true", binaryPath);
+  await chmod(binaryPath, 0o111);
+
+  const result = await inspectInstalledNativeRuntime(installRoot);
+
+  assert.deepEqual(result, {
+    state: "installed",
+    packageName: runtimePackage.packageName,
+    binaryPath,
+  });
+  await assert.doesNotReject(
+    () => assertInstalledNativeRuntime(installRoot),
+  );
+});
+
+test("installed native runtime assertion rejects execute-only placeholder binaries", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Windows does not model execute-only file permissions");
+    return;
+  }
+
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the runtime assertion");
+    return;
+  }
+
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-installed-runtime-exec-only-placeholder-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(installRoot, "node_modules", runtimePackage.packageName, "bin"), {
+    recursive: true,
+  });
+  const binaryPath = path.join(installRoot, "node_modules", runtimePackage.packageName, "bin", "maximus");
+  await cp(path.join(process.cwd(), "npm", runtimePackage.directoryName, "bin", "maximus"), binaryPath);
+  await chmod(binaryPath, 0o111);
+
+  const result = await inspectInstalledNativeRuntime(installRoot);
+
+  assert.deepEqual(result, {
+    state: "not-runnable",
+    packageName: runtimePackage.packageName,
+    binaryPath,
+  });
+  await assert.rejects(
+    () => assertInstalledNativeRuntime(installRoot),
+    /not executable/,
   );
 });
 

--- a/test/packed-wrapper-fallback.test.js
+++ b/test/packed-wrapper-fallback.test.js
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+import { chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { resolvePackedWrapperLaunch } from "../scripts/lib/packed-wrapper-launch.mjs";
+
+const cleanFixtureDir = path.join(process.cwd(), "test", "fixtures", "clean-project");
+
+test("packed install without the optional runtime keeps legacy-compatible commands working", async (t) => {
+  const installRoot = await createPackedFallbackInstall(t);
+
+  for (const args of [
+    ["audit", cleanFixtureDir],
+    ["doctor", cleanFixtureDir],
+    ["fix", cleanFixtureDir, "--dry-run"],
+  ]) {
+    const result = await runPackedWrapper(installRoot, args);
+
+    assert.equal(result.code, 0, `expected maximus ${args.join(" ")} to succeed`);
+    assert.equal(result.stderr.trim(), "");
+  }
+});
+
+test("packed install without the optional runtime blocks config files, Rust-only flags, and fix without dry-run", async (t) => {
+  const installRoot = await createPackedFallbackInstall(t);
+  const configFixture = path.join(installRoot, "project-with-config");
+  await mkdir(configFixture, { recursive: true });
+  await writeFile(
+    path.join(configFixture, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+
+  const configResult = await runPackedWrapper(installRoot, ["audit"], { cwd: configFixture });
+  assert.equal(configResult.code, 1);
+  assert.equal(configResult.stdout.trim(), "");
+  assert.match(
+    configResult.stderr,
+    /A Rust runtime is required when a Maximus config file is present/,
+  );
+
+  const rustOnlyResult = await runPackedWrapper(installRoot, [
+    "audit",
+    cleanFixtureDir,
+    "--only",
+    "env",
+  ]);
+  assert.equal(rustOnlyResult.code, 1);
+  assert.equal(rustOnlyResult.stdout.trim(), "");
+  assert.match(
+    rustOnlyResult.stderr,
+    /A Rust runtime is required for options not supported by the frozen JS compatibility path/,
+  );
+  assert.match(rustOnlyResult.stderr, /--only/);
+
+  const fixResult = await runPackedWrapper(installRoot, ["fix", cleanFixtureDir]);
+  assert.equal(fixResult.code, 1);
+  assert.equal(fixResult.stdout.trim(), "");
+  assert.match(fixResult.stderr, /fix \(without --dry-run\)/);
+});
+
+async function createPackedFallbackInstall(t) {
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-fallback-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  const packageRoot = path.join(installRoot, "node_modules", "@jeremyfellaz", "maximus");
+  await mkdir(path.join(packageRoot, "bin"), { recursive: true });
+  await mkdir(path.join(installRoot, "node_modules", ".bin"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(packageRoot, "bin", "maximus.js"));
+  await cp(path.join(process.cwd(), "package.json"), path.join(packageRoot, "package.json"));
+  await cp(path.join(process.cwd(), "src"), path.join(packageRoot, "src"), {
+    recursive: true,
+  });
+  await chmod(path.join(packageRoot, "bin", "maximus.js"), 0o755);
+  await symlink(
+    "../@jeremyfellaz/maximus/bin/maximus.js",
+    path.join(installRoot, "node_modules", ".bin", "maximus"),
+  );
+
+  return installRoot;
+}
+
+async function runPackedWrapper(installRoot, args, options = {}) {
+  const launch = await resolvePackedWrapperLaunch(installRoot);
+
+  return await new Promise((resolve, reject) => {
+    const stdout = [];
+    const stderr = [];
+    const child = spawn(launch.command, [...launch.args, ...args], {
+      cwd: options.cwd ?? installRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      resolve({
+        code,
+        signal,
+        stdout: stdout.join(""),
+        stderr: stderr.join(""),
+      });
+    });
+  });
+}

--- a/test/packed-wrapper-launch.test.js
+++ b/test/packed-wrapper-launch.test.js
@@ -51,3 +51,15 @@ test("packed wrapper launch falls back to the installed package entrypoint when 
     args: [packageEntrypoint],
   });
 });
+
+test("packed wrapper launch fails clearly when the install exposes no runnable entrypoint", async (t) => {
+  const installRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-packed-launch-missing-"));
+  t.after(async () => {
+    await rm(installRoot, { recursive: true, force: true });
+  });
+
+  await assert.rejects(
+    () => resolvePackedWrapperLaunch(installRoot),
+    /did not expose a runnable Maximus entrypoint/,
+  );
+});

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -148,6 +148,113 @@ test("wrapper ignores placeholder native packages and falls back to the JS refer
   assert.equal(result.stderr.trim(), "");
 });
 
+test("wrapper accepts execute-only installed runtime binaries", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Windows does not model execute-only file permissions");
+    return;
+  }
+
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the wrapper");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-exec-only-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", runtimePackage.packageName, "bin"), {
+    recursive: true,
+  });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage.packageName, "package.json"),
+    JSON.stringify(
+      {
+        name: runtimePackage.packageName,
+        version: "0.1.0",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await cp("/usr/bin/true", path.join(rootDir, "node_modules", runtimePackage.packageName, "bin", "maximus"));
+  await chmod(path.join(rootDir, "node_modules", runtimePackage.packageName, "bin", "maximus"), 0o111);
+
+  const result = await runWrapper(path.join(rootDir, "bin", "maximus.js"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout.trim(), "");
+  assert.equal(result.stderr.trim(), "");
+});
+
+test("wrapper ignores execute-only placeholder runtimes and falls back to the JS reference runtime", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Windows does not model execute-only file permissions");
+    return;
+  }
+
+  const runtimePackage = currentRuntimePackage();
+  if (!runtimePackage) {
+    t.skip("current platform is intentionally unsupported by the wrapper");
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-exec-only-placeholder-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", runtimePackage.packageName, "bin"), {
+    recursive: true,
+  });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await cp(
+    path.join(process.cwd(), "npm", runtimePackage.directoryName, "bin", "maximus"),
+    path.join(rootDir, "node_modules", runtimePackage.packageName, "bin", "maximus"),
+  );
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", runtimePackage.packageName, "package.json"),
+    JSON.stringify(
+      {
+        name: runtimePackage.packageName,
+        version: "0.1.0",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await chmod(path.join(rootDir, "node_modules", runtimePackage.packageName, "bin", "maximus"), 0o111);
+
+  const result = await runWrapper(path.join(rootDir, "bin", "maximus.js"), rootDir);
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    runtime: "js",
+    args: ["audit", "."],
+  });
+  assert.equal(result.stderr.trim(), "");
+});
+
 test("wrapper blocks the frozen JS fallback when Rust-only flags are requested", async (t) => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-rust-only-flag-"));
   t.after(async () => {


### PR DESCRIPTION
## 배경
- `P067-C published install fallback 회귀 차단` slice입니다.
- optional runtime 없이 설치된 packed wrapper가 실제로 fallback 경로를 타는지, 그리고 그 상태에서 허용/차단 계약이 유지되는지를 smoke와 targeted test 양쪽에서 고정하려고 했습니다.

## 변경 사항
- installed native runtime 검증 로직에 `installed` / `missing` / `placeholder` 상태 구분을 추가했습니다.
- packed wrapper smoke에서 optional runtime이 포함된 설치본은 native runtime 존재를 확인하고, `--omit=optional` 설치본은 native runtime이 실제로 빠졌는지 확인한 뒤 fallback 시나리오를 실행하도록 보강했습니다.
- packed install 기준 fallback 회귀 테스트를 추가해 legacy-compatible 명령 허용과 config / Rust-only flag / `fix` without `--dry-run` 차단을 함께 고정했습니다.
- packed wrapper entrypoint가 없는 설치본에서 명확히 실패하는 테스트를 추가했습니다.

## 검증
- `node --test test/installed-native-runtime.test.js test/packed-wrapper-launch.test.js test/packed-wrapper-fallback.test.js test/wrapper-runtime.test.js`
- `npm test`
- `npm pack --json --pack-destination /tmp/maximus-p067c-ship-pack`
- `node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-p067c-ship-pack/pack.json ./test/fixtures/clean-project`
- `git diff --check`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/p067-c-packed-fallback-guard`
- 현재 워크트리: `/Users/pjw/workspace/maximus`
- 이번 publish에는 추가 source worktree는 포함하지 않았습니다.
