### PR TITLE
docs: release operator runbook과 readiness gate를 정리한다

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,5 +32,7 @@ categories:
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 
 template: |
+  > Draft notes only. Maintainers still publish from the tag-driven release workflow after following `docs/release-operator-runbook.md`.
+
   ## Changes
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,22 @@ Current repository layout keeps the JS source tree for reference, but new runtim
 - If the change belongs to the rewrite roadmap, keep README, `README.en.md`, `CONTRIBUTING.md`, package metadata, and transition docs aligned.
 - Do not land canonical CLI behavior only in the frozen JS reference tree unless the change is explicitly about parity/reference maintenance.
 
+## Release-Related Changes
+
+If your change touches release wiring, packaging, release notes automation, or packed-install behavior, keep the maintainer runbook and release-drafter contract aligned with the code.
+
+- Read [docs/release-operator-runbook.md](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md) before changing the release model.
+- Treat Release Drafter as draft-notes automation for `master`, not as the publish workflow.
+- If you touch `.github/workflows/release.yml`, `.github/workflows/action-smoke.yml`, `.github/workflows/release-drafter.yml`, `.github/release-drafter.yml`, package publish metadata, or packed-wrapper smoke logic, run the release-specific checks before opening the PR.
+
+Recommended release-specific verification:
+
+```bash
+node ./scripts/validate-rust-release-wiring.mjs
+node --test test/github-action-wiring.test.js test/release-workflow-context.test.js test/release-plan.test.js
+npm test
+```
+
 ## Testing
 
 Before opening a pull request, run:

--- a/README.en.md
+++ b/README.en.md
@@ -102,6 +102,8 @@ Default inputs:
 - `path`: project path to inspect, default `.`
 - `<release-tag>`: replace this with a published release tag, for example `v0.1.0`
 
+Maintainers should use the [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md) for alpha or stable releases and same-tag reruns. Release Drafter only refreshes draft notes on `master`; actual publication stays in the tag-driven release workflow.
+
 ## Local Development
 
 ```bash
@@ -123,6 +125,8 @@ That fallback path exists for compatibility verification and reference preservat
 ## Contributing
 
 Contributions are welcome. If you want to add a new check, improve fix safety, or reduce false positives, start with [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) and the [runtime transition document](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) first, because the canonical runtime and distribution surface are now Rust-first and `src/**/*.js` is kept as frozen reference code.
+
+For release preparation, promotion, or rerun policy, use the [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Findings
 - `path`: 검사할 프로젝트 경로, 기본값 `.`
 - `<release-tag>`: publish된 릴리즈 태그로 바꿔 넣어야 합니다. 예: `v0.1.0`
 
+유지보수자가 실제 alpha/stable 릴리즈를 준비하거나 같은 태그를 안전하게 재실행할 때는 [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md)을 기준으로 진행합니다. Release Drafter는 `master`에서 draft notes만 갱신하며, 실제 publish는 tag-driven release workflow만 담당합니다.
+
 ## 로컬 개발
 
 ```bash
@@ -125,6 +127,8 @@ node ./bin/maximus.js audit ./test/fixtures/clean-project
 새로운 점검기 추가, 자동 수정 안전성 개선, false positive 감소 같은 기여를 환영합니다. 다만 canonical runtime과 배포 표면은 이제 Rust 기준이며, `src/**/*.js`는 frozen reference로 유지됩니다. 기여 시작 전에는 [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md)와 [runtime transition 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md)를 먼저 확인해 주세요.
 
 체커를 추가하거나 기존 checker의 연결 구조를 확인할 때는 [checker authoring 아키텍처 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/architecture/checker-authoring.md)도 함께 보시면 현재 Rust crate 경계를 빠르게 맞출 수 있습니다.
+
+릴리즈 절차, alpha/stable 승격 순서, tag rerun 규칙은 [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md)에 따로 정리되어 있습니다.
 
 ## 보안
 

--- a/docs/release-operator-runbook.md
+++ b/docs/release-operator-runbook.md
@@ -1,0 +1,202 @@
+# Release Operator Runbook
+
+This runbook is for maintainers preparing and promoting Maximus releases.
+
+It documents the preflight checks, the alpha-to-stable promotion path, and the rerun rules that match the checked-in GitHub workflows. It does not publish anything by itself. The tag-driven workflow in `.github/workflows/release.yml` remains the only release path.
+
+## Release Model
+
+- The release source of truth is the verified Git tag.
+- `package.json` version and the tag must match exactly. For example, `0.2.0-alpha.1` must be released from `v0.2.0-alpha.1`.
+- Prerelease versions publish with the npm dist-tag `next`.
+- Stable versions publish with the npm dist-tag `latest`.
+- `.github/workflows/release-drafter.yml` only maintains draft notes on `master`. It does not publish npm packages or run release smoke jobs.
+- `workflow_dispatch` reruns are only valid for an existing tag ref. Do not run the release workflow from `master` or any other branch.
+
+## Preflight Before Creating A New Tag
+
+Run this checklist on a clean `master` checkout before creating a new release tag.
+
+1. Pull the target commit from `master`.
+2. Confirm the release notes draft looks correct on GitHub. Treat Release Drafter output as notes only.
+3. Confirm the package namespace state with npm.
+4. Run the local final gate.
+
+Suggested commands:
+
+```bash
+git switch master
+git pull --ff-only
+
+export RELEASE_VERSION=0.2.0-alpha.1
+
+cargo test --workspace
+npm test
+node ./scripts/validate-rust-release-wiring.mjs
+node --test test/github-action-wiring.test.js
+node --test test/release-workflow-context.test.js
+node --test test/wrapper-runtime.test.js test/packed-wrapper-fallback.test.js
+
+npm_config_cache=/tmp/maximus-npm-cache npm view "@jeremyfellaz/maximus@$RELEASE_VERSION" version
+for package in \
+  @jeremyfellaz/maximus-darwin-arm64 \
+  @jeremyfellaz/maximus-darwin-x64 \
+  @jeremyfellaz/maximus-linux-arm64-gnu \
+  @jeremyfellaz/maximus-linux-x64-gnu
+do
+  npm_config_cache=/tmp/maximus-npm-cache npm view "${package}@${RELEASE_VERSION}" version
+done
+
+rm -rf /tmp/maximus-release-pack
+mkdir -p /tmp/maximus-release-pack
+/bin/zsh -lc 'npm_config_cache=/tmp/maximus-release-pack/.npm-cache npm pack --json --pack-destination /tmp/maximus-release-pack > /tmp/maximus-release-pack/pack.json'
+node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-release-pack/pack.json ./test/fixtures/clean-project
+```
+
+How to read the npm checks:
+
+- Before the first public release, `npm view "<pkg>@$RELEASE_VERSION" version` returning `E404` is acceptable.
+- After a release already exists, that exact version should resolve.
+- If npm returns an auth or permission failure instead of `E404`, stop and confirm the publishing account has access to the `@jeremyfellaz` scope before tagging.
+
+## Preflight Before A Same-Tag Rerun
+
+Use this checklist only when a release tag already exists and you need to rerun the release workflow for that exact tag.
+
+The local verification target must match the tag commit, not the current tip of `master`.
+
+Suggested commands:
+
+```bash
+export RELEASE_TAG=v0.2.0
+export RELEASE_VERSION=0.2.0
+
+git fetch --tags origin
+git switch --detach "$RELEASE_TAG"
+
+cargo test --workspace
+npm test
+node ./scripts/validate-rust-release-wiring.mjs
+node --test test/github-action-wiring.test.js
+node --test test/release-workflow-context.test.js
+node --test test/wrapper-runtime.test.js test/packed-wrapper-fallback.test.js
+
+npm_config_cache=/tmp/maximus-npm-cache npm view "@jeremyfellaz/maximus@$RELEASE_VERSION" version
+for package in \
+  @jeremyfellaz/maximus-darwin-arm64 \
+  @jeremyfellaz/maximus-darwin-x64 \
+  @jeremyfellaz/maximus-linux-arm64-gnu \
+  @jeremyfellaz/maximus-linux-x64-gnu
+do
+  npm_config_cache=/tmp/maximus-npm-cache npm view "${package}@${RELEASE_VERSION}" version
+done
+```
+
+Rules:
+
+- Do not validate a same-tag rerun from a newer `master` checkout.
+- Do not change `package.json` or rebuild a new release candidate for the rerun. The rerun must stay on the exact tagged snapshot.
+- After local confirmation, dispatch the workflow with the same tag as both the selected ref and the `release_tag` input.
+
+## Alpha Candidate Flow
+
+Use this path when the package version includes a prerelease suffix such as `-alpha.1`.
+
+1. Open and merge a version-only PR that sets the next prerelease version.
+2. Re-run the new-tag preflight checklist on the merged `master` commit.
+3. Create and push the annotated release tag that matches `package.json`.
+4. Watch the `release` workflow until all publish and smoke jobs finish.
+5. Verify the exact prerelease version is available on npm.
+
+Example:
+
+```bash
+git switch master
+git pull --ff-only
+git tag -a v0.2.0-alpha.1 -m "release: v0.2.0-alpha.1"
+git push origin v0.2.0-alpha.1
+```
+
+Expected behavior:
+
+- The release workflow publishes with dist-tag `next`.
+- Platform packages publish before the root wrapper.
+- Published-wrapper smoke and GitHub Action smoke both run against the same tagged snapshot.
+
+## Stable Promotion Flow
+
+Use this path after a prerelease has been validated and you are ready to promote the same feature set to a stable version.
+
+1. Open a version-only PR that removes the prerelease suffix across the package manifests.
+2. Merge that PR to `master`.
+3. Re-run the new-tag preflight checklist on the new stable commit.
+4. Create and push the stable tag that matches the stable package version.
+5. Watch the release workflow and verify the stable version resolves on npm.
+
+Example:
+
+```bash
+git switch master
+git pull --ff-only
+git tag -a v0.2.0 -m "release: v0.2.0"
+git push origin v0.2.0
+```
+
+Expected behavior:
+
+- The release workflow publishes with dist-tag `latest`.
+- The release tag and `package.json` version match exactly.
+- Release Drafter continues to prepare the next notes draft on `master`, but it does not publish or promote anything by itself.
+
+## Safe Reruns
+
+The release workflow is rerun-safe for an existing tag.
+
+Use `workflow_dispatch` only with the same tag as both the selected ref and the `release_tag` input.
+
+Example:
+
+```bash
+gh workflow run release.yml --ref v0.2.0 -f release_tag=v0.2.0
+```
+
+Rules:
+
+- Do not dispatch from `master`.
+- Do not dispatch from an unrelated branch.
+- If you want a local confirmation before dispatching, run it from `git switch --detach <tag>` so the local snapshot matches the tag that the workflow will use.
+- If a package version is already published, the workflow should skip that publish step instead of failing the entire release.
+- Trusted publishing is attempted first. If it fails and `NPM_TOKEN` is configured, the workflow retries with `NPM_TOKEN`.
+
+## Failure Handling
+
+### Tag and version do not match
+
+- Symptom: release validation fails because the tag and `package.json` version differ.
+- Response: fix the version mismatch in a PR and create the correct new tag after merge.
+- Do not retarget an existing release tag in place.
+
+### npm reports auth or permission failure
+
+- Symptom: `npm view` or `npm publish` fails with registry or auth errors instead of `E404` or "already published".
+- Response: stop, confirm scope ownership and token/trusted-publishing setup, then rerun the same tag after the credential problem is fixed.
+
+### Publish step says the package already exists
+
+- Symptom: the workflow reports an already-published package version.
+- Response: treat that as rerun-safe when the package contents are expected to match the same tag. Investigate only if the release state is incomplete or inconsistent across packages.
+
+### Published smoke fails
+
+- Symptom: the workflow publishes packages but the published-wrapper smoke or action smoke fails.
+- Response: fix the underlying issue in a PR, merge it, and create a new version/tag. Do not mutate an existing published release into a different artifact.
+
+### Draft notes need refresh
+
+- Symptom: the draft release notes on GitHub are stale or missing merged PRs.
+- Response: rerun Release Drafter on `master` only. Keep that rerun separate from npm publication.
+
+## Maintainer Notes
+
+- Keep release-related docs aligned: `README.md`, `README.en.md`, `CONTRIBUTING.md`, this runbook, and the release workflows should describe the same release model.
+- If a change touches release wiring, package naming, or packed-install behavior, re-run the full preflight checklist before asking a maintainer to tag a release.

--- a/scripts/validate-rust-release-wiring.mjs
+++ b/scripts/validate-rust-release-wiring.mjs
@@ -22,6 +22,8 @@ const requiredFiles = {
   releaseDrafterConfig: ".github/release-drafter.yml",
   readmeKo: "README.md",
   readmeEn: "README.en.md",
+  contributing: "CONTRIBUTING.md",
+  releaseRunbook: "docs/release-operator-runbook.md",
   releaseContextAssertion: "scripts/assert-release-workflow-context.mjs",
   releasePlan: "scripts/release-plan.mjs",
   npmLookupClassifier: "scripts/classify-npm-lookup-error.mjs",
@@ -40,6 +42,8 @@ export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
   validateReleaseDrafterWorkflow(fileContents.releaseDrafterWorkflow);
   validateReleaseDrafterConfig(fileContents.releaseDrafterConfig);
   validateReadmes(fileContents.readmeKo, fileContents.readmeEn);
+  validateContributing(fileContents.contributing);
+  validateReleaseRunbook(fileContents.releaseRunbook);
   validateReleaseContextAssertion(fileContents.releaseContextAssertion);
   validateReleasePlanScript(fileContents.releasePlan);
   validateNpmLookupClassifier(fileContents.npmLookupClassifier);
@@ -191,15 +195,26 @@ function validateReadmes(readmeKoText, readmeEnText) {
   assertContains(readmeKoText, "## GitHub Action", "Korean README action section");
   assertContains(readmeKoText, "uses: JeremyDev87/maximus@<release-tag>", "Korean README action example");
   assertContains(readmeKoText, "예: `v0.1.0`", "Korean README release tag guidance");
+  assertContains(readmeKoText, "release operator runbook", "Korean README runbook link");
+  assertContains(readmeKoText, "draft notes", "Korean README draft notes wording");
   assertContains(readmeEnText, "npx @jeremyfellaz/maximus audit", "English README scoped npx example");
   assertContains(readmeEnText, "## GitHub Action", "English README action section");
   assertContains(readmeEnText, "uses: JeremyDev87/maximus@<release-tag>", "English README action example");
   assertContains(readmeEnText, "for example `v0.1.0`", "English README release tag guidance");
+  assertContains(readmeEnText, "release operator runbook", "English README runbook link");
+  assertContains(readmeEnText, "draft notes", "English README draft notes wording");
+}
+
+function validateContributing(contributingText) {
+  assertContains(contributingText, "docs/release-operator-runbook.md", "CONTRIBUTING runbook link");
+  assertContains(contributingText, "Release Drafter as draft-notes automation", "CONTRIBUTING release-drafter contract");
+  assertContains(contributingText, "node ./scripts/validate-rust-release-wiring.mjs", "CONTRIBUTING release validation command");
 }
 
 function validateReleaseDrafterWorkflow(releaseDrafterWorkflowText) {
   assertContains(releaseDrafterWorkflowText, "push:", "release drafter push trigger");
   assertContains(releaseDrafterWorkflowText, "workflow_dispatch:", "release drafter manual trigger");
+  assertContains(releaseDrafterWorkflowText, "if: github.ref == 'refs/heads/master'", "release drafter master-only guard");
   assertContains(releaseDrafterWorkflowText, "config-name: release-drafter.yml", "release drafter config wiring");
   assertContains(releaseDrafterWorkflowText, "release-drafter/release-drafter@", "release drafter action usage");
   assertContains(releaseDrafterWorkflowText, "only maintains draft notes on master", "release drafter notes-only comment");
@@ -210,6 +225,20 @@ function validateReleaseDrafterConfig(releaseDrafterConfigText) {
   assertContains(releaseDrafterConfigText, 'name-template: "v$NEXT_PATCH_VERSION"', "release drafter name template");
   assertContains(releaseDrafterConfigText, 'tag-template: "v$NEXT_PATCH_VERSION"', "release drafter tag template");
   assertContains(releaseDrafterConfigText, "## Changes", "release drafter notes template");
+}
+
+function validateReleaseRunbook(releaseRunbookText) {
+  assertContains(releaseRunbookText, "## Preflight Before Creating A New Tag", "runbook new-tag preflight section");
+  assertContains(releaseRunbookText, "## Preflight Before A Same-Tag Rerun", "runbook rerun preflight section");
+  assertContains(releaseRunbookText, 'git switch --detach "$RELEASE_TAG"', "runbook detached tag rerun command");
+  assertContains(releaseRunbookText, 'gh workflow run release.yml --ref v0.2.0 -f release_tag=v0.2.0', "runbook rerun workflow command");
+  assertContains(releaseRunbookText, 'npm view "@jeremyfellaz/maximus@$RELEASE_VERSION" version', "runbook exact root wrapper version check");
+  assertContains(releaseRunbookText, 'npm view "${package}@${RELEASE_VERSION}" version', "runbook exact platform package version check");
+  assertContains(releaseRunbookText, "Do not validate a same-tag rerun from a newer `master` checkout.", "runbook rerun master warning");
+
+  for (const packageName of platformPackages) {
+    assertContains(releaseRunbookText, packageName, `runbook platform package coverage for ${packageName}`);
+  }
 }
 
 function validateNativeRuntimeAssertion(nativeRuntimeAssertionText) {

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -5,7 +5,7 @@ import { validateRustReleaseWiring } from "../scripts/validate-rust-release-wiri
 test("Rust release wiring validation passes for the checked-in GitHub automation files", async () => {
   const summary = await validateRustReleaseWiring(process.cwd());
 
-  assert.equal(summary.checkedFiles.length, 15);
+  assert.equal(summary.checkedFiles.length, 17);
   assert.deepEqual(summary.platformPackages, [
     "@jeremyfellaz/maximus-darwin-arm64",
     "@jeremyfellaz/maximus-darwin-x64",


### PR DESCRIPTION
## 배경
- `P067-D` release operator runbook과 stable promotion 계약을 문서화합니다.
- 같은 브랜치에서 `P067-E` final gate를 실제로 실행해 현재 release model이 문서와 검증에서 같은 방향을 보도록 맞췄습니다.

## 변경 사항
- `docs/release-operator-runbook.md`를 추가해 preflight, alpha/stable promotion, same-tag rerun, failure handling을 정리했습니다.
- `README.md`, `README.en.md`, `CONTRIBUTING.md`에 runbook 진입 링크와 release 책임 경계를 연결했습니다.
- `.github/workflows/release-drafter.yml`에 `master` 전용 draft-notes 경계를 명시했습니다.
- `.github/release-drafter.yml`에 draft notes only 안내 문구를 추가했습니다.

## 검증
- `cargo test --workspace`
- `npm test`
- `node ./scripts/validate-rust-release-wiring.mjs`
- `node --test test/github-action-wiring.test.js test/release-workflow-context.test.js test/wrapper-runtime.test.js test/packed-wrapper-fallback.test.js`
- `actionlint .github/workflows/dev.yml .github/workflows/action-smoke.yml .github/workflows/release.yml .github/workflows/rust-release-binaries.yml .github/workflows/release-drafter.yml`
- `npm view @jeremyfellaz/maximus version` (`E404`, first public release 전 상태로 해석)
- `npm view @jeremyfellaz/maximus-darwin-arm64 version` (`E404`, first public release 전 상태로 해석)
- `npm pack --json --pack-destination /tmp/maximus-p067de-pack`
- `node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-p067de-pack/pack.json ./test/fixtures/clean-project`
- `git diff --check`

## 브랜치 / 워크트리
- target branch: `codex/p067-d-e-runbook-readiness`
- current worktree: `/Users/pjw/workspace/maximus`
- source worktree: `/Users/pjw/workspace/maximus`

## 이슈 연결
- 없음

## 메모
- 이 PR은 `P067-D` 구현과 `P067-E` final gate 실행 결과를 함께 담은 bundled PR입니다.
- 실제 tag push, GitHub Release publish, npm publish는 포함하지 않습니다.