### PR TITLE
docs: 기여자 로드맵 문서를 추가한다

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,18 @@ For small fixes, feel free to open a pull request directly.
 
 If you are adding or changing a checker, read [docs/architecture/checker-authoring.md](https://github.com/JeremyDev87/maximus/blob/master/docs/architecture/checker-authoring.md) first. It describes the current Rust crate layout, registry, and test locations that this repository uses today.
 
+If you are new to the repository, these contributor docs are the quickest way to orient yourself:
+
+- [docs/roadmap.md](https://github.com/JeremyDev87/maximus/blob/master/docs/roadmap.md) for the current contribution lanes and repository shape
+- [docs/good-first-issues.md](https://github.com/JeremyDev87/maximus/blob/master/docs/good-first-issues.md) for narrow starter tasks
+- [docs/checker-ideas.md](https://github.com/JeremyDev87/maximus/blob/master/docs/checker-ideas.md) for backlog-style checker candidates that are not implemented yet
+
 If you are working from the local planning docs, use the following rule set:
 
 - Treat `docs/plan/001` through `012` as the source of truth for Rust v1 objectives, target outcomes, public interface changes, tests and acceptance, and done criteria.
 - Do not reuse the JS file lists inside those plan docs as ownership guidance for new implementation work.
-- Do not start `docs/plan/013+` implementation work before the Rust cutover phases are complete.
-- Follow the transition families in order: `062` for direction, `063` for bootstrap/core, `064` for current MVP parity, `065` for backlog `001~012`, `066` for wrapper/cutover/distribution.
+- Treat `docs/plan/013+` as post-cutover backlog work. Re-check current `master`, merge history, and the active board before assuming a slice is still pending.
+- Keep new runtime behavior in the Rust crates, the launcher, and the docs instead of reviving the frozen JS reference tree as a default implementation lane.
 
 ## Development Setup
 

--- a/README.en.md
+++ b/README.en.md
@@ -126,6 +126,8 @@ That fallback path exists for compatibility verification and reference preservat
 
 Contributions are welcome. If you want to add a new check, improve fix safety, or reduce false positives, start with [CONTRIBUTING.md](https://github.com/JeremyDev87/maximus/blob/master/CONTRIBUTING.md) and the [runtime transition document](https://github.com/JeremyDev87/maximus/blob/master/docs/runtime-transition.md) first, because the canonical runtime and distribution surface are now Rust-first and `src/**/*.js` is kept as frozen reference code.
 
+If you want a quick map of where to start in the current repository, read the [contributor roadmap](https://github.com/JeremyDev87/maximus/blob/master/docs/roadmap.md), [good first issues](https://github.com/JeremyDev87/maximus/blob/master/docs/good-first-issues.md), and [checker ideas](https://github.com/JeremyDev87/maximus/blob/master/docs/checker-ideas.md). These docs separate the implemented surface from backlog-style ideas.
+
 For release preparation, promotion, or rerun policy, use the [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md).
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ node ./bin/maximus.js audit ./test/fixtures/clean-project
 
 체커를 추가하거나 기존 checker의 연결 구조를 확인할 때는 [checker authoring 아키텍처 문서](https://github.com/JeremyDev87/maximus/blob/master/docs/architecture/checker-authoring.md)도 함께 보시면 현재 Rust crate 경계를 빠르게 맞출 수 있습니다.
 
+현재 저장소 기준으로 어디서 시작하면 좋은지 빠르게 잡고 싶다면 [contributor roadmap](https://github.com/JeremyDev87/maximus/blob/master/docs/roadmap.md), [good first issues](https://github.com/JeremyDev87/maximus/blob/master/docs/good-first-issues.md), [checker ideas](https://github.com/JeremyDev87/maximus/blob/master/docs/checker-ideas.md)를 같이 보시면 좋습니다. 이 문서들은 이미 구현된 표면과 아직 backlog인 주제를 구분해서 안내합니다.
+
 릴리즈 절차, alpha/stable 승격 순서, tag rerun 규칙은 [release operator runbook](https://github.com/JeremyDev87/maximus/blob/master/docs/release-operator-runbook.md)에 따로 정리되어 있습니다.
 
 ## 보안

--- a/docs/checker-ideas.md
+++ b/docs/checker-ideas.md
@@ -1,0 +1,59 @@
+# Checker Ideas
+
+This document is a contributor-facing backlog of checker ideas that are not all implemented yet.
+
+Use it to spot promising rule candidates without confusing them with the checks that already exist today.
+
+## Already Implemented Today
+
+These checks already exist in the Rust runtime:
+
+- `duplicates`
+- `env`
+- `eslint-prettier`
+- `tsconfig`
+- `lockfiles`
+- `package-entrypoints`
+
+If you want to extend one of those areas, start with [Checker Authoring](./architecture/checker-authoring.md) and the relevant integration tests under `crates/maximus-checks/tests/`.
+
+## Candidate Ideas
+
+| Idea | Area | Why it matters | Likely home |
+| --- | --- | --- | --- |
+| Empty `include` or `exclude` pattern detection | TypeScript | Catches configurations that look intentional but match nothing | `crates/maximus-checks/src/tsconfig.rs` |
+| Output path overlap detection | TypeScript | Prevents `outDir`, `declarationDir`, or build outputs from stepping on each other | `crates/maximus-checks/src/tsconfig.rs` |
+| Module system consistency | TypeScript and package metadata | Flags mismatches between `package.json`, `tsconfig`, and emitted files | `crates/maximus-checks/src/tsconfig.rs`, `crates/maximus-checks/src/package_entrypoints.rs` |
+| Path alias shadowing | TypeScript | Finds aliases that hide package imports or each other in surprising ways | `crates/maximus-checks/src/tsconfig.rs` |
+| Monorepo tsconfig drift | Workspace | Highlights package-local divergence from shared base configs | `crates/maximus-checks/src/tsconfig.rs` |
+| `types` and `typeRoots` guidance | TypeScript | Helps explain resolution bugs that are hard to spot from a broken build alone | `crates/maximus-checks/src/tsconfig.rs` |
+| JSX config hints | TypeScript | Warns when React or JSX toolchains are partly configured but incomplete | `crates/maximus-checks/src/tsconfig.rs` |
+| Vite and tsconfig alias sync | Toolchain integration | Catches alias maps that differ between bundler and compiler | `crates/maximus-checks/src/tsconfig.rs` plus fixture tests |
+| Jest and Vitest dual-config conflict detection | Test tooling | Finds test runners that overlap without clear ownership | new checker module or `structure`-adjacent helper |
+| EditorConfig and Prettier conflict detection | Formatting | Surfaces formatting drift that causes noisy diffs and confusing saves | new checker module |
+| Ignore file drift | Repo hygiene | Detects generated or packaged artifacts that escape ignore rules | new checker module plus discovery tests |
+| `.env` gitignore protection | Env safety | Catches repos that commit runtime env files without explicit intent | `crates/maximus-checks/src/env.rs` or adjacent module |
+| Node engines versus CI matrix drift | Release and CI | Warns when supported Node versions and CI reality no longer match | new checker module plus workflow fixtures |
+| `files` versus `.npmignore` conflicts | Packaging | Prevents publishing a different file set than maintainers expect | new checker module plus package fixtures |
+| Unused config file detection | Cleanup | Helps identify dead config files that silently stop mattering | new checker module, possibly with discovery support |
+
+## What Makes A Good Checker Candidate Here
+
+A good Maximus checker usually does all of the following:
+
+- reads configuration that already exists in the repo
+- produces a concrete file-scoped finding
+- can be demonstrated with a small fixture
+- avoids destructive fixes unless the safe behavior is obvious
+- fits into one clear checker id
+
+## Picking The Next One
+
+If you want the easiest place to start:
+
+1. pick one idea from the TypeScript or package metadata rows above
+2. add a fixture that reproduces the problem
+3. add a single integration test in `crates/maximus-checks/tests/`
+4. keep the pull request to one rule family
+
+If you want a smaller entry point than a new checker, go back to [Good First Issues](./good-first-issues.md).

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -1,0 +1,50 @@
+# Good First Issues
+
+This document collects starter-sized contribution ideas for people who want a clear first pull request.
+
+These are intentionally narrow. They are chosen because they have a small write surface, a straightforward validation path, and low conflict risk with other work.
+
+## Before You Pick One
+
+Read these first:
+
+1. [Contributor Roadmap](./roadmap.md)
+2. [Contributing Guide](../CONTRIBUTING.md)
+3. [Checker Authoring](./architecture/checker-authoring.md) if the task touches a Rust checker
+
+## Starter Task Candidates
+
+| Topic | Difficulty | Why it is a good first issue | Start here | Validation |
+| --- | --- | --- | --- | --- |
+| Empty `include` and `exclude` pattern diagnostics in `tsconfig` | Small | One checker, one fixture family, easy failing case | `crates/maximus-checks/src/tsconfig.rs`, `crates/maximus-checks/tests/tsconfig_checks.rs` | `cargo test -p maximus-checks --test tsconfig_checks`, `npm test`, `node ./bin/maximus.js audit <fixture>` |
+| Add one new `package-entrypoints` regression case | Small | The checker is already isolated and heavily test-driven | `crates/maximus-checks/src/package_entrypoints.rs`, `crates/maximus-checks/tests/package_entrypoints_checks.rs` | targeted Cargo test, `cargo test --workspace`, `npm test` |
+| Expand filesystem edge-case fixtures | Small to Medium | Mostly test and fixture work, with low risk to user-facing behavior | `test/fixtures/`, `crates/maximus-checks/tests/`, `test/*.test.js` | targeted tests, `npm test` |
+| Add one snapshot-style audit or doctor regression | Small | Good introduction to report output without changing core discovery logic | `test/golden-rust/`, `test/reference-parity.test.js`, related CLI tests | targeted Node tests, `npm test` |
+| Tighten contributor-facing docs after a checker lands | Small | Docs-only change, good for learning repository boundaries | `README.md`, `CONTRIBUTING.md`, `docs/` | static link review, `git diff --check` |
+
+## How To Keep A Starter PR Healthy
+
+- Keep the scope to one rule, one edge case, or one doc improvement.
+- Prefer one new fixture over a broad refactor.
+- Add at least one regression test that fails before the change and passes after it.
+- If you touch runtime behavior, run both Rust tests and the wrapper-facing baseline command.
+
+## Good Signals For A First PR
+
+Starter work in this repo usually has most of these properties:
+
+- touches one checker or one docs area
+- changes fewer than a handful of files
+- can be validated with one targeted test command plus the repo baseline
+- does not change the release model or package distribution contract
+
+## Better Left For Later
+
+These are usually not good first issues:
+
+- multi-check refactors
+- release workflow redesign
+- wrapper/runtime boundary changes
+- roadmap-sized work that changes README, workflow files, package metadata, and runtime behavior together
+
+If you want something bigger after a first contribution, continue with [Checker Ideas](./checker-ideas.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,111 @@
+# Contributor Roadmap
+
+This document helps contributors choose work that matches the repository shape today.
+
+Maximus now treats Rust as the canonical runtime. That means the main implementation surface lives in the Rust workspace, while `src/**/*.js` stays as frozen reference code for parity and compatibility checks.
+
+## Current Project Shape
+
+The repository currently has four practical contribution lanes:
+
+| Lane | What lives there today | Best starting files | Typical validation |
+| --- | --- | --- | --- |
+| Rust core and discovery | project scanning, config loading, shared data models | `crates/maximus-core/src/` | `cargo test --workspace` |
+| Rust checks and CLI | registered checks, report rendering, fix selection | `crates/maximus-checks/src/`, `crates/maximus-cli/src/` | `cargo test --workspace`, `npm test`, `node ./bin/maximus.js audit ./test/fixtures/clean-project` |
+| Wrapper and release wiring | npm launcher, packed-install checks, GitHub Actions | `bin/maximus.js`, `scripts/`, `.github/workflows/` | `npm test`, release wiring checks, packed wrapper smoke |
+| Docs and contributor UX | onboarding, runbooks, architecture notes | `README.md`, `CONTRIBUTING.md`, `docs/` | static link review, `git diff --check` |
+
+## What Is Already Implemented
+
+The Rust runtime already ships these registered checks:
+
+- `duplicates`
+- `env`
+- `eslint-prettier`
+- `tsconfig`
+- `lockfiles`
+- `package-entrypoints`
+
+The repository also already has:
+
+- a thin npm launcher in `bin/maximus.js`
+- platform package manifests under `npm/`
+- packed-install smoke checks
+- GitHub Action and release workflow wiring
+- frozen JS reference code under `src/`
+
+These are current repository facts, not backlog items.
+
+## What Still Makes Good Contribution Work
+
+The next useful work tends to fall into three buckets:
+
+### 1. Harden existing checks
+
+Good work in this lane usually improves one of these:
+
+- false positive reduction
+- missing edge-case coverage
+- better file targeting or clearer findings
+- regression tests for already-supported behavior
+
+This is the best lane if you want to work in `crates/maximus-checks` without changing the whole product surface.
+
+### 2. Expand coverage with one check at a time
+
+There is still room to add narrow, well-tested checks around:
+
+- TypeScript project configuration drift
+- package metadata and publish safety
+- environment file safety
+- workspace-level consistency rules
+
+In this repository, the healthiest change shape is still one checker or one regression family per pull request.
+
+### 3. Improve contributor and operator experience
+
+Not every useful contribution is a new rule. We also need:
+
+- clearer onboarding docs
+- better fixture coverage for real project shapes
+- sharper release and maintenance runbooks
+- examples that help new contributors reproduce findings locally
+
+## Recommended Starting Path
+
+Choose the path that matches your comfort level:
+
+| If you want to... | Start here |
+| --- | --- |
+| understand the current runtime boundary | [Runtime Transition](./runtime-transition.md) |
+| add or extend a checker | [Checker Authoring](./architecture/checker-authoring.md) |
+| pick a small starter task | [Good First Issues](./good-first-issues.md) |
+| browse possible future checks | [Checker Ideas](./checker-ideas.md) |
+| work on release or packaging behavior | [Release Operator Runbook](./release-operator-runbook.md) |
+
+## Rules That Keep Contributions Mergeable
+
+- Keep one behavior change per pull request when possible.
+- Add or update regression tests for every checker change.
+- Keep README, CONTRIBUTING, and docs aligned when user-facing behavior changes.
+- Treat `src/**/*.js` as frozen reference code, not the default lane for new runtime behavior.
+- Prefer repository evidence over plan assumptions when the code and an older note disagree.
+
+## A Good First Week In This Repo
+
+If you are new to Maximus, this sequence tends to work well:
+
+1. Read [CONTRIBUTING.md](../CONTRIBUTING.md).
+2. Read [Checker Authoring](./architecture/checker-authoring.md) if you want to touch runtime logic.
+3. Pick one item from [Good First Issues](./good-first-issues.md).
+4. Run the baseline commands before and after your change:
+
+```bash
+npm test
+cargo test --workspace
+node ./bin/maximus.js audit ./test/fixtures/clean-project
+```
+
+## What This Document Is Not
+
+This roadmap is a contributor-facing orientation guide. It does not try to mirror every local planning note or every unmerged idea. Use it to find the right lane, then validate your understanding against the repository as it exists on `master`.


### PR DESCRIPTION
## 배경
- 신규 기여자가 현재 저장소 상태에서 어디서 시작해야 하는지 빠르게 파악할 수 있는 공개 문서가 없었습니다.
- README와 CONTRIBUTING에는 개별 문서 링크가 있었지만, 구현된 표면과 backlog를 구분한 contributor 진입 문서는 비어 있었습니다.

## 변경 사항
- `docs/roadmap.md`를 추가해 현재 구현된 표면과 기여 lane을 정리했습니다.
- `docs/good-first-issues.md`를 추가해 작은 starter task 후보와 검증 경로를 정리했습니다.
- `docs/checker-ideas.md`를 추가해 아직 구현되지 않은 checker 후보를 contributor-facing backlog로 정리했습니다.
- `README.md`, `CONTRIBUTING.md`에서 새 문서로 진입할 수 있게 링크를 연결했습니다.
- `CONTRIBUTING.md`의 local planning 안내를 post-cutover 기준으로 다듬었습니다.

## 검증
- `git diff --check`
- `rg -n "docs/roadmap\.md|docs/good-first-issues\.md|docs/checker-ideas\.md|checker-authoring\.md|release-operator-runbook\.md" README.md CONTRIBUTING.md docs/roadmap.md docs/good-first-issues.md docs/checker-ideas.md`
- `ls docs/roadmap.md docs/good-first-issues.md docs/checker-ideas.md`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/p061-a-contributor-roadmap-docs`
- 대상 워크트리: `/Users/pjw/workspace/maximus`
- 포함한 추가 source worktree 없음

## 이슈 연결
- 별도 issue 연결 없음