### PR TITLE
feat: 빈 include/exclude 패턴 검사를 추가한다

### DIFF
--- a/crates/maximus-checks/src/tsconfig.rs
+++ b/crates/maximus-checks/src/tsconfig.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
@@ -45,6 +46,11 @@ const DEPRECATED_COMPILER_OPTIONS: &[(&str, &str)] = &[
 const CHECKABLE_EXTENSIONS: &[&str] = &[
     ".cjs", ".cts", ".js", ".json", ".jsx", ".mjs", ".mts", ".ts", ".tsx",
 ];
+const TS_PATTERN_EXTENSIONS: &[&str] =
+    &[".cts", ".d.cts", ".d.mts", ".d.ts", ".mts", ".ts", ".tsx"];
+const TS_PATTERN_EXTENSIONS_WITH_JS: &[&str] = &[
+    ".cjs", ".cts", ".d.cts", ".d.mts", ".d.ts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx",
+];
 
 enum CompositeResolution {
     Enabled,
@@ -55,6 +61,43 @@ enum CompositeResolution {
         detail: String,
         hint: &'static str,
     },
+}
+
+#[derive(Default)]
+struct EffectivePatternOptions {
+    allow_js: bool,
+    out_dir: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct EffectivePatternField {
+    values: Vec<String>,
+    base_dir: PathBuf,
+    config_path: PathBuf,
+}
+
+#[derive(Default)]
+struct EffectivePatternConfig {
+    options: EffectivePatternOptions,
+    include: Option<EffectivePatternField>,
+    exclude: Option<EffectivePatternField>,
+    files: Option<EffectivePatternField>,
+    issues: Vec<PatternFieldIssue>,
+}
+
+struct PatternFieldIssue {
+    field_name: &'static str,
+    config_path: PathBuf,
+    suffix: String,
+    title: String,
+    detail: String,
+    hint: &'static str,
+}
+
+enum ExtendedPatternConfigDocument {
+    None,
+    Loaded(PathBuf, Value),
+    Issue(PatternFieldIssue),
 }
 
 pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
@@ -90,6 +133,7 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
 
         collect_deprecated_option_findings(&mut findings, &file.path, compiler_options);
         collect_project_reference_findings(&mut findings, &file.path, &file.dir, references)?;
+        collect_include_exclude_pattern_findings(&mut findings, &file.path, &file.dir, &config)?;
 
         let Some(paths_config) = compiler_options.and_then(|options| options.get("paths")) else {
             continue;
@@ -199,22 +243,17 @@ fn collect_project_reference_findings(
     };
     let Some(references) = references.as_array() else {
         findings.push(make_finding(FindingInput {
-            id: format!(
-                "tsconfig-references-shape:{}",
-                file_path.to_string_lossy()
-            ),
+            id: format!("tsconfig-references-shape:{}", file_path.to_string_lossy()),
             title: "references must be an array".to_string(),
             category: Some("tsconfig".to_string()),
             detail: Some(
-                "TypeScript project references must use an array of { path } entries."
-                    .to_string(),
+                "TypeScript project references must use an array of { path } entries.".to_string(),
             ),
             file: Some(file_path.to_path_buf()),
             fix_ids: Vec::new(),
             fixable: false,
             hint: Some(
-                "Rewrite references to the standard [{ \"path\": \"../pkg\" }] shape."
-                    .to_string(),
+                "Rewrite references to the standard [{ \"path\": \"../pkg\" }] shape.".to_string(),
             ),
             severity: Some(Severity::Error),
         }));
@@ -364,7 +403,10 @@ fn collect_project_reference_findings(
             Err(error) => return Err(error),
         };
 
-        let target_config = match parse_jsonc::<Value>(&target_text, &target_config_path.to_string_lossy()) {
+        let target_config = match parse_jsonc::<Value>(
+            &target_text,
+            &target_config_path.to_string_lossy(),
+        ) {
             Ok(target_config) => target_config,
             Err(error) => {
                 findings.push(make_finding(FindingInput {
@@ -593,6 +635,322 @@ fn collect_paths_findings(
     Ok(())
 }
 
+fn collect_include_exclude_pattern_findings(
+    findings: &mut Vec<Finding>,
+    file_path: &Path,
+    config_dir: &Path,
+    config: &Value,
+) -> io::Result<()> {
+    let base_dir = normalize_path(config_dir);
+    let effective_pattern_config = resolve_effective_pattern_config(file_path, config)?;
+
+    for issue in &effective_pattern_config.issues {
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-patterns-shape:{}:{}:{}:{}",
+                file_path.to_string_lossy(),
+                issue.field_name,
+                issue.suffix,
+                issue.config_path.to_string_lossy()
+            ),
+            title: issue.title.clone(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(issue.detail.clone()),
+            file: Some(issue.config_path.clone()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(issue.hint.to_string()),
+            severity: Some(Severity::Error),
+        }));
+    }
+
+    let candidate_extensions = ts_pattern_extensions(effective_pattern_config.options.allow_js);
+    let default_excluded_dirs = collect_default_excluded_dirs(&effective_pattern_config.options);
+    let (explicit_files, explicit_file_issues) = collect_explicit_tsconfig_files(
+        effective_pattern_config.files.as_ref(),
+        candidate_extensions,
+    )?;
+    for issue in explicit_file_issues {
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-patterns-shape:{}:{}:{}:{}",
+                file_path.to_string_lossy(),
+                issue.field_name,
+                issue.suffix,
+                issue.config_path.to_string_lossy()
+            ),
+            title: issue.title,
+            category: Some("tsconfig".to_string()),
+            detail: Some(issue.detail),
+            file: Some(issue.config_path),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(issue.hint.to_string()),
+            severity: Some(Severity::Error),
+        }));
+    }
+    let mut exclude_eligible_files = if effective_pattern_config.include.is_some()
+        || effective_pattern_config.files.is_some()
+    {
+        BTreeSet::new()
+    } else {
+        collect_default_pattern_matches(&base_dir, candidate_extensions, &default_excluded_dirs)?
+    };
+
+    if let Some(include_field) = effective_pattern_config.include.as_ref() {
+        for pattern in &include_field.values {
+            let matches = collect_pattern_matches(
+                &include_field.base_dir,
+                pattern,
+                candidate_extensions,
+                &default_excluded_dirs,
+            )?;
+            if matches.is_empty() {
+                findings.push(make_finding(FindingInput {
+                    id: format!(
+                        "tsconfig-patterns:{}:include:{pattern}",
+                        file_path.to_string_lossy()
+                    ),
+                    title: "Include pattern does not match any files".to_string(),
+                    category: Some("tsconfig".to_string()),
+                    detail: Some(format!(
+                        "include pattern \"{pattern}\" matched 0 files under base dir {}.",
+                        include_field.base_dir.to_string_lossy()
+                    )),
+                    file: Some(file_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Fix or remove empty include patterns before TypeScript silently skips expected inputs."
+                            .to_string(),
+                    ),
+                    severity: Some(Severity::Warn),
+                }));
+                continue;
+            }
+
+            exclude_eligible_files.extend(matches);
+        }
+    }
+
+    let mut included_files = explicit_files.clone();
+    included_files.extend(exclude_eligible_files.iter().cloned());
+
+    if included_files.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(exclude_field) = effective_pattern_config.exclude.as_ref() {
+        for pattern in &exclude_field.values {
+            let effective_included_count = explicit_files.len() + exclude_eligible_files.len();
+            let matches = exclude_eligible_files
+                .iter()
+                .filter(|candidate| {
+                    pattern_matches_file(
+                        &exclude_field.base_dir,
+                        pattern,
+                        candidate,
+                        candidate_extensions,
+                        &default_excluded_dirs,
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            let removed_count = matches.len();
+
+            if removed_count == 0 {
+                findings.push(make_finding(FindingInput {
+                    id: format!(
+                        "tsconfig-patterns:{}:exclude:{pattern}",
+                        file_path.to_string_lossy()
+                    ),
+                    title: "Exclude pattern does not filter any included files".to_string(),
+                    category: Some("tsconfig".to_string()),
+                    detail: Some(format!(
+                        "exclude pattern \"{pattern}\" removed 0 files from {} included file(s) under base dir {}.",
+                        effective_included_count,
+                        exclude_field.base_dir.to_string_lossy()
+                    )),
+                    file: Some(file_path.to_path_buf()),
+                    fix_ids: Vec::new(),
+                    fixable: false,
+                    hint: Some(
+                        "Remove or tighten exclude entries that do not change the effective TypeScript input set."
+                            .to_string(),
+                    ),
+                    severity: Some(Severity::Info),
+                }));
+                continue;
+            }
+
+            for matched in matches {
+                exclude_eligible_files.remove(&matched);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_explicit_tsconfig_files(
+    files_field: Option<&EffectivePatternField>,
+    candidate_extensions: &[&str],
+) -> io::Result<(BTreeSet<PathBuf>, Vec<PatternFieldIssue>)> {
+    let Some(files_field) = files_field else {
+        return Ok((BTreeSet::new(), Vec::new()));
+    };
+
+    let mut explicit_files = BTreeSet::new();
+    let mut issues = Vec::new();
+
+    for (index, file) in files_field.values.iter().enumerate() {
+        if file.trim().is_empty() {
+            continue;
+        }
+        if pattern_contains_wildcard(file) {
+            issues.push(PatternFieldIssue {
+                field_name: "files",
+                config_path: files_field.config_path.clone(),
+                suffix: format!("entry-{index}-wildcard"),
+                title: "\"files\" entries must point to explicit files".to_string(),
+                detail: format!(
+                    "{} declares files[{index}] as {file}, but TypeScript files entries cannot use glob wildcards.",
+                    files_field.config_path.to_string_lossy()
+                ),
+                hint: pattern_field_hint("files"),
+            });
+            continue;
+        }
+
+        let resolved = resolve_path(&files_field.base_dir, file);
+        if path_exists(&resolved) {
+            let metadata = match fs::metadata(&resolved) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                    issues.push(PatternFieldIssue {
+                        field_name: "files",
+                        config_path: files_field.config_path.clone(),
+                        suffix: format!("entry-{index}-unreadable"),
+                        title: "\"files\" entries must point to readable files".to_string(),
+                        detail: format!(
+                            "{} declares files[{index}] as {file}, but reading that path failed: {error}.",
+                            files_field.config_path.to_string_lossy()
+                        ),
+                        hint: pattern_field_hint("files"),
+                    });
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            if metadata.is_dir() {
+                issues.push(PatternFieldIssue {
+                    field_name: "files",
+                    config_path: files_field.config_path.clone(),
+                    suffix: format!("entry-{index}-directory"),
+                    title: "\"files\" entries must point to files".to_string(),
+                    detail: format!(
+                        "{} declares files[{index}] as {file}, but that path resolves to a directory.",
+                        files_field.config_path.to_string_lossy()
+                    ),
+                    hint: pattern_field_hint("files"),
+                });
+                continue;
+            }
+            if metadata.is_file() && is_ts_pattern_candidate_file(&resolved, candidate_extensions) {
+                explicit_files.insert(normalize_path(&resolved));
+                continue;
+            }
+
+            issues.push(PatternFieldIssue {
+                field_name: "files",
+                config_path: files_field.config_path.clone(),
+                suffix: format!("entry-{index}-unsupported"),
+                title: "\"files\" entries must point to supported TypeScript input files".to_string(),
+                detail: format!(
+                    "{} declares files[{index}] as {file}, but that file is not a supported TypeScript input.",
+                    files_field.config_path.to_string_lossy()
+                ),
+                hint: pattern_field_hint("files"),
+            });
+            continue;
+        }
+
+        if has_explicit_extension(file) {
+            issues.push(PatternFieldIssue {
+                field_name: "files",
+                config_path: files_field.config_path.clone(),
+                suffix: format!("entry-{index}-missing"),
+                title: "\"files\" entries must point to existing files".to_string(),
+                detail: format!(
+                    "{} declares files[{index}] as {file}, but that path does not resolve to an existing file.",
+                    files_field.config_path.to_string_lossy()
+                ),
+                hint: pattern_field_hint("files"),
+            });
+            continue;
+        }
+
+        let resolved_string = resolved.to_string_lossy();
+        let mut matched_extension = false;
+        for extension in candidate_extensions {
+            let candidate = PathBuf::from(format!("{resolved_string}{extension}"));
+            if path_exists(&candidate) && fs::metadata(&candidate)?.is_file() {
+                explicit_files.insert(normalize_path(&candidate));
+                matched_extension = true;
+            }
+        }
+        if !matched_extension {
+            issues.push(PatternFieldIssue {
+                field_name: "files",
+                config_path: files_field.config_path.clone(),
+                suffix: format!("entry-{index}-missing"),
+                title: "\"files\" entries must point to existing files".to_string(),
+                detail: format!(
+                    "{} declares files[{index}] as {file}, but that path does not resolve to an existing file.",
+                    files_field.config_path.to_string_lossy()
+                ),
+                hint: pattern_field_hint("files"),
+            });
+        }
+    }
+
+    Ok((explicit_files, issues))
+}
+
+fn collect_default_excluded_dirs(
+    effective_pattern_options: &EffectivePatternOptions,
+) -> Vec<PathBuf> {
+    effective_pattern_options.out_dir.iter().cloned().collect()
+}
+
+fn ts_pattern_extensions(allow_js: bool) -> &'static [&'static str] {
+    if allow_js {
+        TS_PATTERN_EXTENSIONS_WITH_JS
+    } else {
+        TS_PATTERN_EXTENSIONS
+    }
+}
+
+fn should_skip_default_pattern_dir(path: &Path, default_excluded_dirs: &[PathBuf]) -> bool {
+    let path = normalize_path(path);
+    if path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| matches!(value, "node_modules" | "bower_components" | "jspm_packages"))
+    {
+        return true;
+    }
+
+    is_within_default_excluded_dir(&path, default_excluded_dirs)
+}
+
+fn is_within_default_excluded_dir(path: &Path, default_excluded_dirs: &[PathBuf]) -> bool {
+    let path = normalize_path(path);
+    default_excluded_dirs
+        .iter()
+        .any(|excluded_dir| path.starts_with(excluded_dir))
+}
+
 fn compare_imports_and_paths(
     findings: &mut Vec<Finding>,
     tsconfig_path: &Path,
@@ -688,7 +1046,10 @@ fn stringify_import_target(import_target: &Value) -> String {
         .unwrap_or_else(|| serde_json::to_string(import_target).unwrap_or_default())
 }
 
-fn resolve_reference_config_path(base_dir: &Path, reference_path: &str) -> io::Result<Option<PathBuf>> {
+fn resolve_reference_config_path(
+    base_dir: &Path,
+    reference_path: &str,
+) -> io::Result<Option<PathBuf>> {
     let resolved = resolve_path(base_dir, reference_path);
 
     if path_exists(&resolved) {
@@ -730,7 +1091,10 @@ fn resolve_effective_composite_inner(
             return match composite_value.as_bool() {
                 Some(true) => Ok(CompositeResolution::Enabled),
                 Some(false) => Ok(CompositeResolution::Disabled),
-                None => Ok(invalid_composite_type_issue(config_path, visited.is_empty())),
+                None => Ok(invalid_composite_type_issue(
+                    config_path,
+                    visited.is_empty(),
+                )),
             };
         }
     }
@@ -790,7 +1154,10 @@ fn resolve_effective_composite_inner(
         }
         Err(error) => return Err(error),
     };
-    let parent_config = match parse_jsonc::<Value>(&parent_text, &parent_config_path.to_string_lossy()) {
+    let parent_config = match parse_jsonc::<Value>(
+        &parent_text,
+        &parent_config_path.to_string_lossy(),
+    ) {
         Ok(parent_config) => parent_config,
         Err(error) => {
             return Ok(CompositeResolution::Issue {
@@ -840,6 +1207,150 @@ fn invalid_composite_type_issue(config_path: &Path, is_direct_target: bool) -> C
     }
 }
 
+fn resolve_effective_pattern_config(
+    config_path: &Path,
+    config: &Value,
+) -> io::Result<EffectivePatternConfig> {
+    let mut visited = Vec::new();
+    resolve_effective_pattern_config_inner(config_path, config, &mut visited)
+}
+
+fn resolve_effective_pattern_config_inner(
+    config_path: &Path,
+    config: &Value,
+    visited: &mut Vec<PathBuf>,
+) -> io::Result<EffectivePatternConfig> {
+    let normalized_config_path = normalize_path(config_path);
+    if visited.contains(&normalized_config_path) {
+        return Ok(EffectivePatternConfig::default());
+    }
+    visited.push(normalized_config_path);
+
+    let mut effective_config = match load_extended_tsconfig_document(config_path, config, visited)? {
+        ExtendedPatternConfigDocument::Loaded(parent_config_path, parent_config) => {
+            resolve_effective_pattern_config_inner(&parent_config_path, &parent_config, visited)?
+        }
+        ExtendedPatternConfigDocument::Issue(issue) => EffectivePatternConfig {
+            issues: vec![issue],
+            ..EffectivePatternConfig::default()
+        },
+        ExtendedPatternConfigDocument::None => EffectivePatternConfig::default(),
+    };
+
+    if let Some(compiler_options) = config.get("compilerOptions").and_then(Value::as_object) {
+        if let Some(allow_js) = compiler_options.get("allowJs").and_then(Value::as_bool) {
+            effective_config.options.allow_js = allow_js;
+        }
+
+        if let Some(out_dir) = compiler_options.get("outDir").and_then(Value::as_str) {
+            effective_config.options.out_dir = Some(resolve_path(
+                config_path.parent().unwrap_or_else(|| Path::new(".")),
+                out_dir,
+            ));
+        }
+    }
+
+    if let Some(config_object) = config.as_object() {
+        apply_pattern_field_override(&mut effective_config, config_object, "include", config_path);
+        apply_pattern_field_override(&mut effective_config, config_object, "exclude", config_path);
+        apply_pattern_field_override(&mut effective_config, config_object, "files", config_path);
+    }
+
+    visited.pop();
+    Ok(effective_config)
+}
+
+fn apply_pattern_field_override(
+    effective_config: &mut EffectivePatternConfig,
+    config_object: &Map<String, Value>,
+    field_name: &'static str,
+    config_path: &Path,
+) {
+    let Some(value) = config_object.get(field_name) else {
+        return;
+    };
+
+    effective_config
+        .issues
+        .retain(|issue| issue.field_name != field_name);
+    let (field, issues) = parse_effective_pattern_field(field_name, value, config_path);
+    match field_name {
+        "include" => effective_config.include = Some(field),
+        "exclude" => effective_config.exclude = Some(field),
+        "files" => effective_config.files = Some(field),
+        _ => {}
+    }
+    effective_config.issues.extend(issues);
+}
+
+fn parse_effective_pattern_field(
+    field_name: &'static str,
+    value: &Value,
+    config_path: &Path,
+) -> (EffectivePatternField, Vec<PatternFieldIssue>) {
+    let base_dir = normalize_path(config_path.parent().unwrap_or_else(|| Path::new(".")));
+    let mut issues = Vec::new();
+
+    let Some(values) = value.as_array() else {
+        issues.push(PatternFieldIssue {
+            field_name,
+            config_path: config_path.to_path_buf(),
+            suffix: "shape".to_string(),
+            title: format!("\"{field_name}\" must be an array of strings"),
+            detail: format!(
+                "{} declares {field_name}, but TypeScript expects an array of string patterns.",
+                config_path.to_string_lossy()
+            ),
+            hint: pattern_field_hint(field_name),
+        });
+        return (
+            EffectivePatternField {
+                values: Vec::new(),
+                base_dir,
+                config_path: config_path.to_path_buf(),
+            },
+            issues,
+        );
+    };
+
+    let mut collected_values = Vec::new();
+    for (index, entry) in values.iter().enumerate() {
+        let Some(pattern) = entry.as_str() else {
+            issues.push(PatternFieldIssue {
+                field_name,
+                config_path: config_path.to_path_buf(),
+                suffix: format!("entry-{index}"),
+                title: format!("\"{field_name}\" contains a non-string pattern"),
+                detail: format!(
+                    "{} declares {field_name}[{index}], but TypeScript expects string patterns.",
+                    config_path.to_string_lossy()
+                ),
+                hint: pattern_field_hint(field_name),
+            });
+            continue;
+        };
+        collected_values.push(pattern.to_string());
+    }
+
+    (
+        EffectivePatternField {
+            values: collected_values,
+            base_dir,
+            config_path: config_path.to_path_buf(),
+        },
+        issues,
+    )
+}
+
+fn pattern_field_hint(field_name: &str) -> &'static str {
+    match field_name {
+        "include" => "Rewrite include as an array of string globs before relying on TypeScript input discovery.",
+        "exclude" => "Rewrite exclude as an array of string globs before relying on TypeScript input filtering.",
+        "files" => "Rewrite files as an array of string paths before relying on explicit TypeScript inputs.",
+        _ => "Rewrite tsconfig pattern fields as arrays of strings.",
+    }
+}
+
 fn resolve_extends_config_path(base_dir: &Path, extends_path: &str) -> Option<PathBuf> {
     let extends_candidate = Path::new(extends_path);
     let is_local_extends = extends_candidate.is_absolute()
@@ -848,7 +1359,9 @@ fn resolve_extends_config_path(base_dir: &Path, extends_path: &str) -> Option<Pa
         || extends_path.starts_with(".\\")
         || extends_path.starts_with("..\\");
     if is_local_extends {
-        return resolve_tsconfig_candidate(&resolve_path(base_dir, extends_path)).ok().flatten();
+        return resolve_tsconfig_candidate(&resolve_path(base_dir, extends_path))
+            .ok()
+            .flatten();
     }
 
     for ancestor in base_dir.ancestors() {
@@ -859,6 +1372,127 @@ fn resolve_extends_config_path(base_dir: &Path, extends_path: &str) -> Option<Pa
     }
 
     None
+}
+
+fn load_extended_tsconfig_document(
+    config_path: &Path,
+    config: &Value,
+    visited: &[PathBuf],
+) -> io::Result<ExtendedPatternConfigDocument> {
+    let Some(extends_path) = config.get("extends").and_then(Value::as_str) else {
+        return Ok(ExtendedPatternConfigDocument::None);
+    };
+    let Some(parent_config_path) = resolve_extends_config_path(
+        config_path.parent().unwrap_or_else(|| Path::new(".")),
+        extends_path,
+    ) else {
+        return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+            "missing",
+            config_path.to_path_buf(),
+            "Inherited tsconfig could not be found".to_string(),
+            format!(
+                "{} extends {extends_path}, but that config file could not be resolved.",
+                config_path.to_string_lossy()
+            ),
+            "Fix missing extends targets before relying on inherited tsconfig pattern settings.",
+        )));
+    };
+    if visited_contains_path(visited, &parent_config_path) {
+        return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+            "cycle",
+            parent_config_path.clone(),
+            "Inherited tsconfig extends cycle detected".to_string(),
+            format!(
+                "{} creates a cycle in the extends chain for pattern resolution.",
+                parent_config_path.to_string_lossy()
+            ),
+            "Break extends cycles before relying on inherited tsconfig pattern settings.",
+        )));
+    };
+
+    let parent_text = match read_text_if_exists(&parent_config_path) {
+        Ok(Some(parent_text)) => parent_text,
+        Ok(None) => {
+            return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+                "unreadable",
+                parent_config_path.clone(),
+                "Inherited tsconfig could not be read".to_string(),
+                format!(
+                    "{} extends {}, but that config file could not be read.",
+                    config_path.to_string_lossy(),
+                    parent_config_path.to_string_lossy()
+                ),
+                "Make sure extended tsconfig files are readable before relying on inherited pattern settings.",
+            )))
+        }
+        Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+            return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+                "unreadable",
+                parent_config_path.clone(),
+                "Inherited tsconfig could not be read".to_string(),
+                format!(
+                    "{} extends {}, but reading it failed: {error}.",
+                    config_path.to_string_lossy(),
+                    parent_config_path.to_string_lossy()
+                ),
+                "Make sure extended tsconfig files are readable before relying on inherited pattern settings.",
+            )))
+        }
+        Err(error) => return Err(error),
+    };
+    let parent_config =
+        match parse_jsonc::<Value>(&parent_text, &parent_config_path.to_string_lossy()) {
+            Ok(parent_config) => parent_config,
+            Err(error) => {
+                return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+                    "parse",
+                    parent_config_path.clone(),
+                    "Inherited tsconfig could not be parsed".to_string(),
+                    error.to_string(),
+                    "Fix invalid JSONC syntax in extended tsconfig files before relying on inherited pattern settings.",
+                )))
+            }
+        };
+    if !looks_like_tsconfig_document(&parent_config_path, &parent_config) {
+        return Ok(ExtendedPatternConfigDocument::Issue(pattern_extends_issue(
+            "invalid-target",
+            parent_config_path.clone(),
+            "Inherited config must point to a tsconfig file".to_string(),
+            format!(
+                "{} extends {}, but that file does not look like a tsconfig document.",
+                config_path.to_string_lossy(),
+                parent_config_path.to_string_lossy()
+            ),
+            "Point extends at a real tsconfig-style file before relying on inherited pattern settings.",
+        )));
+    }
+
+    Ok(ExtendedPatternConfigDocument::Loaded(
+        parent_config_path,
+        parent_config,
+    ))
+}
+
+fn visited_contains_path(visited: &[PathBuf], candidate: &Path) -> bool {
+    let candidate = normalize_path(candidate);
+    visited.contains(&candidate)
+}
+
+fn pattern_extends_issue(
+    suffix: &str,
+    config_path: PathBuf,
+    title: String,
+    detail: String,
+    hint: &'static str,
+) -> PatternFieldIssue {
+    PatternFieldIssue {
+        field_name: "extends",
+        config_path,
+        suffix: suffix.to_string(),
+        title,
+        detail,
+        hint,
+    }
 }
 
 fn looks_like_tsconfig_document(file_path: &Path, config: &Value) -> bool {
@@ -904,7 +1538,8 @@ fn looks_like_tsconfig_file_name(file_path: &Path) -> bool {
         return false;
     };
 
-    file_name == "tsconfig.json" || (file_name.starts_with("tsconfig.") && file_name.ends_with(".json"))
+    file_name == "tsconfig.json"
+        || (file_name.starts_with("tsconfig.") && file_name.ends_with(".json"))
 }
 
 fn is_known_non_tsconfig_file(file_path: &Path) -> bool {
@@ -1058,7 +1693,7 @@ fn matches_path(candidate_path: &Path, patterns: &[String]) -> bool {
     let normalized_path = normalize_path_for_match(candidate_path);
     patterns
         .iter()
-        .any(|pattern| wildcard_pattern_matches(&normalized_path, pattern))
+        .any(|pattern| pattern_matches_candidate(&normalized_path, pattern))
 }
 
 fn build_wildcard_patterns(base_dir: &Path, target: &str) -> Vec<String> {
@@ -1083,13 +1718,77 @@ fn has_explicit_extension(target: &str) -> bool {
 }
 
 fn wildcard_pattern_matches(candidate: &str, pattern: &str) -> bool {
-    let candidate_chars = candidate.chars().collect::<Vec<_>>();
-    let pattern_chars = pattern.chars().collect::<Vec<_>>();
-    let mut memo = vec![vec![None; pattern_chars.len() + 1]; candidate_chars.len() + 1];
+    fn segment_pattern_matches(candidate: &str, pattern: &str) -> bool {
+        let candidate_chars = candidate.chars().collect::<Vec<_>>();
+        let pattern_chars = pattern.chars().collect::<Vec<_>>();
+        let mut memo = vec![vec![None; pattern_chars.len() + 1]; candidate_chars.len() + 1];
 
-    fn matches(
-        candidate: &[char],
-        pattern: &[char],
+        fn matches(
+            candidate: &[char],
+            pattern: &[char],
+            candidate_index: usize,
+            pattern_index: usize,
+            memo: &mut [Vec<Option<bool>>],
+        ) -> bool {
+            if let Some(result) = memo[candidate_index][pattern_index] {
+                return result;
+            }
+
+            let result = if pattern_index == pattern.len() {
+                candidate_index == candidate.len()
+            } else if pattern[pattern_index] == '*' {
+                let mut offset = candidate_index;
+                let mut matched = false;
+                while offset <= candidate.len() {
+                    if matches(candidate, pattern, offset, pattern_index + 1, memo) {
+                        matched = true;
+                        break;
+                    }
+                    if offset == candidate.len() {
+                        break;
+                    }
+                    offset += 1;
+                }
+                matched
+            } else if candidate_index < candidate.len()
+                && pattern[pattern_index] == '?'
+                && candidate[candidate_index] != '/'
+            {
+                matches(
+                    candidate,
+                    pattern,
+                    candidate_index + 1,
+                    pattern_index + 1,
+                    memo,
+                )
+            } else if candidate_index < candidate.len()
+                && candidate[candidate_index] == pattern[pattern_index]
+            {
+                matches(
+                    candidate,
+                    pattern,
+                    candidate_index + 1,
+                    pattern_index + 1,
+                    memo,
+                )
+            } else {
+                false
+            };
+
+            memo[candidate_index][pattern_index] = Some(result);
+            result
+        }
+
+        matches(&candidate_chars, &pattern_chars, 0, 0, &mut memo)
+    }
+
+    let candidate_segments = candidate.split('/').collect::<Vec<_>>();
+    let pattern_segments = pattern.split('/').collect::<Vec<_>>();
+    let mut memo = vec![vec![None; pattern_segments.len() + 1]; candidate_segments.len() + 1];
+
+    fn matches_segments(
+        candidate: &[&str],
+        pattern: &[&str],
         candidate_index: usize,
         pattern_index: usize,
         memo: &mut [Vec<Option<bool>>],
@@ -1100,21 +1799,13 @@ fn wildcard_pattern_matches(candidate: &str, pattern: &str) -> bool {
 
         let result = if pattern_index == pattern.len() {
             candidate_index == candidate.len()
-        } else if pattern[pattern_index] == '*' {
-            let mut offset = candidate_index + 1;
-            let mut matched = false;
-            while offset <= candidate.len() {
-                if matches(candidate, pattern, offset, pattern_index + 1, memo) {
-                    matched = true;
-                    break;
-                }
-                offset += 1;
-            }
-            matched
+        } else if pattern[pattern_index] == "**" {
+            (candidate_index..=candidate.len())
+                .any(|offset| matches_segments(candidate, pattern, offset, pattern_index + 1, memo))
         } else if candidate_index < candidate.len()
-            && candidate[candidate_index] == pattern[pattern_index]
+            && segment_pattern_matches(candidate[candidate_index], pattern[pattern_index])
         {
-            matches(
+            matches_segments(
                 candidate,
                 pattern,
                 candidate_index + 1,
@@ -1129,7 +1820,11 @@ fn wildcard_pattern_matches(candidate: &str, pattern: &str) -> bool {
         result
     }
 
-    matches(&candidate_chars, &pattern_chars, 0, 0, &mut memo)
+    matches_segments(&candidate_segments, &pattern_segments, 0, 0, &mut memo)
+}
+
+fn pattern_matches_candidate(candidate: &str, pattern: &str) -> bool {
+    wildcard_pattern_matches(candidate, pattern)
 }
 
 fn normalize_path_for_match(path: &Path) -> String {
@@ -1142,6 +1837,256 @@ fn has_url_like_prefix(target: &str) -> bool {
     };
 
     !prefix.is_empty() && prefix.chars().all(|ch| ch.is_ascii_alphabetic())
+}
+
+fn collect_pattern_matches(
+    base_dir: &Path,
+    pattern: &str,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<Vec<PathBuf>> {
+    if pattern.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if !pattern_contains_wildcard(pattern) {
+        return collect_static_pattern_matches(
+            base_dir,
+            pattern,
+            candidate_extensions,
+            default_excluded_dirs,
+        );
+    }
+
+    let search_root = resolve_pattern_search_root(base_dir, pattern);
+    if !path_exists(&search_root) {
+        return Ok(Vec::new());
+    }
+    if is_within_default_excluded_dir(&search_root, default_excluded_dirs) {
+        return Ok(Vec::new());
+    }
+
+    let mut matches = BTreeSet::new();
+    collect_pattern_matches_recursive(
+        &search_root,
+        &resolve_path(base_dir, pattern),
+        candidate_extensions,
+        default_excluded_dirs,
+        &mut matches,
+    )?;
+    Ok(matches.into_iter().collect())
+}
+
+fn collect_default_pattern_matches(
+    base_dir: &Path,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<BTreeSet<PathBuf>> {
+    let mut matches = BTreeSet::new();
+    collect_supported_files_recursively(
+        base_dir,
+        &mut matches,
+        candidate_extensions,
+        default_excluded_dirs,
+    )?;
+    Ok(matches)
+}
+
+fn collect_static_pattern_matches(
+    base_dir: &Path,
+    pattern: &str,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<Vec<PathBuf>> {
+    let resolved = resolve_path(base_dir, pattern);
+    if path_exists(&resolved) {
+        let metadata = fs::metadata(&resolved)?;
+        if metadata.is_dir() {
+            if is_within_default_excluded_dir(&resolved, default_excluded_dirs) {
+                return Ok(Vec::new());
+            }
+            let mut matches = BTreeSet::new();
+            collect_supported_files_recursively(
+                &resolved,
+                &mut matches,
+                candidate_extensions,
+                default_excluded_dirs,
+            )?;
+            return Ok(matches.into_iter().collect());
+        }
+
+        if metadata.is_file()
+            && !is_within_default_excluded_dir(&resolved, default_excluded_dirs)
+            && is_ts_pattern_candidate_file(&resolved, candidate_extensions)
+        {
+            return Ok(vec![resolved]);
+        }
+        return Ok(Vec::new());
+    }
+
+    if has_explicit_extension(pattern) {
+        return Ok(Vec::new());
+    }
+
+    let resolved_string = resolved.to_string_lossy();
+    let mut matches = Vec::new();
+    for extension in candidate_extensions {
+        let candidate = PathBuf::from(format!("{resolved_string}{extension}"));
+        if path_exists(&candidate)
+            && !is_within_default_excluded_dir(&candidate, default_excluded_dirs)
+            && fs::metadata(&candidate)?.is_file()
+        {
+            matches.push(candidate);
+        }
+    }
+
+    Ok(matches)
+}
+
+fn collect_supported_files_recursively(
+    root: &Path,
+    matches: &mut BTreeSet<PathBuf>,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<()> {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::PermissionDenied => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if should_skip_default_pattern_dir(&entry_path, default_excluded_dirs) {
+                continue;
+            }
+            collect_supported_files_recursively(
+                &entry_path,
+                matches,
+                candidate_extensions,
+                default_excluded_dirs,
+            )?;
+            continue;
+        }
+
+        if file_type.is_file() && is_ts_pattern_candidate_file(&entry_path, candidate_extensions) {
+            matches.insert(normalize_path(&entry_path));
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_pattern_matches_recursive(
+    root: &Path,
+    absolute_pattern: &Path,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+    matches: &mut BTreeSet<PathBuf>,
+) -> io::Result<()> {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::PermissionDenied => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            if should_skip_default_pattern_dir(&entry_path, default_excluded_dirs) {
+                continue;
+            }
+            collect_pattern_matches_recursive(
+                &entry_path,
+                absolute_pattern,
+                candidate_extensions,
+                default_excluded_dirs,
+                matches,
+            )?;
+            continue;
+        }
+
+        if file_type.is_file()
+            && is_ts_pattern_candidate_file(&entry_path, candidate_extensions)
+            && pattern_matches_candidate(
+                &normalize_path_for_match(&entry_path),
+                &normalize_path_for_match(absolute_pattern),
+            )
+        {
+            matches.insert(normalize_path(&entry_path));
+        }
+    }
+
+    Ok(())
+}
+
+fn pattern_matches_file(
+    base_dir: &Path,
+    pattern: &str,
+    candidate: &Path,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> bool {
+    if pattern.trim().is_empty() {
+        return false;
+    }
+
+    let candidate = normalize_path(candidate);
+    if !pattern_contains_wildcard(pattern) {
+        let resolved = resolve_path(base_dir, pattern);
+        if path_exists(&resolved) {
+            return fs::metadata(&resolved)
+                .map(|metadata| {
+                    if metadata.is_dir() {
+                        !should_skip_default_pattern_dir(&resolved, default_excluded_dirs)
+                            && candidate.starts_with(&resolved)
+                    } else {
+                        candidate == normalize_path(&resolved)
+                    }
+                })
+                .unwrap_or(false);
+        }
+
+        if has_explicit_extension(pattern) {
+            return false;
+        }
+
+        let resolved_string = resolved.to_string_lossy();
+        return candidate_extensions
+            .iter()
+            .any(|extension| candidate == PathBuf::from(format!("{resolved_string}{extension}")));
+    }
+
+    pattern_matches_candidate(
+        &normalize_path_for_match(&candidate),
+        &normalize_path_for_match(&resolve_path(base_dir, pattern)),
+    )
+}
+
+fn resolve_pattern_search_root(base_dir: &Path, pattern: &str) -> PathBuf {
+    let prefix = pattern
+        .find(['*', '?'])
+        .map(|index| &pattern[..index])
+        .unwrap_or(pattern);
+    let search_prefix = wildcard_search_prefix(prefix);
+    resolve_path(base_dir, search_prefix)
+}
+
+fn pattern_contains_wildcard(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?')
+}
+
+fn is_ts_pattern_candidate_file(path: &Path, candidate_extensions: &[&str]) -> bool {
+    let normalized = normalize_path_for_match(path);
+    candidate_extensions
+        .iter()
+        .any(|extension| normalized.ends_with(extension))
 }
 
 fn resolve_path(base_dir: &Path, target: &str) -> PathBuf {

--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -2,14 +2,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use maximus_core::{discover_project, Severity};
-use tempfile::TempDir;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
 
-#[path = "../src/tsconfig.rs"]
-mod tsconfig;
 #[path = "../src/check_outcome.rs"]
 mod check_outcome;
+#[path = "../src/tsconfig.rs"]
+mod tsconfig;
 
 use tsconfig::run_tsconfig_check;
 
@@ -468,6 +468,792 @@ fn tsconfig_check_treats_paths_targets_as_fallback_candidates() {
 }
 
 #[test]
+fn tsconfig_check_reports_empty_include_and_useless_exclude_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("empty-include/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("empty-include/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("empty-exclude/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/**/*.ts"],
+          "exclude": ["generated/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("empty-exclude/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("useful-patterns/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/**/*.ts"],
+          "exclude": ["src/generated/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("useful-patterns/src/index.ts"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("useful-patterns/src/generated/skip.ts"),
+        "export const skip = true;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:src/missing/**/*.ts",
+            fixture
+                .path()
+                .join("empty-include/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"src/missing/**/*.ts\" matched 0 files under base dir {}.",
+            fixture.path().join("empty-include").to_string_lossy()
+        ),
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+        Some(fixture.path().join("empty-include/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:exclude:generated/**/*.ts",
+            fixture
+                .path()
+                .join("empty-exclude/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"generated/**/*.ts\" removed 0 files from 1 included file(s) under base dir {}.",
+            fixture.path().join("empty-exclude").to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(fixture.path().join("empty-exclude/tsconfig.json")),
+    );
+
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("useful-patterns/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "useful include/exclude patterns should not report tsconfig-pattern findings"
+    );
+}
+
+#[test]
+fn tsconfig_check_uses_default_include_and_allow_js_rules_for_pattern_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("exclude-only/tsconfig.json"),
+        r#"
+        {
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("exclude-only/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+
+    write(
+        fixture.path().join("js-without-allowjs/tsconfig.json"),
+        r#"
+        {
+          "include": ["src"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("js-without-allowjs/src/index.js"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("js-with-allowjs/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "allowJs": true
+          },
+          "include": ["src"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("js-with-allowjs/src/index.js"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("question-mark-include/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/file?.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("question-mark-include/src/file1.ts"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("star-zero-include/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/file*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("star-zero-include/src/file.ts"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("inherited-allowjs/tsconfig.json"),
+        r#"
+        {
+          "extends": "./tsconfig.base.json",
+          "include": ["src"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("inherited-allowjs/tsconfig.base.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "allowJs": true
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("inherited-allowjs/src/index.js"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("inherited-outdir/tsconfig.json"),
+        r#"
+        {
+          "extends": "./tsconfig.base.json",
+          "exclude": ["dist/**/*.d.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("inherited-outdir/tsconfig.base.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "outDir": "./dist"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("inherited-outdir/src/index.d.ts"),
+        "export declare const source: true;\n",
+    );
+    write(
+        fixture.path().join("inherited-outdir/dist/index.d.ts"),
+        "export declare const built: true;\n",
+    );
+    write(
+        fixture.path().join("outdir-include/tsconfig.json"),
+        r#"
+        {
+          "extends": "./tsconfig.base.json",
+          "include": ["dist"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-include/tsconfig.base.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "outDir": "./dist"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-include/dist/index.d.ts"),
+        "export declare const built: true;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:exclude:missing/**/*.ts",
+            fixture
+                .path()
+                .join("exclude-only/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"missing/**/*.ts\" removed 0 files from 1 included file(s) under base dir {}.",
+            fixture.path().join("exclude-only").to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(fixture.path().join("exclude-only/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:src",
+            fixture
+                .path()
+                .join("js-without-allowjs/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"src\" matched 0 files under base dir {}.",
+            fixture.path().join("js-without-allowjs").to_string_lossy()
+        ),
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+        Some(fixture.path().join("js-without-allowjs/tsconfig.json")),
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("js-with-allowjs/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "allowJs-enabled include patterns should accept JavaScript inputs"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("question-mark-include/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "question-mark wildcards should match single-character file names"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("star-zero-include/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "star wildcards should still match zero-width suffixes"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("inherited-allowjs/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "allowJs inherited through extends should allow JavaScript inputs"
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:exclude:dist/**/*.d.ts",
+            fixture
+                .path()
+                .join("inherited-outdir/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"dist/**/*.d.ts\" removed 0 files from 1 included file(s) under base dir {}.",
+            fixture.path().join("inherited-outdir").to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(fixture.path().join("inherited-outdir/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:dist",
+            fixture
+                .path()
+                .join("outdir-include/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"dist\" matched 0 files under base dir {}.",
+            fixture.path().join("outdir-include").to_string_lossy()
+        ),
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+        Some(fixture.path().join("outdir-include/tsconfig.json")),
+    );
+}
+
+#[test]
+fn tsconfig_check_skips_explicitly_empty_inputs_and_implicit_default_excludes() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("include-empty/tsconfig.json"),
+        r#"
+        {
+          "include": [],
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("include-empty/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+
+    write(
+        fixture.path().join("files-empty/tsconfig.json"),
+        r#"
+        {
+          "files": [],
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("files-empty/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+
+    write(
+        fixture.path().join("default-excludes/tsconfig.json"),
+        r#"
+        {
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture
+            .path()
+            .join("default-excludes/node_modules/pkg/index.d.ts"),
+        "export declare const ignored: true;\n",
+    );
+    write(
+        fixture.path().join("files-with-exclude/tsconfig.json"),
+        r#"
+        {
+          "files": ["src/index.d.ts"],
+          "exclude": ["src/**/*.d.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("files-with-exclude/src/index.d.ts"),
+        "export declare const explicit: true;\n",
+    );
+    write(
+        fixture.path().join("duplicate-excludes/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/**/*.d.ts"],
+          "exclude": ["src/generated/**/*.d.ts", "src/generated/**/*.d.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture
+            .path()
+            .join("duplicate-excludes/src/generated/index.d.ts"),
+        "export declare const duplicated: true;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("include-empty/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "explicitly empty include arrays should not fall back to default include scanning"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("files-empty/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "files arrays should disable default include scanning even when they are empty"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("default-excludes/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "implicit default excludes like node_modules should not count as included inputs"
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:exclude:src/**/*.d.ts",
+            fixture
+                .path()
+                .join("files-with-exclude/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"src/**/*.d.ts\" removed 0 files from 1 included file(s) under base dir {}.",
+            fixture.path().join("files-with-exclude").to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(fixture.path().join("files-with-exclude/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:exclude:src/generated/**/*.d.ts",
+            fixture
+                .path()
+                .join("duplicate-excludes/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"src/generated/**/*.d.ts\" removed 0 files from 0 included file(s) under base dir {}.",
+            fixture.path().join("duplicate-excludes").to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(fixture.path().join("duplicate-excludes/tsconfig.json")),
+    );
+}
+
+#[test]
+fn tsconfig_check_inherits_pattern_fields_and_reports_invalid_pattern_entries() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("shared/tsconfig.base.json"),
+        r#"
+        {
+          "include": ["./src/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("app-inherited-include/tsconfig.json"),
+        r#"
+        {
+          "extends": "../shared/tsconfig.base.json"
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("app-inherited-include/src/index.ts"),
+        "export const ok = true;\n",
+    );
+    write(
+        fixture.path().join("app-missing-extends/tsconfig.json"),
+        r#"
+        {
+          "extends": "../shared-missing/tsconfig.base.json"
+        }
+        "#,
+    );
+
+    write(
+        fixture.path().join("shared-empty/tsconfig.base.json"),
+        r#"
+        {
+          "files": []
+        }
+        "#,
+    );
+    write(
+        fixture
+            .path()
+            .join("app-inherited-files-empty/tsconfig.json"),
+        r#"
+        {
+          "extends": "../shared-empty/tsconfig.base.json",
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture
+            .path()
+            .join("app-inherited-files-empty/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+
+    write(
+        fixture.path().join("invalid-pattern-entry/tsconfig.json"),
+        r#"
+        {
+          "include": [42]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("invalid-files-entry/tsconfig.json"),
+        r#"
+        {
+          "files": ["src/*.ts"],
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("invalid-files-entry/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+    write(
+        fixture.path().join("invalid-files-directory/tsconfig.json"),
+        r#"
+        {
+          "files": ["src"],
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("invalid-files-directory/src/index.d.ts"),
+        "export declare const ok: true;\n",
+    );
+    write(
+        fixture.path().join("invalid-files-missing/tsconfig.json"),
+        r#"
+        {
+          "files": ["src/missing.ts"],
+          "exclude": ["missing/**/*.ts"]
+        }
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:./src/**/*.ts",
+            fixture
+                .path()
+                .join("app-inherited-include/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"./src/**/*.ts\" matched 0 files under base dir {}.",
+            fixture.path().join("shared").to_string_lossy()
+        ),
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+        Some(fixture.path().join("app-inherited-include/tsconfig.json")),
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-patterns:{}:",
+                fixture
+                    .path()
+                    .join("app-inherited-files-empty/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "inherited files arrays should disable default include scanning on child configs"
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns-shape:{}:extends:missing:{}",
+            fixture
+                .path()
+                .join("app-missing-extends/tsconfig.json")
+                .to_string_lossy(),
+            fixture
+                .path()
+                .join("app-missing-extends/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Inherited tsconfig could not be found",
+        &format!(
+            "{} extends ../shared-missing/tsconfig.base.json, but that config file could not be resolved.",
+            fixture
+                .path()
+                .join("app-missing-extends/tsconfig.json")
+                .to_string_lossy()
+        ),
+        "Fix missing extends targets before relying on inherited tsconfig pattern settings.",
+        Some(fixture.path().join("app-missing-extends/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns-shape:{}:include:entry-0:{}",
+            fixture
+                .path()
+                .join("invalid-pattern-entry/tsconfig.json")
+                .to_string_lossy(),
+            fixture
+                .path()
+                .join("invalid-pattern-entry/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "\"include\" contains a non-string pattern",
+        &format!(
+            "{} declares include[0], but TypeScript expects string patterns.",
+            fixture
+                .path()
+                .join("invalid-pattern-entry/tsconfig.json")
+                .to_string_lossy()
+        ),
+        "Rewrite include as an array of string globs before relying on TypeScript input discovery.",
+        Some(fixture.path().join("invalid-pattern-entry/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns-shape:{}:files:entry-0-wildcard:{}",
+            fixture
+                .path()
+                .join("invalid-files-entry/tsconfig.json")
+                .to_string_lossy(),
+            fixture
+                .path()
+                .join("invalid-files-entry/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "\"files\" entries must point to explicit files",
+        &format!(
+            "{} declares files[0] as src/*.ts, but TypeScript files entries cannot use glob wildcards.",
+            fixture
+                .path()
+                .join("invalid-files-entry/tsconfig.json")
+                .to_string_lossy()
+        ),
+        "Rewrite files as an array of string paths before relying on explicit TypeScript inputs.",
+        Some(fixture.path().join("invalid-files-entry/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns-shape:{}:files:entry-0-directory:{}",
+            fixture
+                .path()
+                .join("invalid-files-directory/tsconfig.json")
+                .to_string_lossy(),
+            fixture
+                .path()
+                .join("invalid-files-directory/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "\"files\" entries must point to files",
+        &format!(
+            "{} declares files[0] as src, but that path resolves to a directory.",
+            fixture
+                .path()
+                .join("invalid-files-directory/tsconfig.json")
+                .to_string_lossy()
+        ),
+        "Rewrite files as an array of string paths before relying on explicit TypeScript inputs.",
+        Some(fixture.path().join("invalid-files-directory/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns-shape:{}:files:entry-0-missing:{}",
+            fixture
+                .path()
+                .join("invalid-files-missing/tsconfig.json")
+                .to_string_lossy(),
+            fixture
+                .path()
+                .join("invalid-files-missing/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "\"files\" entries must point to existing files",
+        &format!(
+            "{} declares files[0] as src/missing.ts, but that path does not resolve to an existing file.",
+            fixture
+                .path()
+                .join("invalid-files-missing/tsconfig.json")
+                .to_string_lossy()
+        ),
+        "Rewrite files as an array of string paths before relying on explicit TypeScript inputs.",
+        Some(fixture.path().join("invalid-files-missing/tsconfig.json")),
+    );
+}
+
+#[test]
 fn tsconfig_check_reports_project_reference_missing_and_composite_contracts() {
     let fixture = TempDir::new().expect("temp dir should exist");
 
@@ -576,8 +1362,8 @@ fn tsconfig_check_reports_invalid_composite_value_types() {
         r#"{ "compilerOptions": { "composite": true } }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let finding = outcome
@@ -635,8 +1421,8 @@ fn tsconfig_check_does_not_resolve_extensionless_reference_paths_to_sibling_json
         r#"{ "compilerOptions": { "composite": true } }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert_has_finding(
@@ -676,8 +1462,8 @@ fn tsconfig_check_respects_inherited_composite_for_project_references() {
         r#"{ "extends": "../../tsconfig.base.json" }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert!(
@@ -717,8 +1503,8 @@ fn tsconfig_check_respects_package_based_extends_for_project_references() {
         r#"{ "extends": "@tsconfig/shared/tsconfig.json" }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert!(
@@ -756,8 +1542,8 @@ fn tsconfig_check_reports_inherited_parse_errors_before_composite_missing() {
         r#"{ "compilerOptions": { "composite": true, }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let finding = outcome
@@ -781,7 +1567,10 @@ fn tsconfig_check_reports_inherited_parse_errors_before_composite_missing() {
         finding.hint,
         "Fix invalid JSONC syntax in extended tsconfig files before relying on inherited composite settings."
     );
-    assert_eq!(finding.file, Some(fixture.path().join("root/tsconfig.json")));
+    assert_eq!(
+        finding.file,
+        Some(fixture.path().join("root/tsconfig.json"))
+    );
     assert!(
         outcome.findings.iter().all(|finding| {
             finding.id
@@ -813,8 +1602,8 @@ fn tsconfig_check_reports_missing_inherited_configs_before_composite_missing() {
         r#"{ "extends": "../../tsconfig.base.json" }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let finding = outcome
@@ -838,7 +1627,10 @@ fn tsconfig_check_reports_missing_inherited_configs_before_composite_missing() {
         finding.hint,
         "Make sure extends points at an existing tsconfig-style file before relying on inherited composite settings."
     );
-    assert_eq!(finding.file, Some(fixture.path().join("root/tsconfig.json")));
+    assert_eq!(
+        finding.file,
+        Some(fixture.path().join("root/tsconfig.json"))
+    );
     assert!(
         outcome.findings.iter().all(|finding| {
             finding.id
@@ -874,8 +1666,8 @@ fn tsconfig_check_reports_extends_cycles_before_composite_missing() {
         r#"{ "extends": "./packages/pkg-a/tsconfig.json" }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let finding = outcome
@@ -931,8 +1723,8 @@ fn tsconfig_check_reports_unparseable_project_reference_targets() {
         r#"{ "compilerOptions": { "paths": { "@bad/*": ["src/*",] } }"#,
     );
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let parse_finding = outcome
@@ -960,9 +1752,7 @@ fn tsconfig_check_reports_unparseable_project_reference_targets() {
         Some(fixture.path().join("root/tsconfig.json"))
     );
     assert!(
-        parse_finding
-            .detail
-            .contains("pkg-a/tsconfig.json"),
+        parse_finding.detail.contains("pkg-a/tsconfig.json"),
         "parse detail should preserve the referenced target path"
     );
 }
@@ -1057,7 +1847,10 @@ fn tsconfig_check_reports_project_reference_shape_errors() {
         &outcome.findings,
         &format!(
             "tsconfig-references-entry:{}:0",
-            fixture.path().join("entries/tsconfig.json").to_string_lossy()
+            fixture
+                .path()
+                .join("entries/tsconfig.json")
+                .to_string_lossy()
         ),
         Severity::Error,
         "Each project reference entry must be an object with a path",
@@ -1069,7 +1862,10 @@ fn tsconfig_check_reports_project_reference_shape_errors() {
         &outcome.findings,
         &format!(
             "tsconfig-references-entry:{}:1",
-            fixture.path().join("entries/tsconfig.json").to_string_lossy()
+            fixture
+                .path()
+                .join("entries/tsconfig.json")
+                .to_string_lossy()
         ),
         Severity::Error,
         "Each project reference entry must declare a string path",
@@ -1081,7 +1877,10 @@ fn tsconfig_check_reports_project_reference_shape_errors() {
         &outcome.findings,
         &format!(
             "tsconfig-references-entry:{}:2",
-            fixture.path().join("entries/tsconfig.json").to_string_lossy()
+            fixture
+                .path()
+                .join("entries/tsconfig.json")
+                .to_string_lossy()
         ),
         Severity::Error,
         "Each project reference entry must declare a string path",
@@ -1107,7 +1906,10 @@ fn tsconfig_check_reports_unreadable_project_reference_targets() {
         }
         "#,
     );
-    write(&target_path, r#"{ "compilerOptions": { "composite": true } }"#);
+    write(
+        &target_path,
+        r#"{ "compilerOptions": { "composite": true } }"#,
+    );
 
     let original_permissions = fs::metadata(&target_path)
         .expect("target metadata should exist")
@@ -1117,8 +1919,8 @@ fn tsconfig_check_reports_unreadable_project_reference_targets() {
     fs::set_permissions(&target_path, unreadable_permissions)
         .expect("target permissions should update");
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     let mut restore_permissions = original_permissions;
@@ -1226,8 +2028,8 @@ fn tsconfig_check_accepts_empty_json_reference_targets_with_explicit_file_names(
     );
     write(fixture.path().join("packages/pkg-a/build.json"), "{}");
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert!(
@@ -1258,8 +2060,8 @@ fn tsconfig_check_rejects_empty_generic_json_reference_targets() {
     );
     write(fixture.path().join("packages/pkg-a/schema.json"), "{}");
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert_has_finding(
@@ -1295,8 +2097,8 @@ fn tsconfig_check_accepts_empty_reference_targets_with_non_json_file_names() {
     );
     write(fixture.path().join("packages/pkg-a/build"), "{}");
 
-    let project = discover_project(fixture.path().join("root").as_path())
-        .expect("project should discover");
+    let project =
+        discover_project(fixture.path().join("root").as_path()).expect("project should discover");
     let outcome = run_tsconfig_check(&project).expect("check should run");
 
     assert!(

--- a/docs/checker-ideas.md
+++ b/docs/checker-ideas.md
@@ -21,7 +21,6 @@ If you want to extend one of those areas, start with [Checker Authoring](./archi
 
 | Idea | Area | Why it matters | Likely home |
 | --- | --- | --- | --- |
-| Empty `include` or `exclude` pattern detection | TypeScript | Catches configurations that look intentional but match nothing | `crates/maximus-checks/src/tsconfig.rs` |
 | Output path overlap detection | TypeScript | Prevents `outDir`, `declarationDir`, or build outputs from stepping on each other | `crates/maximus-checks/src/tsconfig.rs` |
 | Module system consistency | TypeScript and package metadata | Flags mismatches between `package.json`, `tsconfig`, and emitted files | `crates/maximus-checks/src/tsconfig.rs`, `crates/maximus-checks/src/package_entrypoints.rs` |
 | Path alias shadowing | TypeScript | Finds aliases that hide package imports or each other in surprising ways | `crates/maximus-checks/src/tsconfig.rs` |

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -16,7 +16,7 @@ Read these first:
 
 | Topic | Difficulty | Why it is a good first issue | Start here | Validation |
 | --- | --- | --- | --- | --- |
-| Empty `include` and `exclude` pattern diagnostics in `tsconfig` | Small | One checker, one fixture family, easy failing case | `crates/maximus-checks/src/tsconfig.rs`, `crates/maximus-checks/tests/tsconfig_checks.rs` | `cargo test -p maximus-checks --test tsconfig_checks`, `npm test`, `node ./bin/maximus.js audit <fixture>` |
+| Add one `tsconfig` regression case around false positives or missing diagnostics | Small | One checker, one fixture family, and a tight validation path | `crates/maximus-checks/src/tsconfig.rs`, `crates/maximus-checks/tests/tsconfig_checks.rs` | `cargo test -p maximus-checks --test tsconfig_checks`, `npm test`, `node ./bin/maximus.js audit <fixture>` |
 | Add one new `package-entrypoints` regression case | Small | The checker is already isolated and heavily test-driven | `crates/maximus-checks/src/package_entrypoints.rs`, `crates/maximus-checks/tests/package_entrypoints_checks.rs` | targeted Cargo test, `cargo test --workspace`, `npm test` |
 | Expand filesystem edge-case fixtures | Small to Medium | Mostly test and fixture work, with low risk to user-facing behavior | `test/fixtures/`, `crates/maximus-checks/tests/`, `test/*.test.js` | targeted tests, `npm test` |
 | Add one snapshot-style audit or doctor regression | Small | Good introduction to report output without changing core discovery logic | `test/golden-rust/`, `test/reference-parity.test.js`, related CLI tests | targeted Node tests, `npm test` |

--- a/test/fixtures/tsconfig-patterns/empty-exclude/src/index.d.ts
+++ b/test/fixtures/tsconfig-patterns/empty-exclude/src/index.d.ts
@@ -1,0 +1,1 @@
+declare const ok: true;

--- a/test/fixtures/tsconfig-patterns/empty-exclude/tsconfig.json
+++ b/test/fixtures/tsconfig-patterns/empty-exclude/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["generated/**/*.ts"]
+}

--- a/test/fixtures/tsconfig-patterns/empty-include/src/index.d.ts
+++ b/test/fixtures/tsconfig-patterns/empty-include/src/index.d.ts
@@ -1,0 +1,1 @@
+declare const ok: true;

--- a/test/fixtures/tsconfig-patterns/empty-include/tsconfig.json
+++ b/test/fixtures/tsconfig-patterns/empty-include/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["src/missing/**/*.ts"]
+}

--- a/test/fixtures/tsconfig-patterns/exclude-only/src/index.d.ts
+++ b/test/fixtures/tsconfig-patterns/exclude-only/src/index.d.ts
@@ -1,0 +1,1 @@
+export declare const ok: true;

--- a/test/fixtures/tsconfig-patterns/exclude-only/tsconfig.json
+++ b/test/fixtures/tsconfig-patterns/exclude-only/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["missing/**/*.ts"]
+}

--- a/test/fixtures/tsconfig-patterns/useful-patterns/src/generated/skip.d.ts
+++ b/test/fixtures/tsconfig-patterns/useful-patterns/src/generated/skip.d.ts
@@ -1,0 +1,1 @@
+declare const skip: true;

--- a/test/fixtures/tsconfig-patterns/useful-patterns/src/index.d.ts
+++ b/test/fixtures/tsconfig-patterns/useful-patterns/src/index.d.ts
@@ -1,0 +1,1 @@
+declare const ok: true;

--- a/test/fixtures/tsconfig-patterns/useful-patterns/tsconfig.json
+++ b/test/fixtures/tsconfig-patterns/useful-patterns/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/generated/**/*.ts"]
+}

--- a/test/tsconfig-patterns-cli.test.js
+++ b/test/tsconfig-patterns-cli.test.js
@@ -1,0 +1,510 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "..");
+
+test("fixture-backed tsconfig pattern audits stay wired through the CLI", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const scenarios = [
+    {
+      name: "empty-include",
+      expectedStatus: 1,
+      expected: [
+        "Include pattern does not match any files",
+        'include pattern "src/missing/**/*.ts" matched 0 files',
+      ],
+      absent: ["Exclude pattern does not filter any included files"],
+    },
+    {
+      name: "empty-exclude",
+      expectedStatus: 0,
+      expected: [
+        "Exclude pattern does not filter any included files",
+        'exclude pattern "generated/**/*.ts" removed 0 files from 1 included file(s)',
+      ],
+      absent: ["Include pattern does not match any files"],
+    },
+    {
+      name: "exclude-only",
+      expectedStatus: 0,
+      expected: [
+        "Exclude pattern does not filter any included files",
+        'exclude pattern "missing/**/*.ts" removed 0 files from 1 included file(s)',
+      ],
+      absent: ["Include pattern does not match any files"],
+    },
+    {
+      name: "useful-patterns",
+      expectedStatus: 0,
+      expected: ["No config drift detected."],
+      absent: [
+        "Include pattern does not match any files",
+        "Exclude pattern does not filter any included files",
+      ],
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const result = runAudit(`./test/fixtures/tsconfig-patterns/${scenario.name}`);
+
+    assert.equal(result.status, scenario.expectedStatus, result.stderr);
+    for (const snippet of scenario.expected) {
+      assert.ok(
+        result.stdout.includes(snippet),
+        `expected ${scenario.name} output to include ${snippet}`,
+      );
+    }
+    for (const snippet of scenario.absent) {
+      assert.ok(
+        !result.stdout.includes(snippet),
+        `expected ${scenario.name} output to omit ${snippet}`,
+      );
+    }
+  }
+});
+
+test("CLI audit respects allowJs when evaluating tsconfig include patterns", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-pattern-cli-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "js-without-allowjs", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "js-without-allowjs", "tsconfig.json"),
+    JSON.stringify({ include: ["src"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "js-without-allowjs", "src", "index.js"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "js-with-allowjs", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "js-with-allowjs", "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { allowJs: true }, include: ["src"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "js-with-allowjs", "src", "index.js"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+
+  const withoutAllowJs = runAudit(path.join(rootDir, "js-without-allowjs"));
+  assert.equal(withoutAllowJs.status, 1, withoutAllowJs.stderr);
+  assert.ok(withoutAllowJs.stdout.includes("Include pattern does not match any files"));
+
+  const withAllowJs = runAudit(path.join(rootDir, "js-with-allowjs"));
+  assert.equal(withAllowJs.status, 0, withAllowJs.stderr);
+  assert.ok(withAllowJs.stdout.includes("No config drift detected."));
+  assert.ok(!withAllowJs.stdout.includes("Include pattern does not match any files"));
+});
+
+test("CLI audit matches question-mark and zero-width star tsconfig include globs", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-pattern-glob-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "question-mark", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "question-mark", "tsconfig.json"),
+    JSON.stringify({ include: ["src/file?.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "question-mark", "src", "file1.ts"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "star-zero", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "star-zero", "tsconfig.json"),
+    JSON.stringify({ include: ["src/file*.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "star-zero", "src", "file.ts"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+
+  for (const target of ["question-mark", "star-zero"]) {
+    const result = runAudit(path.join(rootDir, target));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes("No config drift detected."));
+    assert.ok(!result.stdout.includes("Include pattern does not match any files"));
+  }
+});
+
+test("CLI audit respects inherited allowJs and outDir when evaluating tsconfig patterns", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-pattern-extends-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "inherited-allowjs", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "inherited-allowjs", "tsconfig.json"),
+    JSON.stringify({ extends: "./tsconfig.base.json", include: ["src"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "inherited-allowjs", "tsconfig.base.json"),
+    JSON.stringify({ compilerOptions: { allowJs: true } }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "inherited-allowjs", "src", "index.js"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "inherited-outdir", "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "inherited-outdir", "dist"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "inherited-outdir", "tsconfig.json"),
+    JSON.stringify({ extends: "./tsconfig.base.json", exclude: ["dist/**/*.d.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "inherited-outdir", "tsconfig.base.json"),
+    JSON.stringify({ compilerOptions: { outDir: "./dist" } }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "inherited-outdir", "src", "index.d.ts"),
+    "export declare const source: true;\n",
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "inherited-outdir", "dist", "index.d.ts"),
+    "export declare const built: true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "outdir-include", "dist"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "outdir-include", "tsconfig.json"),
+    JSON.stringify({ extends: "./tsconfig.base.json", include: ["dist"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "outdir-include", "tsconfig.base.json"),
+    JSON.stringify({ compilerOptions: { outDir: "./dist" } }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "outdir-include", "dist", "index.d.ts"),
+    "export declare const built: true;\n",
+    "utf8",
+  );
+
+  const inheritedAllowJs = runAudit(path.join(rootDir, "inherited-allowjs"));
+  assert.equal(inheritedAllowJs.status, 0, inheritedAllowJs.stderr);
+  assert.ok(inheritedAllowJs.stdout.includes("No config drift detected."));
+  assert.ok(!inheritedAllowJs.stdout.includes("Include pattern does not match any files"));
+
+  const inheritedOutDir = runAudit(path.join(rootDir, "inherited-outdir"));
+  assert.equal(inheritedOutDir.status, 0, inheritedOutDir.stderr);
+  assert.ok(inheritedOutDir.stdout.includes("Exclude pattern does not filter any included files"));
+  assert.ok(inheritedOutDir.stdout.includes('exclude pattern "dist/**/*.d.ts" removed 0 files from 1 included file(s)'));
+
+  const outdirInclude = runAudit(path.join(rootDir, "outdir-include"));
+  assert.equal(outdirInclude.status, 1, outdirInclude.stderr);
+  assert.ok(outdirInclude.stdout.includes("Include pattern does not match any files"));
+  assert.ok(outdirInclude.stdout.includes('include pattern "dist" matched 0 files'));
+});
+
+test("CLI audit skips explicit empty inputs and default node_modules when evaluating tsconfig patterns", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-pattern-empty-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "include-empty", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "include-empty", "tsconfig.json"),
+    JSON.stringify({ include: [], exclude: ["missing/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "include-empty", "src", "index.d.ts"),
+    "export declare const ok: true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "files-empty", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "files-empty", "tsconfig.json"),
+    JSON.stringify({ files: [], exclude: ["missing/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "files-empty", "src", "index.d.ts"),
+    "export declare const ok: true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "default-excludes", "node_modules", "pkg"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "default-excludes", "tsconfig.json"),
+    JSON.stringify({ exclude: ["missing/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "default-excludes", "node_modules", "pkg", "index.d.ts"),
+    "export declare const ignored: true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "files-with-exclude", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "files-with-exclude", "tsconfig.json"),
+    JSON.stringify({ files: ["src/index.d.ts"], exclude: ["src/**/*.d.ts"] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "files-with-exclude", "src", "index.d.ts"),
+    "export declare const explicit: true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "duplicate-excludes", "src", "generated"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "duplicate-excludes", "tsconfig.json"),
+    JSON.stringify(
+      {
+        include: ["src/**/*.d.ts"],
+        exclude: ["src/generated/**/*.d.ts", "src/generated/**/*.d.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "duplicate-excludes", "src", "generated", "index.d.ts"),
+    "export declare const duplicated: true;\n",
+    "utf8",
+  );
+
+  for (const target of ["include-empty", "files-empty", "default-excludes"]) {
+    const result = runAudit(path.join(rootDir, target));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes("No config drift detected."));
+    assert.ok(!result.stdout.includes("Include pattern does not match any files"));
+    assert.ok(!result.stdout.includes("Exclude pattern does not filter any included files"));
+  }
+
+  const filesWithExclude = runAudit(path.join(rootDir, "files-with-exclude"));
+  assert.equal(filesWithExclude.status, 0, filesWithExclude.stderr);
+  assert.ok(filesWithExclude.stdout.includes("Exclude pattern does not filter any included files"));
+  assert.ok(filesWithExclude.stdout.includes('exclude pattern "src/**/*.d.ts" removed 0 files from 1 included file(s)'));
+
+  const duplicateExcludes = runAudit(path.join(rootDir, "duplicate-excludes"));
+  assert.equal(duplicateExcludes.status, 0, duplicateExcludes.stderr);
+  assert.ok(duplicateExcludes.stdout.includes("Exclude pattern does not filter any included files"));
+  assert.ok(duplicateExcludes.stdout.includes('exclude pattern "src/generated/**/*.d.ts" removed 0 files from 0 included file(s)'));
+});
+
+test("CLI audit inherits top-level pattern fields and reports invalid pattern entries", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-pattern-inherited-fields-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "shared"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "shared", "tsconfig.base.json"),
+    JSON.stringify({ include: ["./src/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "app-inherited-include", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "app-inherited-include", "tsconfig.json"),
+    JSON.stringify({ extends: "../shared/tsconfig.base.json" }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "app-inherited-include", "src", "index.ts"),
+    "export const ok = true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "app-missing-extends"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "app-missing-extends", "tsconfig.json"),
+    JSON.stringify({ extends: "../shared-missing/tsconfig.base.json" }, null, 2),
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "shared-empty"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "shared-empty", "tsconfig.base.json"),
+    JSON.stringify({ files: [] }, null, 2),
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "app-inherited-files-empty", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "app-inherited-files-empty", "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "../shared-empty/tsconfig.base.json",
+        exclude: ["missing/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "app-inherited-files-empty", "src", "index.d.ts"),
+    "export declare const ok: true;\n",
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "invalid-pattern-entry"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "invalid-pattern-entry", "tsconfig.json"),
+    JSON.stringify({ include: [42] }, null, 2),
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "invalid-files-entry", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "invalid-files-entry", "tsconfig.json"),
+    JSON.stringify(
+      {
+        files: ["src/*.ts"],
+        exclude: ["missing/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "invalid-files-entry", "src", "index.d.ts"),
+    "export declare const ok: true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "invalid-files-directory", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "invalid-files-directory", "tsconfig.json"),
+    JSON.stringify(
+      {
+        files: ["src"],
+        exclude: ["missing/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "invalid-files-directory", "src", "index.d.ts"),
+    "export declare const ok: true;\n",
+    "utf8",
+  );
+  await mkdir(path.join(rootDir, "invalid-files-missing"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "invalid-files-missing", "tsconfig.json"),
+    JSON.stringify(
+      {
+        files: ["src/missing.ts"],
+        exclude: ["missing/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const inheritedInclude = runAudit(path.join(rootDir, "app-inherited-include"));
+  assert.equal(inheritedInclude.status, 1, inheritedInclude.stderr);
+  assert.ok(inheritedInclude.stdout.includes("Include pattern does not match any files"));
+  assert.ok(inheritedInclude.stdout.includes('include pattern "./src/**/*.ts" matched 0 files'));
+
+  const missingExtends = runAudit(path.join(rootDir, "app-missing-extends"));
+  assert.equal(missingExtends.status, 1, missingExtends.stderr);
+  assert.ok(missingExtends.stdout.includes("Inherited tsconfig could not be found"));
+  assert.ok(missingExtends.stdout.includes("shared-missing/tsconfig.base.json"));
+
+  const inheritedFilesEmpty = runAudit(path.join(rootDir, "app-inherited-files-empty"));
+  assert.equal(inheritedFilesEmpty.status, 0, inheritedFilesEmpty.stderr);
+  assert.ok(inheritedFilesEmpty.stdout.includes("No config drift detected."));
+  assert.ok(!inheritedFilesEmpty.stdout.includes("Exclude pattern does not filter any included files"));
+
+  const invalidPatternEntry = runAudit(path.join(rootDir, "invalid-pattern-entry"));
+  assert.equal(invalidPatternEntry.status, 1, invalidPatternEntry.stderr);
+  assert.ok(invalidPatternEntry.stdout.includes('"include" contains a non-string pattern'));
+  assert.ok(invalidPatternEntry.stdout.includes("declares include[0], but TypeScript expects string patterns."));
+
+  const invalidFilesEntry = runAudit(path.join(rootDir, "invalid-files-entry"));
+  assert.equal(invalidFilesEntry.status, 1, invalidFilesEntry.stderr);
+  assert.ok(invalidFilesEntry.stdout.includes('"files" entries must point to explicit files'));
+  assert.ok(invalidFilesEntry.stdout.includes("declares files[0] as src/*.ts"));
+
+  const invalidFilesDirectory = runAudit(path.join(rootDir, "invalid-files-directory"));
+  assert.equal(invalidFilesDirectory.status, 1, invalidFilesDirectory.stderr);
+  assert.ok(invalidFilesDirectory.stdout.includes('"files" entries must point to files'));
+  assert.ok(invalidFilesDirectory.stdout.includes("declares files[0] as src, but that path resolves to a directory."));
+
+  const invalidFilesMissing = runAudit(path.join(rootDir, "invalid-files-missing"));
+  assert.equal(invalidFilesMissing.status, 1, invalidFilesMissing.stderr);
+  assert.ok(invalidFilesMissing.stdout.includes('"files" entries must point to existing files'));
+  assert.ok(invalidFilesMissing.stdout.includes("declares files[0] as src/missing.ts"));
+});
+
+function runAudit(target) {
+  return spawnSync(process.execPath, ["./bin/maximus.js", "audit", target], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+async function shouldRunRustCliAssertions(t) {
+  for (const candidate of [path.join(repoRoot, "target", "debug", "maximus"), path.join(repoRoot, "target", "release", "maximus")]) {
+    try {
+      await access(candidate);
+      return true;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  t.skip("Rust canonical runtime build is not available; skip CLI pattern assertions on the frozen JS compatibility path.");
+  return false;
+}


### PR DESCRIPTION
## 배경
- `TODO.md`는 아직 stale하지만, `master`와 기존 Rust 구현 상태를 다시 확인해보니 다음 실구현 slice는 `P014-A`였습니다.
- 이번 변경은 tsconfig의 명백한 빈 `include`와 실효가 없는 `exclude`를 조기에 알려서 TypeScript 입력 누락을 빨리 잡도록 합니다.

## 변경 사항
- Rust tsconfig checker에 빈 `include` 패턴 경고와 실효 없는 `exclude` 패턴 정보 진단을 추가했습니다.
- `**/`를 포함한 실용 glob 매칭을 보강하고, 회귀 테스트를 추가했습니다.
- CLI 검증용 fixture를 `test/fixtures/tsconfig-patterns`에 추가했습니다.
- 방금 구현된 항목이 바로 stale해지지 않도록 기여자 문서의 관련 아이템을 정리했습니다.

## 검증
- `cargo test -p maximus-checks --test tsconfig_checks`
- `cargo build -p maximus-cli`
- `cargo test --workspace`
- `npm test`
- `node ./bin/maximus.js audit ./test/fixtures/tsconfig-patterns/empty-include`
- `node ./bin/maximus.js audit ./test/fixtures/tsconfig-patterns/empty-exclude`
- `node ./bin/maximus.js audit ./test/fixtures/tsconfig-patterns/useful-patterns`
- `git diff --check`

## 브랜치 / 워크트리
- target branch: `codex/p014-a-empty-include-exclude-patterns`
- current worktree: `/Users/pjw/workspace/maximus`
- source worktree: 없음

## 이슈 연결
- 없음