### PR TITLE
feat: tsconfig 출력 경로 겹침 검사를 추가한다

### DIFF
--- a/crates/maximus-checks/src/tsconfig.rs
+++ b/crates/maximus-checks/src/tsconfig.rs
@@ -67,6 +67,7 @@ enum CompositeResolution {
 struct EffectivePatternOptions {
     allow_js: bool,
     out_dir: Option<PathBuf>,
+    root_dir: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -134,6 +135,13 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
         collect_deprecated_option_findings(&mut findings, &file.path, compiler_options);
         collect_project_reference_findings(&mut findings, &file.path, &file.dir, references)?;
         collect_include_exclude_pattern_findings(&mut findings, &file.path, &file.dir, &config)?;
+        collect_output_path_overlap_findings(
+            &mut findings,
+            &project.root_dir,
+            &file.path,
+            &file.dir,
+            &config,
+        )?;
 
         let Some(paths_config) = compiler_options.and_then(|options| options.get("paths")) else {
             continue;
@@ -792,6 +800,327 @@ fn collect_include_exclude_pattern_findings(
     Ok(())
 }
 
+fn collect_output_path_overlap_findings(
+    findings: &mut Vec<Finding>,
+    project_root: &Path,
+    file_path: &Path,
+    config_dir: &Path,
+    config: &Value,
+) -> io::Result<()> {
+    let base_dir = normalize_path(config_dir);
+    let effective_pattern_config = resolve_effective_pattern_config(file_path, config)?;
+    let Some(output_dir) = effective_pattern_config.options.out_dir.clone() else {
+        return Ok(());
+    };
+    let output_dir = normalize_path(&output_dir);
+    let candidate_extensions = ts_pattern_extensions(effective_pattern_config.options.allow_js);
+    let default_excluded_dirs = collect_default_excluded_dirs(&effective_pattern_config.options);
+    let effective_source_files = collect_effective_tsconfig_input_files(
+        &base_dir,
+        &effective_pattern_config,
+        candidate_extensions,
+        &default_excluded_dirs,
+    )?;
+    let raw_source_files = if output_dir == base_dir && effective_source_files.is_empty() {
+        collect_effective_tsconfig_input_files(
+            &base_dir,
+            &effective_pattern_config,
+            candidate_extensions,
+            &[],
+        )?
+    } else {
+        BTreeSet::new()
+    };
+    let source_roots = collect_output_source_roots(
+        &base_dir,
+        &effective_pattern_config,
+        candidate_extensions,
+        &effective_source_files,
+        &default_excluded_dirs,
+    )?;
+
+    if let Some(source_root) = source_roots
+        .iter()
+        .find(|source_root| output_dir == **source_root)
+    {
+        let output_display = display_project_relative_path(project_root, &output_dir);
+        let source_display = display_project_relative_path(project_root, source_root);
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-output-paths:{}:outdir-equals-source:{output_display}",
+                file_path.to_string_lossy()
+            ),
+            title: "Output directory overlaps the TypeScript source root".to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(format!(
+                "outDir \"{output_display}\" overlaps source root \"{source_display}\"."
+            )),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Move emit output outside the source root so build artifacts do not overwrite source files."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Error),
+        }));
+        return Ok(());
+    }
+
+    if let Some(source_root) = source_roots
+        .iter()
+        .find(|source_root| output_dir.starts_with(*source_root))
+    {
+        let output_display = display_project_relative_path(project_root, &output_dir);
+        let source_display = display_project_relative_path(project_root, source_root);
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-output-paths:{}:outdir-nested-in-source:{output_display}",
+                file_path.to_string_lossy()
+            ),
+            title: "Output directory is nested inside the TypeScript source root".to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(format!(
+                "outDir \"{output_display}\" is nested inside source root \"{source_display}\"."
+            )),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Move emit output outside the source root so build artifacts do not overwrite source files."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Error),
+        }));
+        return Ok(());
+    }
+
+    if let Some(overlapping_input) = effective_source_files
+        .iter()
+        .find(|candidate| candidate.starts_with(&output_dir))
+        .or_else(|| {
+            raw_source_files
+                .iter()
+                .find(|candidate| candidate.starts_with(&output_dir))
+        })
+    {
+        let output_display = display_project_relative_path(project_root, &output_dir);
+        let input_display = display_project_relative_path(project_root, overlapping_input);
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-output-paths:{}:outdir-contains-input:{output_display}",
+                file_path.to_string_lossy()
+            ),
+            title: "Output directory contains TypeScript input files".to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(format!(
+                "outDir \"{output_display}\" contains TypeScript input \"{input_display}\"."
+            )),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Move emit output outside any directory that currently contains TypeScript input files."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Error),
+        }));
+        return Ok(());
+    }
+
+    if let Some(source_root) = source_roots
+        .iter()
+        .find(|source_root| source_root.starts_with(&output_dir))
+    {
+        let output_display = display_project_relative_path(project_root, &output_dir);
+        let source_display = display_project_relative_path(project_root, source_root);
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-output-paths:{}:outdir-contains-source:{output_display}",
+                file_path.to_string_lossy()
+            ),
+            title: "Output directory contains the TypeScript source root".to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(format!(
+                "outDir \"{output_display}\" contains source root \"{source_display}\"."
+            )),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Prefer an output directory that is completely separate from the TypeScript source root."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    Ok(())
+}
+
+fn collect_effective_tsconfig_input_files(
+    base_dir: &Path,
+    effective_pattern_config: &EffectivePatternConfig,
+    candidate_extensions: &[&str],
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<BTreeSet<PathBuf>> {
+    let (explicit_files, _) = collect_explicit_tsconfig_files(
+        effective_pattern_config.files.as_ref(),
+        candidate_extensions,
+    )?;
+    let mut exclude_eligible_files = if effective_pattern_config.include.is_some()
+        || effective_pattern_config.files.is_some()
+    {
+        BTreeSet::new()
+    } else {
+        collect_default_pattern_matches(base_dir, candidate_extensions, default_excluded_dirs)?
+    };
+
+    if let Some(include_field) = effective_pattern_config.include.as_ref() {
+        for pattern in &include_field.values {
+            let matches = collect_pattern_matches(
+                &include_field.base_dir,
+                pattern,
+                candidate_extensions,
+                default_excluded_dirs,
+            )?;
+            exclude_eligible_files.extend(matches);
+        }
+    }
+
+    if let Some(exclude_field) = effective_pattern_config.exclude.as_ref() {
+        for pattern in &exclude_field.values {
+            let matches = exclude_eligible_files
+                .iter()
+                .filter(|candidate| {
+                    pattern_matches_file(
+                        &exclude_field.base_dir,
+                        pattern,
+                        candidate,
+                        candidate_extensions,
+                        default_excluded_dirs,
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            for matched in matches {
+                exclude_eligible_files.remove(&matched);
+            }
+        }
+    }
+
+    let mut included_files = explicit_files;
+    included_files.extend(exclude_eligible_files);
+    Ok(included_files)
+}
+
+fn collect_output_source_roots(
+    base_dir: &Path,
+    effective_pattern_config: &EffectivePatternConfig,
+    candidate_extensions: &[&str],
+    included_files: &BTreeSet<PathBuf>,
+    default_excluded_dirs: &[PathBuf],
+) -> io::Result<BTreeSet<PathBuf>> {
+    let mut source_roots = BTreeSet::new();
+
+    if let Some(root_dir) = effective_pattern_config.options.root_dir.as_ref() {
+        source_roots.insert(normalize_path(root_dir));
+    }
+
+    if let Some(include_field) = effective_pattern_config.include.as_ref() {
+        for pattern in &include_field.values {
+            let matches = collect_pattern_matches(
+                &include_field.base_dir,
+                pattern,
+                candidate_extensions,
+                default_excluded_dirs,
+            )?;
+            if matches.is_empty() {
+                continue;
+            }
+
+            if let Some(source_root) =
+                resolve_pattern_source_root(&include_field.base_dir, pattern)
+            {
+                source_roots.insert(source_root);
+            }
+        }
+    }
+
+    for file in included_files {
+        if let Some(parent) = file.parent() {
+            let parent = normalize_path(parent);
+            if parent != *base_dir {
+                source_roots.insert(parent);
+            }
+        }
+    }
+
+    Ok(prune_nested_paths(source_roots))
+}
+
+fn resolve_pattern_source_root(base_dir: &Path, pattern: &str) -> Option<PathBuf> {
+    if pattern.trim().is_empty() {
+        return None;
+    }
+
+    if pattern_contains_wildcard(pattern) {
+        let prefix = pattern
+            .find(['*', '?'])
+            .map(|index| &pattern[..index])
+            .unwrap_or(pattern);
+        let search_prefix = wildcard_search_prefix(prefix);
+        if matches!(search_prefix, "." | "") {
+            return None;
+        }
+        return Some(resolve_path_with_backslash_support(base_dir, search_prefix));
+    }
+
+    let resolved = resolve_path_with_backslash_support(base_dir, pattern);
+    if path_exists(&resolved) {
+        match fs::metadata(&resolved) {
+            Ok(metadata) if metadata.is_dir() => return Some(normalize_path(&resolved)),
+            Ok(_) => return resolved.parent().map(normalize_path),
+            Err(_) => return None,
+        }
+    }
+
+    if has_explicit_extension(pattern) {
+        return resolved.parent().map(normalize_path);
+    }
+
+    Some(normalize_path(&resolved))
+}
+
+fn prune_nested_paths(paths: BTreeSet<PathBuf>) -> BTreeSet<PathBuf> {
+    let mut pruned = BTreeSet::new();
+
+    for path in paths {
+        if pruned
+            .iter()
+            .any(|existing: &PathBuf| path.starts_with(existing))
+        {
+            continue;
+        }
+        pruned.retain(|existing: &PathBuf| !existing.starts_with(&path));
+        pruned.insert(path);
+    }
+
+    pruned
+}
+
+fn display_project_relative_path(project_root: &Path, path: &Path) -> String {
+    let project_root = normalize_path(project_root);
+    let path = normalize_path(path);
+
+    match path.strip_prefix(&project_root) {
+        Ok(relative) if relative.as_os_str().is_empty() => ".".to_string(),
+        Ok(relative) => normalize_path_for_match(relative),
+        Err(_) => normalize_path_for_match(&path),
+    }
+}
+
 fn collect_explicit_tsconfig_files(
     files_field: Option<&EffectivePatternField>,
     candidate_extensions: &[&str],
@@ -1242,8 +1571,15 @@ fn resolve_effective_pattern_config_inner(
             effective_config.options.allow_js = allow_js;
         }
 
+        if let Some(root_dir) = compiler_options.get("rootDir").and_then(Value::as_str) {
+            effective_config.options.root_dir = Some(resolve_path_with_backslash_support(
+                config_path.parent().unwrap_or_else(|| Path::new(".")),
+                root_dir,
+            ));
+        }
+
         if let Some(out_dir) = compiler_options.get("outDir").and_then(Value::as_str) {
-            effective_config.options.out_dir = Some(resolve_path(
+            effective_config.options.out_dir = Some(resolve_path_with_backslash_support(
                 config_path.parent().unwrap_or_else(|| Path::new(".")),
                 out_dir,
             ));
@@ -2091,6 +2427,10 @@ fn is_ts_pattern_candidate_file(path: &Path, candidate_extensions: &[&str]) -> b
 
 fn resolve_path(base_dir: &Path, target: &str) -> PathBuf {
     normalize_path(&base_dir.join(target))
+}
+
+fn resolve_path_with_backslash_support(base_dir: &Path, target: &str) -> PathBuf {
+    resolve_path(base_dir, &target.replace('\\', "/"))
 }
 
 fn normalize_path(path: &Path) -> PathBuf {

--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -991,6 +991,290 @@ fn tsconfig_check_skips_explicitly_empty_inputs_and_implicit_default_excludes() 
 }
 
 #[test]
+fn tsconfig_check_reports_output_path_overlap_contracts() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("outdir-src/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": "./src",
+            "outDir": "./src"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-src/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("outdir-src-generated/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": "./src",
+            "outDir": "./src/generated"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-src-generated/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("outdir-dist/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": "./src",
+            "outDir": "./dist"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-dist/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("outdir-contains-source/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": "./src/generated",
+            "outDir": "./src"
+          },
+          "files": []
+        }
+        "#,
+    );
+
+    write(
+        fixture.path().join("rootdir-dot/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": ".",
+            "outDir": "./src"
+          },
+          "files": ["index.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("rootdir-dot/index.ts"),
+        "export const root = true;\n",
+    );
+
+    write(
+        fixture.path().join("files-with-unmatched-include/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "outDir": "./src/generated"
+          },
+          "files": ["index.ts"],
+          "include": ["src/**/*.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("files-with-unmatched-include/index.ts"),
+        "export const root = true;\n",
+    );
+
+    write(
+        fixture.path().join("outdir-dot/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "outDir": "."
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("outdir-dot/src/index.ts"),
+        "export const source = true;\n",
+    );
+
+    write(
+        fixture.path().join("mixed-inputs/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "outDir": "./src"
+          },
+          "files": ["src/index.ts", "config.ts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("mixed-inputs/src/index.ts"),
+        "export const emitted = true;\n",
+    );
+    write(
+        fixture.path().join("mixed-inputs/config.ts"),
+        "export const config = true;\n",
+    );
+
+    write(
+        fixture.path().join("windows-style/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "rootDir": ".\\src",
+            "outDir": ".\\src\\generated"
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("windows-style/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-equals-source:outdir-src/src",
+            fixture
+                .path()
+                .join("outdir-src/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory overlaps the TypeScript source root",
+        "outDir \"outdir-src/src\" overlaps source root \"outdir-src/src\".",
+        "Move emit output outside the source root so build artifacts do not overwrite source files.",
+        Some(fixture.path().join("outdir-src/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-nested-in-source:outdir-src-generated/src/generated",
+            fixture
+                .path()
+                .join("outdir-src-generated/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory is nested inside the TypeScript source root",
+        "outDir \"outdir-src-generated/src/generated\" is nested inside source root \"outdir-src-generated/src\".",
+        "Move emit output outside the source root so build artifacts do not overwrite source files.",
+        Some(fixture.path().join("outdir-src-generated/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-contains-source:outdir-contains-source/src",
+            fixture
+                .path()
+                .join("outdir-contains-source/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Output directory contains the TypeScript source root",
+        "outDir \"outdir-contains-source/src\" contains source root \"outdir-contains-source/src/generated\".",
+        "Prefer an output directory that is completely separate from the TypeScript source root.",
+        Some(fixture.path().join("outdir-contains-source/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-nested-in-source:rootdir-dot/src",
+            fixture
+                .path()
+                .join("rootdir-dot/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory is nested inside the TypeScript source root",
+        "outDir \"rootdir-dot/src\" is nested inside source root \"rootdir-dot\".",
+        "Move emit output outside the source root so build artifacts do not overwrite source files.",
+        Some(fixture.path().join("rootdir-dot/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-contains-input:outdir-dot",
+            fixture
+                .path()
+                .join("outdir-dot/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory contains TypeScript input files",
+        "outDir \"outdir-dot\" contains TypeScript input \"outdir-dot/src/index.ts\".",
+        "Move emit output outside any directory that currently contains TypeScript input files.",
+        Some(fixture.path().join("outdir-dot/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-equals-source:mixed-inputs/src",
+            fixture
+                .path()
+                .join("mixed-inputs/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory overlaps the TypeScript source root",
+        "outDir \"mixed-inputs/src\" overlaps source root \"mixed-inputs/src\".",
+        "Move emit output outside the source root so build artifacts do not overwrite source files.",
+        Some(fixture.path().join("mixed-inputs/tsconfig.json")),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-output-paths:{}:outdir-nested-in-source:windows-style/src/generated",
+            fixture
+                .path()
+                .join("windows-style/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Error,
+        "Output directory is nested inside the TypeScript source root",
+        "outDir \"windows-style/src/generated\" is nested inside source root \"windows-style/src\".",
+        "Move emit output outside the source root so build artifacts do not overwrite source files.",
+        Some(fixture.path().join("windows-style/tsconfig.json")),
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-output-paths:{}:",
+                fixture
+                    .path()
+                    .join("outdir-dist/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "safe dist output directories should not report overlap findings"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            !finding.id.starts_with(&format!(
+                "tsconfig-output-paths:{}:",
+                fixture
+                    .path()
+                    .join("files-with-unmatched-include/tsconfig.json")
+                    .to_string_lossy()
+            ))
+        }),
+        "unmatched include patterns should not create output overlap findings when only files inputs are active"
+    );
+}
+
+#[test]
 fn tsconfig_check_inherits_pattern_fields_and_reports_invalid_pattern_entries() {
     let fixture = TempDir::new().expect("temp dir should exist");
 

--- a/test/fixtures/output-path-overlap/outdir-dist/src/index.ts
+++ b/test/fixtures/output-path-overlap/outdir-dist/src/index.ts
@@ -1,0 +1,1 @@
+export const source = true;

--- a/test/fixtures/output-path-overlap/outdir-dist/tsconfig.json
+++ b/test/fixtures/output-path-overlap/outdir-dist/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  }
+}

--- a/test/fixtures/output-path-overlap/outdir-src/src/index.ts
+++ b/test/fixtures/output-path-overlap/outdir-src/src/index.ts
@@ -1,0 +1,1 @@
+export const source = true;

--- a/test/fixtures/output-path-overlap/outdir-src/tsconfig.json
+++ b/test/fixtures/output-path-overlap/outdir-src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./src"
+  }
+}

--- a/test/output-path-overlap.test.js
+++ b/test/output-path-overlap.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "..");
+
+test("fixture-backed output path overlap audits stay wired through the CLI", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const overlap = runAudit("./test/fixtures/output-path-overlap/outdir-src");
+  assert.equal(overlap.status, 1, overlap.stderr);
+  assert.ok(overlap.stdout.includes("Output directory overlaps the TypeScript source root"));
+  assert.ok(overlap.stdout.includes('outDir "src" overlaps source root "src".'));
+
+  const safe = runAudit("./test/fixtures/output-path-overlap/outdir-dist");
+  assert.equal(safe.status, 0, safe.stderr);
+  assert.ok(safe.stdout.includes("No config drift detected."));
+  assert.ok(!safe.stdout.includes("Output directory overlaps the TypeScript source root"));
+  assert.ok(!safe.stdout.includes("Output directory is nested inside the TypeScript source root"));
+});
+
+test("CLI audit handles rootDir-dot, mixed inputs, and unmatched-include overlap boundaries", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-output-path-overlap-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "rootdir-dot"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "rootdir-dot", "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { rootDir: ".", outDir: "./src" },
+        files: ["index.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(path.join(rootDir, "rootdir-dot", "index.ts"), "export const root = true;\n", "utf8");
+
+  await mkdir(path.join(rootDir, "outdir-dot", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "outdir-dot", "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { outDir: "." },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(path.join(rootDir, "outdir-dot", "src", "index.ts"), "export const source = true;\n", "utf8");
+
+  await mkdir(path.join(rootDir, "mixed", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "mixed", "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { outDir: "./src" },
+        files: ["src/index.ts", "config.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(path.join(rootDir, "mixed", "src", "index.ts"), "export const emitted = true;\n", "utf8");
+  await writeFile(path.join(rootDir, "mixed", "config.ts"), "export const config = true;\n", "utf8");
+
+  await mkdir(path.join(rootDir, "safe", "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "safe", "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: { outDir: "./src/generated" },
+        files: ["index.ts"],
+        include: ["src/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(path.join(rootDir, "safe", "index.ts"), "export const root = true;\n", "utf8");
+
+  const rootdirDot = runAudit(path.join(rootDir, "rootdir-dot"));
+  assert.equal(rootdirDot.status, 1, rootdirDot.stderr);
+  assert.ok(rootdirDot.stdout.includes("Output directory is nested inside the TypeScript source root"));
+  assert.ok(rootdirDot.stdout.includes('outDir "src" is nested inside source root ".".'));
+
+  const outdirDot = runAudit(path.join(rootDir, "outdir-dot"));
+  assert.equal(outdirDot.status, 1, outdirDot.stderr);
+  assert.ok(outdirDot.stdout.includes("Output directory contains TypeScript input files"));
+  assert.ok(outdirDot.stdout.includes('outDir "." contains TypeScript input "src/index.ts".'));
+
+  const mixed = runAudit(path.join(rootDir, "mixed"));
+  assert.equal(mixed.status, 1, mixed.stderr);
+  assert.ok(mixed.stdout.includes("Output directory overlaps the TypeScript source root"));
+  assert.ok(mixed.stdout.includes('outDir "src" overlaps source root "src".'));
+
+  const safe = runAudit(path.join(rootDir, "safe"));
+  assert.equal(safe.status, 1, safe.stderr);
+  assert.ok(!safe.stdout.includes("Output directory overlaps the TypeScript source root"));
+  assert.ok(!safe.stdout.includes("Output directory is nested inside the TypeScript source root"));
+  assert.ok(safe.stdout.includes("Include pattern does not match any files"));
+});
+
+function runAudit(target) {
+  return spawnSync(process.execPath, ["./bin/maximus.js", "audit", target], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+async function shouldRunRustCliAssertions(t) {
+  for (const candidate of [path.join(repoRoot, "target", "debug", "maximus"), path.join(repoRoot, "target", "release", "maximus")]) {
+    try {
+      await access(candidate);
+      return true;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  t.skip("Rust canonical runtime build is not available; skip CLI output-path assertions on the frozen JS compatibility path.");
+  return false;
+}


### PR DESCRIPTION
배경

- tsconfig 검사에는 `outDir`와 source tree가 겹쳐 빌드 산출물이 소스를 덮는 구성을 막는 진단이 없었습니다.
- 이번 변경은 `docs/plan/015-output-path-overlap.md`의 `P015-A`를 Rust canonical runtime 경로에 반영합니다.

변경 사항

- `crates/maximus-checks/src/tsconfig.rs`에 `outDir`/`rootDir`/effective input set 기반 출력 경로 겹침 진단을 추가했습니다.
- source root와 동일하거나 source 내부 output은 `error`, output이 source root를 감싸는 애매한 경계는 `warn`으로 분류했습니다.
- Windows 스타일 백슬래시 경로도 normalize해서 같은 규칙으로 비교하도록 맞췄습니다.
- `crates/maximus-checks/tests/tsconfig_checks.rs`에 Rust 단위 회귀를 추가했습니다.
- `test/output-path-overlap.test.js`와 `test/fixtures/output-path-overlap/*`로 CLI fixture smoke를 추가했습니다.

검증

- `cargo test --workspace`
- `npm test`
- `node ./bin/maximus.js audit ./test/fixtures/output-path-overlap/outdir-src`
- `node ./bin/maximus.js audit ./test/fixtures/output-path-overlap/outdir-dist`
- `git diff --check`

브랜치 / 워크트리

- 대상 브랜치: `codex/p015-a-output-path-overlap`
- 현재 워크트리: `/Users/pjw/workspace/maximus`
- 추가 source worktree 없음

리스크

- 이번 구현은 TypeScript 전체 emit 의미론을 완전 재현하려는 범위는 아니고, 명백한 `outDir`/source overlap을 조기 감지하는 데 초점을 맞췄습니다.