### PR TITLE
fix: discovery가 파일시스템 edge case를 안전하게 건너뛴다

### DIFF
--- a/crates/maximus-core/src/discover.rs
+++ b/crates/maximus-core/src/discover.rs
@@ -78,7 +78,11 @@ pub fn discover_project_with_ignore_root(
         .filter_entry(|entry| should_visit(&ignore_root, entry, &ignored_patterns));
 
     for entry in walker {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if should_skip_walk_error(&error) => continue,
+            Err(error) => return Err(error.into()),
+        };
         if !entry.file_type().is_file() {
             continue;
         }
@@ -216,6 +220,16 @@ fn should_visit(ignore_root: &Path, entry: &DirEntry, ignored_patterns: &[Ignore
     }
 
     !is_ignored_path_from_root(ignore_root, entry.path(), ignored_patterns)
+}
+
+fn should_skip_walk_error(error: &walkdir::Error) -> bool {
+    error.depth() > 0
+        && error.io_error().is_some_and(|io_error| {
+            matches!(
+                io_error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+            )
+        })
 }
 
 fn normalize_ignore_pattern(pattern: &str) -> Option<IgnorePattern> {

--- a/crates/maximus-core/tests/core_models.rs
+++ b/crates/maximus-core/tests/core_models.rs
@@ -265,6 +265,79 @@ fn discovery_skips_directly_ignored_target_directory() {
     assert!(snapshot.package_files.is_empty());
 }
 
+#[cfg(unix)]
+#[test]
+fn discovery_skips_permission_denied_directories_instead_of_crashing() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = TempDir::new().unwrap();
+    let visible_dir = fixture.path().join("visible");
+    let blocked_dir = fixture.path().join("blocked");
+
+    std::fs::create_dir_all(&visible_dir).unwrap();
+    std::fs::write(
+        visible_dir.join("package.json"),
+        r#"{"name":"visible-fixture"}"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(&blocked_dir).unwrap();
+    std::fs::write(
+        blocked_dir.join("package.json"),
+        r#"{"name":"blocked-fixture"}"#,
+    )
+    .unwrap();
+
+    let original_permissions = std::fs::metadata(&blocked_dir).unwrap().permissions();
+    let mut blocked_permissions = original_permissions.clone();
+    blocked_permissions.set_mode(0o000);
+    std::fs::set_permissions(&blocked_dir, blocked_permissions).unwrap();
+
+    let snapshot = discover_project(fixture.path()).unwrap();
+
+    std::fs::set_permissions(&blocked_dir, original_permissions).unwrap();
+
+    assert_eq!(
+        snapshot
+            .files
+            .iter()
+            .map(|file| file.relative_path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["visible/package.json"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn discovery_ignores_broken_symlink_entries() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = TempDir::new().unwrap();
+    let linked_dir = fixture.path().join("linked");
+
+    std::fs::write(
+        fixture.path().join("package.json"),
+        r#"{"name":"root-fixture"}"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(&linked_dir).unwrap();
+    symlink(
+        fixture.path().join("missing-package.json"),
+        linked_dir.join("package.json"),
+    )
+    .unwrap();
+
+    let snapshot = discover_project(fixture.path()).unwrap();
+
+    assert_eq!(
+        snapshot
+            .files
+            .iter()
+            .map(|file| file.relative_path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["package.json"]
+    );
+}
+
 #[test]
 fn findings_are_defaulted_sorted_deduplicated_and_summarized() {
     let error = make_finding(FindingInput {


### PR DESCRIPTION
## 배경
- `P049-A` 범위에서 Rust canonical runtime 기준 파일시스템 edge case를 실제 구현 표면으로 재해석했습니다.
- nested directory traversal 중 `PermissionDenied` 또는 사라진 경로(`NotFound`) 때문에 discovery 전체가 실패하지 않도록 회귀를 고정할 필요가 있었습니다.

## 변경 사항
- `crates/maximus-core/src/discover.rs`
  - nested walk error가 `PermissionDenied` 또는 `NotFound`일 때 전체 scan을 중단하지 않고 건너뛰도록 조정했습니다.
  - root-level 또는 다른 IO error는 기존처럼 실패를 유지합니다.
- `crates/maximus-core/tests/core_models.rs`
  - unreadable directory가 있어도 visible package discovery가 계속되는 회귀 테스트를 추가했습니다.
  - broken symlink entry를 만나도 discovery가 깨지지 않는 회귀 테스트를 추가했습니다.

## 검증
- `cargo metadata --format-version 1 --no-deps`
- `cargo test --workspace`
- `node ./bin/maximus.js audit ./test/fixtures/clean-project`
- `npm test`
- `npm pack --json --dry-run --cache /tmp/maximus-npm-cache`
- independent Devil's Advocate review: no meaningful findings

## 브랜치 / 워크트리
- target branch: `codex/p049-a-filesystem-edge-cases`
- current worktree: `/Users/pjw/workspace/maximus`
- source worktree 추가 없음

## 이슈 연결
- 별도 이슈 연결 없음
