### PR TITLE
feat: JSON 출력 schema metadata를 고정한다

### DIFF
--- a/crates/maximus-cli/src/report_json.rs
+++ b/crates/maximus-cli/src/report_json.rs
@@ -112,6 +112,8 @@ mod tests {
         let json = render_audit_result(&result).expect("audit json should render");
         let value: Value = serde_json::from_str(&json).expect("audit json should parse");
 
+        assert_eq!(value["schemaVersion"], "1");
+        assert_eq!(value["generator"], "maximus");
         assert_eq!(value["rootDir"], "/tmp/project");
         assert_eq!(value["summary"]["blockingFindings"], 0);
         assert_eq!(value["structure"]["configFiles"], 1);
@@ -137,6 +139,10 @@ mod tests {
         assert!(value.get("initial").is_some());
         assert!(value.get("applied").is_some());
         assert!(value.get("final").is_some());
+        assert_eq!(value["initial"]["schemaVersion"], "1");
+        assert_eq!(value["initial"]["generator"], "maximus");
+        assert_eq!(value["final"]["schemaVersion"], "1");
+        assert_eq!(value["final"]["generator"], "maximus");
     }
 
     #[test]

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -28,6 +28,8 @@ fn root_maximus_config_applies_check_defaults() {
     assert_eq!(output.status.code(), Some(0), "{output:?}");
 
     let value = parse_json(&output);
+    assert_eq!(value["schemaVersion"], "1");
+    assert_eq!(value["generator"], "maximus");
     let findings = value["findings"]
         .as_array()
         .expect("findings should be an array");

--- a/crates/maximus-core/src/findings.rs
+++ b/crates/maximus-core/src/findings.rs
@@ -3,6 +3,9 @@ use serde::Serialize;
 use crate::models::{AuditResult, AuditSummary, Finding, FixPlan, Severity, StructureReport};
 use crate::text_order::locale_compare_like;
 
+pub const JSON_GENERATOR: &str = "maximus";
+pub const JSON_SCHEMA_VERSION: &str = "1";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FindingInput {
     pub id: String,
@@ -19,6 +22,8 @@ pub struct FindingInput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SerializableAuditResult {
+    pub schema_version: &'static str,
+    pub generator: &'static str,
     pub root_dir: std::path::PathBuf,
     pub summary: AuditSummary,
     pub structure: StructureReport,
@@ -139,6 +144,8 @@ pub fn summarize_findings(
 
 pub fn serialize_audit_result(result: &AuditResult) -> SerializableAuditResult {
     SerializableAuditResult {
+        schema_version: JSON_SCHEMA_VERSION,
+        generator: JSON_GENERATOR,
         root_dir: result.root_dir.clone(),
         summary: result.summary.clone(),
         structure: result.structure.clone(),

--- a/crates/maximus-core/tests/core_models.rs
+++ b/crates/maximus-core/tests/core_models.rs
@@ -635,6 +635,8 @@ fn audit_result_serialization_keeps_js_json_shape() {
     assert_eq!(serialized.fixes.len(), 1);
     assert_eq!(serialized.findings[0].category, "general");
     assert!(serialized.findings[0].fixable);
+    assert_eq!(json["schemaVersion"], "1");
+    assert_eq!(json["generator"], "maximus");
     assert_eq!(json["rootDir"], "/tmp/project");
     assert_eq!(json["summary"]["blockingFindings"], 0);
     assert_eq!(json["summary"]["warningFindings"], 1);

--- a/src/core/findings.js
+++ b/src/core/findings.js
@@ -78,6 +78,8 @@ export function summarizeFindings(findings, fixes, structure) {
 
 export function serializeAuditResult(result) {
   return {
+    schemaVersion: "1",
+    generator: "maximus",
     rootDir: result.rootDir,
     summary: result.summary,
     structure: result.structure,

--- a/test/json-output-contract.test.js
+++ b/test/json-output-contract.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { runCli } from "../src/cli.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("JS audit --json output includes schema metadata", async () => {
+  const targetDir = path.join(repoRoot, "test", "fixtures", "clean-project");
+  const output = await captureJsonOutput(["audit", targetDir, "--json"]);
+
+  assert.equal(output.schemaVersion, "1");
+  assert.equal(output.generator, "maximus");
+  assert.equal(output.rootDir, targetDir);
+});
+
+test("JS fix --json dry-run output includes schema metadata on initial and final payloads", async () => {
+  const targetDir = path.join(repoRoot, "test", "fixtures", "reference-env");
+  const output = await captureJsonOutput(["fix", targetDir, "--dry-run", "--json"]);
+
+  assert.equal(output.initial.schemaVersion, "1");
+  assert.equal(output.initial.generator, "maximus");
+  assert.equal(output.final.schemaVersion, "1");
+  assert.equal(output.final.generator, "maximus");
+});
+
+async function captureJsonOutput(argv) {
+  const logs = [];
+  const originalLog = console.log;
+  const originalExitCode = process.exitCode;
+  console.log = (...args) => {
+    logs.push(args.join(" "));
+  };
+
+  try {
+    process.exitCode = 0;
+    await runCli(argv);
+  } finally {
+    console.log = originalLog;
+    process.exitCode = originalExitCode;
+  }
+
+  assert.equal(logs.length, 1, "CLI should emit a single JSON payload");
+  return JSON.parse(logs[0]);
+}


### PR DESCRIPTION
배경
- #49에서 JSON output에 schema version contract를 추가하되 기존 camelCase/top-level shape drift는 막기로 했습니다.
- 실제 serialization surface가 maximus-core에 있어, CLI 테스트와 함께 core serialization도 같이 고정했습니다.

변경 사항
- audit/fix JSON top-level에 schemaVersion과 generator 필드를 추가했습니다.
- CLI JSON 출력 테스트와 core model serialization 테스트에 새 contract를 반영했습니다.

검증
- cargo test -p maximus-cli --test config_and_filtering
- cargo test -p maximus-core --test core_models

브랜치 / 워크트리
- branch: codex/wave1-rep-json-1
- worktree: /tmp/maximus-wave1/rep-json-1

이슈 연결
- Closes #49