### PR TITLE
feat: doctor 출력에 우선순위 Top 3를 추가한다

### DIFF
--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -108,6 +108,9 @@ pub fn format_doctor_report(result: &AuditResult) -> String {
         lines.push("No config drift detected.".to_string());
     } else {
         lines.push(String::new());
+        lines.push("Top 3 priorities".to_string());
+        lines.extend(format_top_priorities(result));
+        lines.push(String::new());
         lines.push("Findings".to_string());
         lines.extend(format_findings(result));
     }
@@ -121,6 +124,38 @@ pub fn format_doctor_report(result: &AuditResult) -> String {
     }
 
     lines.join("\n")
+}
+
+fn format_top_priorities(result: &AuditResult) -> Vec<String> {
+    result
+        .findings
+        .iter()
+        .take(3)
+        .enumerate()
+        .flat_map(|(index, finding)| {
+            let mut lines = vec![format!(
+                "{}. [{}] {}",
+                index + 1,
+                severity_label(&finding.severity),
+                finding.title
+            )];
+
+            if let Some(file) = &finding.file {
+                lines.push(format!(
+                    "   file: {}",
+                    format_relative_file(&result.root_dir, file)
+                ));
+            }
+
+            if !finding.hint.is_empty() {
+                lines.push(format!("   next: {}", finding.hint));
+            } else if !finding.detail.is_empty() {
+                lines.push(format!("   next: {}", finding.detail));
+            }
+
+            lines
+        })
+        .collect()
 }
 
 pub fn format_fix_result(
@@ -318,7 +353,7 @@ fn relative_path_like_js(root_dir: &Path, file_path: &Path) -> Option<String> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use maximus_core::{AppliedFix, AuditResult, AuditSummary, StructureReport};
+    use maximus_core::{AppliedFix, AuditResult, AuditSummary, Finding, Severity, StructureReport};
 
     use super::{
         format_audit_report, format_doctor_report, format_fix_result, format_help,
@@ -427,6 +462,101 @@ mod tests {
             format_relative_file(&root_dir, Path::new("/tmp/other/file.ts")),
             "../other/file.ts"
         );
+    }
+
+    #[test]
+    fn doctor_report_lists_only_first_three_priorities() {
+        let root_dir = PathBuf::from("/tmp/project");
+        let result = AuditResult {
+            root_dir: root_dir.clone(),
+            summary: AuditSummary {
+                status: "blocking issues".to_string(),
+                total_findings: 4,
+                blocking_findings: 1,
+                warning_findings: 1,
+                info_findings: 2,
+                fixable_findings: 1,
+                fixes_available: 1,
+                config_files: 2,
+                package_count: 1,
+                env_directories: 1,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 1,
+                config_files: 2,
+                recommendations: Vec::new(),
+            },
+            findings: vec![
+                Finding {
+                    id: "err-1".to_string(),
+                    severity: Severity::Error,
+                    category: "tsconfig".to_string(),
+                    title: "First error".to_string(),
+                    detail: "first detail".to_string(),
+                    file: Some(root_dir.join("tsconfig.json")),
+                    hint: "fix the first issue".to_string(),
+                    fixable: false,
+                    fix_ids: Vec::new(),
+                },
+                Finding {
+                    id: "warn-1".to_string(),
+                    severity: Severity::Warn,
+                    category: "env".to_string(),
+                    title: "Second warning".to_string(),
+                    detail: "second detail".to_string(),
+                    file: Some(root_dir.join(".env")),
+                    hint: "run maximus fix".to_string(),
+                    fixable: true,
+                    fix_ids: vec!["env-create-example".to_string()],
+                },
+                Finding {
+                    id: "info-1".to_string(),
+                    severity: Severity::Info,
+                    category: "tsconfig".to_string(),
+                    title: "Third note".to_string(),
+                    detail: "third detail".to_string(),
+                    file: Some(root_dir.join("packages/app/tsconfig.json")),
+                    hint: String::new(),
+                    fixable: false,
+                    fix_ids: Vec::new(),
+                },
+                Finding {
+                    id: "info-2".to_string(),
+                    severity: Severity::Info,
+                    category: "general".to_string(),
+                    title: "Fourth note".to_string(),
+                    detail: "fourth detail".to_string(),
+                    file: None,
+                    hint: String::new(),
+                    fixable: false,
+                    fix_ids: Vec::new(),
+                },
+            ],
+            fixes: Vec::new(),
+        };
+
+        let report = format_doctor_report(&result);
+
+        assert!(report.contains(
+            [
+                "Top 3 priorities",
+                "1. [error] First error",
+                "   file: tsconfig.json",
+                "   next: fix the first issue",
+                "2. [warn] Second warning",
+                "   file: .env",
+                "   next: run maximus fix",
+                "3. [info] Third note",
+                "   file: packages/app/tsconfig.json",
+                "   next: third detail",
+            ]
+            .join("\n")
+            .as_str()
+        ));
+        assert!(report.contains("- [info] Fourth note"));
+        assert!(!report.contains("4. [info] Fourth note"));
     }
 
     #[cfg(windows)]

--- a/crates/maximus-cli/tests/mvp_parity.rs
+++ b/crates/maximus-cli/tests/mvp_parity.rs
@@ -18,10 +18,14 @@ fn js_maximus() -> Command {
 #[test]
 fn text_commands_match_js_reference_outputs() {
     for args in [
-        vec!["audit".to_string(), fixture_path("clean-project").display().to_string()],
-        vec!["doctor".to_string(), fixture_path("clean-project").display().to_string()],
-        vec!["audit".to_string(), fixture_path("reference-env").display().to_string()],
-        vec!["doctor".to_string(), fixture_path("reference-env").display().to_string()],
+        vec![
+            "audit".to_string(),
+            fixture_path("clean-project").display().to_string(),
+        ],
+        vec![
+            "audit".to_string(),
+            fixture_path("reference-env").display().to_string(),
+        ],
         vec![
             "fix".to_string(),
             fixture_path("reference-env").display().to_string(),
@@ -33,6 +37,36 @@ fn text_commands_match_js_reference_outputs() {
         ],
     ] {
         assert_command_matches_js(&args);
+    }
+}
+
+#[test]
+fn doctor_text_commands_match_rust_golden_outputs() {
+    for (fixture, golden_file) in [
+        ("clean-project", "clean-project.doctor.txt"),
+        ("reference-env", "env-missing-example.doctor.txt"),
+        ("reference-tsconfig", "tsconfig-missing-alias.doctor.txt"),
+        ("tsconfig-patterns", "tsconfig-patterns.doctor.txt"),
+        ("windows-crlf", "windows-crlf.doctor.txt"),
+    ] {
+        let target = fixture_path(fixture);
+        let output = rust_maximus()
+            .args(["doctor", target.to_string_lossy().as_ref()])
+            .output()
+            .expect("rust doctor should run");
+
+        assert_eq!(output.status.code(), Some(doctor_expected_status(fixture)));
+        assert_eq!(
+            normalize_output(&output.stdout, &target),
+            normalize_output(
+                fs::read(path_in_workspace("test/golden-rust").join(golden_file))
+                    .expect("golden file should exist")
+                    .as_slice(),
+                &target
+            ),
+            "{fixture}"
+        );
+        assert!(output.stderr.is_empty(), "{fixture}");
     }
 }
 
@@ -86,7 +120,8 @@ fn fix_apply_matches_js_for_text_output_and_written_file() {
     );
     assert_eq!(rust_output.stderr, js_output.stderr);
     assert_eq!(
-        fs::read_to_string(rust_fixture.join(".env.example")).expect("rust output file should exist"),
+        fs::read_to_string(rust_fixture.join(".env.example"))
+            .expect("rust output file should exist"),
         fs::read_to_string(js_fixture.join(".env.example")).expect("js output file should exist")
     );
 }
@@ -113,7 +148,8 @@ fn fix_apply_matches_js_for_json_shape_and_written_file() {
 
     assert_eq!(rust_json, js_json);
     assert_eq!(
-        fs::read_to_string(rust_fixture.join(".env.example")).expect("rust output file should exist"),
+        fs::read_to_string(rust_fixture.join(".env.example"))
+            .expect("rust output file should exist"),
         fs::read_to_string(js_fixture.join(".env.example")).expect("js output file should exist")
     );
 }
@@ -128,7 +164,11 @@ fn assert_command_matches_js(args: &[String]) {
         .output()
         .expect("js command should run");
 
-    assert_eq!(rust_output.status.code(), js_output.status.code(), "{args:?}");
+    assert_eq!(
+        rust_output.status.code(),
+        js_output.status.code(),
+        "{args:?}"
+    );
     assert_eq!(
         normalize_output_for_args(&rust_output, args),
         normalize_output_for_args(&js_output, args),
@@ -147,7 +187,11 @@ fn assert_json_command_matches_js(args: &[String]) {
         .output()
         .expect("js command should run");
 
-    assert_eq!(rust_output.status.code(), js_output.status.code(), "{args:?}");
+    assert_eq!(
+        rust_output.status.code(),
+        js_output.status.code(),
+        "{args:?}"
+    );
     assert_eq!(
         normalize_json_output(&rust_output, Path::new(&args[1])),
         normalize_json_output(&js_output, Path::new(&args[1])),
@@ -169,7 +213,8 @@ fn normalize_output(stdout: &[u8], target_dir: &Path) -> String {
 }
 
 fn normalize_json_output(output: &Output, target_dir: &Path) -> Value {
-    let mut value: Value = serde_json::from_slice(&output.stdout).expect("json output should parse");
+    let mut value: Value =
+        serde_json::from_slice(&output.stdout).expect("json output should parse");
     rewrite_json_paths(&mut value, target_dir);
     value
 }
@@ -196,6 +241,18 @@ fn rewrite_json_paths(value: &mut Value, target_dir: &Path) {
 
 fn fixture_path(name: &str) -> PathBuf {
     workspace_root().join("test/fixtures").join(name)
+}
+
+fn path_in_workspace(path: &str) -> PathBuf {
+    workspace_root().join(path)
+}
+
+fn doctor_expected_status(fixture: &str) -> i32 {
+    match fixture {
+        "clean-project" => 0,
+        "reference-env" | "tsconfig-patterns" | "windows-crlf" | "reference-tsconfig" => 1,
+        other => panic!("missing expected status for fixture {other}"),
+    }
 }
 
 fn prepare_temp_reference_env() -> PathBuf {

--- a/src/core/format-report.js
+++ b/src/core/format-report.js
@@ -78,6 +78,9 @@ export function formatDoctorReport(result) {
     lines.push("No config drift detected.");
   } else {
     lines.push("");
+    lines.push("Top 3 priorities");
+    lines.push(...formatTopPriorities(result));
+    lines.push("");
     lines.push("Findings");
     lines.push(...formatFindings(result));
   }
@@ -150,6 +153,24 @@ function formatFindings(result) {
 
     if (finding.hint) {
       lines.push(`  hint: ${finding.hint}`);
+    }
+
+    return lines;
+  });
+}
+
+function formatTopPriorities(result) {
+  return result.findings.slice(0, 3).flatMap((finding, index) => {
+    const lines = [`${index + 1}. [${finding.severity}] ${finding.title}`];
+
+    if (finding.file) {
+      lines.push(`   file: ${formatFile(result.rootDir, finding.file)}`);
+    }
+
+    if (finding.hint) {
+      lines.push(`   next: ${finding.hint}`);
+    } else if (finding.detail) {
+      lines.push(`   next: ${finding.detail}`);
     }
 
     return lines;

--- a/test/doctor-report-contract.test.js
+++ b/test/doctor-report-contract.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatDoctorReport } from "../src/core/format-report.js";
+
+test("JS doctor formatter includes the Top 3 priorities section", () => {
+  const report = formatDoctorReport({
+    rootDir: "/tmp/project",
+    summary: {
+      status: "blocking issues",
+      fixesAvailable: 1,
+    },
+    structure: {
+      isMonorepo: false,
+      packageCount: 1,
+      configFiles: 2,
+      envDirectories: 1,
+      recommendations: [],
+    },
+    findings: [
+      {
+        severity: "error",
+        title: "Missing example env file",
+        file: "/tmp/project/.env",
+        detail: "A committed .env.example file is missing.",
+        hint: "Create .env.example with safe defaults.",
+        fixable: false,
+      },
+      {
+        severity: "warn",
+        title: "Path alias target does not exist",
+        file: "/tmp/project/tsconfig.json",
+        detail: "@app/* points to src/missing/*.",
+        hint: "Update the alias to an existing directory.",
+        fixable: false,
+      },
+      {
+        severity: "info",
+        title: "Package scripts are tidy",
+        file: null,
+        detail: "No extra work is needed.",
+        hint: "",
+        fixable: false,
+      },
+    ],
+  });
+
+  assert.match(report, /Top 3 priorities/);
+  assert.match(report, /1\. \[error\] Missing example env file/);
+  assert.match(report, /   file: \.env/);
+  assert.match(report, /   next: Create \.env\.example with safe defaults\./);
+  assert.match(report, /2\. \[warn\] Path alias target does not exist/);
+  assert.match(report, /3\. \[info\] Package scripts are tidy/);
+});

--- a/test/golden-rust/env-missing-example.doctor.txt
+++ b/test/golden-rust/env-missing-example.doctor.txt
@@ -8,6 +8,11 @@ Prescription
 - Run "maximus fix" to apply 1 safe fix(es).
 - No manual follow-up is required right now.
 
+Top 3 priorities
+1. [warn] Missing .env.example contract
+   file: .env
+   next: Run "maximus fix" to create a blank contract file.
+
 Findings
 - [warn] Missing .env.example contract
   file: .env

--- a/test/golden-rust/tsconfig-missing-alias.doctor.txt
+++ b/test/golden-rust/tsconfig-missing-alias.doctor.txt
@@ -1,0 +1,20 @@
+Maximus doctor
+Target: <TARGET>
+
+Diagnosis: blocking issues
+Project shape: single package, 1 package(s), 2 config file(s), 0 env folder(s)
+
+Prescription
+- No automatic fixes are currently available.
+- Review 1 manual issue(s) in priority order below.
+
+Top 3 priorities
+1. [error] Path alias target does not exist
+   file: tsconfig.json
+   next: Update or remove stale aliases before they break editor and build resolution.
+
+Findings
+- [error] Path alias target does not exist
+  file: tsconfig.json
+  detail: @missing/* points to ghost/*, but the resolved path was not found.
+  hint: Update or remove stale aliases before they break editor and build resolution.

--- a/test/golden-rust/tsconfig-patterns.doctor.txt
+++ b/test/golden-rust/tsconfig-patterns.doctor.txt
@@ -1,0 +1,34 @@
+Maximus doctor
+Target: <TARGET>
+
+Diagnosis: attention needed
+Project shape: single package, 0 package(s), 4 config file(s), 0 env folder(s)
+
+Prescription
+- No automatic fixes are currently available.
+- Review 3 manual issue(s) in priority order below.
+
+Top 3 priorities
+1. [warn] Include pattern does not match any files
+   file: empty-include/tsconfig.json
+   next: Fix or remove empty include patterns before TypeScript silently skips expected inputs.
+2. [info] Exclude pattern does not filter any included files
+   file: empty-exclude/tsconfig.json
+   next: Remove or tighten exclude entries that do not change the effective TypeScript input set.
+3. [info] Exclude pattern does not filter any included files
+   file: exclude-only/tsconfig.json
+   next: Remove or tighten exclude entries that do not change the effective TypeScript input set.
+
+Findings
+- [warn] Include pattern does not match any files
+  file: empty-include/tsconfig.json
+  detail: include pattern "src/missing/**/*.ts" matched 0 files under base dir <TARGET>/empty-include.
+  hint: Fix or remove empty include patterns before TypeScript silently skips expected inputs.
+- [info] Exclude pattern does not filter any included files
+  file: empty-exclude/tsconfig.json
+  detail: exclude pattern "generated/**/*.ts" removed 0 files from 1 included file(s) under base dir <TARGET>/empty-exclude.
+  hint: Remove or tighten exclude entries that do not change the effective TypeScript input set.
+- [info] Exclude pattern does not filter any included files
+  file: exclude-only/tsconfig.json
+  detail: exclude pattern "missing/**/*.ts" removed 0 files from 1 included file(s) under base dir <TARGET>/exclude-only.
+  hint: Remove or tighten exclude entries that do not change the effective TypeScript input set.

--- a/test/golden-rust/windows-crlf.doctor.txt
+++ b/test/golden-rust/windows-crlf.doctor.txt
@@ -1,0 +1,27 @@
+Maximus doctor
+Target: <TARGET>
+
+Diagnosis: blocking issues
+Project shape: single package, 0 package(s), 2 config file(s), 1 env folder(s)
+
+Prescription
+- Run "maximus fix" to apply 1 safe fix(es).
+- Review 1 manual issue(s) in priority order below.
+
+Top 3 priorities
+1. [error] Path alias target does not exist
+   file: tsconfig.json
+   next: Update or remove stale aliases before they break editor and build resolution.
+2. [warn] Missing .env.example contract
+   file: .env
+   next: Run "maximus fix" to create a blank contract file.
+
+Findings
+- [error] Path alias target does not exist
+  file: tsconfig.json
+  detail: @app/* points to src/*, but the resolved path was not found.
+  hint: Update or remove stale aliases before they break editor and build resolution.
+- [warn] Missing .env.example contract
+  file: .env
+  detail: Runtime env files exist, but .env.example is missing.
+  hint: Run "maximus fix" to create a blank contract file.

--- a/test/reference-parity.test.js
+++ b/test/reference-parity.test.js
@@ -14,6 +14,7 @@ const scenarios = [
     args: ["audit", "./test/fixtures/clean-project"],
     goldenFile: "clean-project.audit.txt",
     expectedStatus: 0,
+    runtime: "js",
     targetDir: path.join(repoRoot, "test", "fixtures", "clean-project"),
   },
   {
@@ -21,6 +22,7 @@ const scenarios = [
     args: ["doctor", "./test/fixtures/clean-project"],
     goldenFile: "clean-project.doctor.txt",
     expectedStatus: 0,
+    runtime: "rust",
     targetDir: path.join(repoRoot, "test", "fixtures", "clean-project"),
   },
   {
@@ -28,6 +30,7 @@ const scenarios = [
     args: ["audit", "./test/fixtures/reference-env"],
     goldenFile: "env-missing-example.audit.txt",
     expectedStatus: 1,
+    runtime: "js",
     targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
   },
   {
@@ -35,13 +38,39 @@ const scenarios = [
     args: ["doctor", "./test/fixtures/reference-env"],
     goldenFile: "env-missing-example.doctor.txt",
     expectedStatus: 1,
+    runtime: "rust",
     targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
+  },
+  {
+    name: "reference tsconfig doctor output stays stable",
+    args: ["doctor", "./test/fixtures/reference-tsconfig"],
+    goldenFile: "tsconfig-missing-alias.doctor.txt",
+    expectedStatus: 1,
+    runtime: "rust",
+    targetDir: path.join(repoRoot, "test", "fixtures", "reference-tsconfig"),
+  },
+  {
+    name: "tsconfig-patterns doctor output stays stable",
+    args: ["doctor", "./test/fixtures/tsconfig-patterns"],
+    goldenFile: "tsconfig-patterns.doctor.txt",
+    expectedStatus: 1,
+    runtime: "rust",
+    targetDir: path.join(repoRoot, "test", "fixtures", "tsconfig-patterns"),
+  },
+  {
+    name: "windows-crlf doctor output stays stable",
+    args: ["doctor", "./test/fixtures/windows-crlf"],
+    goldenFile: "windows-crlf.doctor.txt",
+    expectedStatus: 1,
+    runtime: "rust",
+    targetDir: path.join(repoRoot, "test", "fixtures", "windows-crlf"),
   },
   {
     name: "reference env fix dry-run output stays stable",
     args: ["fix", "./test/fixtures/reference-env", "--dry-run"],
     goldenFile: "env-missing-example.fix-dry-run.txt",
     expectedStatus: 1,
+    runtime: "js",
     targetDir: path.join(repoRoot, "test", "fixtures", "reference-env"),
   },
   {
@@ -49,16 +78,14 @@ const scenarios = [
     args: ["audit", "./test/fixtures/reference-tsconfig"],
     goldenFile: "tsconfig-missing-alias.audit.txt",
     expectedStatus: 1,
+    runtime: "js",
     targetDir: path.join(repoRoot, "test", "fixtures", "reference-tsconfig"),
   },
 ];
 
 for (const scenario of scenarios) {
   test(scenario.name, async () => {
-    const result = spawnSync(process.execPath, ["./bin/maximus.js", ...scenario.args], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    });
+    const result = runScenario(scenario);
 
     assert.equal(result.status, scenario.expectedStatus, result.stderr);
 
@@ -69,6 +96,20 @@ for (const scenario of scenarios) {
     );
 
     assert.equal(actual, golden);
+  });
+}
+
+function runScenario(scenario) {
+  if (scenario.runtime === "rust") {
+    return spawnSync("cargo", ["run", "-q", "-p", "maximus-cli", "--", ...scenario.args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+  }
+
+  return spawnSync(process.execPath, ["./bin/maximus.js", ...scenario.args], {
+    cwd: repoRoot,
+    encoding: "utf8",
   });
 }
 


### PR DESCRIPTION
배경
- #50에서 doctor 텍스트 출력에 Top 3 priorities 계약을 추가하고, fail-closed golden evidence를 함께 갱신하기로 했습니다.
- doctor 텍스트는 Rust 기준 golden으로 고정하고 audit/fix 및 JSON parity는 기존 JS 기준을 유지하도록 분리했습니다.

변경 사항
- doctor report 상단에 finding 순서를 따르는 Top 3 priorities 섹션을 추가했습니다.
- Rust doctor golden 파일을 추가/갱신하고, parity 테스트가 doctor 시나리오에서 Rust CLI를 사용하도록 분리했습니다.

검증
- cargo test -p maximus-cli --test mvp_parity
- node --test test/reference-parity.test.js

브랜치 / 워크트리
- branch: codex/wave1-rep-text-1
- worktree: /tmp/maximus-wave1/rep-text-1

이슈 연결
- Closes #50