### PR TITLE
feat: CLI 종료 코드 정책을 fail-on 설정과 맞춘다

### DIFF
--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -142,15 +142,8 @@ fn run_audit_command(
         println!("{}", report_text::format_audit_report(&audited.result));
     }
 
-    Ok(fail_policy::exit_code(
-        &audited.result.summary,
-        resolved
-            .config
-            .report
-            .fail_on
-            .as_ref()
-            .unwrap_or(&FailOnLevel::Warn),
-    ))
+    let fail_on = effective_fail_on_level(&resolved.config);
+    Ok(fail_policy::exit_code(&audited.result.summary, &fail_on))
 }
 
 fn run_doctor_command(
@@ -167,15 +160,8 @@ fn run_doctor_command(
         println!("{}", report_text::format_doctor_report(&audited.result));
     }
 
-    Ok(fail_policy::exit_code(
-        &audited.result.summary,
-        resolved
-            .config
-            .report
-            .fail_on
-            .as_ref()
-            .unwrap_or(&FailOnLevel::Warn),
-    ))
+    let fail_on = effective_fail_on_level(&resolved.config);
+    Ok(fail_policy::exit_code(&audited.result.summary, &fail_on))
 }
 
 fn run_fix_command(
@@ -255,15 +241,8 @@ fn run_fix_command(
         );
     }
 
-    Ok(fail_policy::exit_code(
-        &final_result.summary,
-        resolved
-            .config
-            .report
-            .fail_on
-            .as_ref()
-            .unwrap_or(&FailOnLevel::Warn),
-    ))
+    let fail_on = effective_fail_on_level(&resolved.config);
+    Ok(fail_policy::exit_code(&final_result.summary, &fail_on))
 }
 
 fn resolve_effective_config(
@@ -301,6 +280,10 @@ fn resolve_effective_config(
         config,
         ignore_root,
     })
+}
+
+fn effective_fail_on_level(config: &MaximusConfig) -> FailOnLevel {
+    config.report.fail_on.clone().unwrap_or_default()
 }
 
 fn parse_fail_on_level(value: &str) -> Result<FailOnLevel, CliError> {

--- a/crates/maximus-cli/tests/exit_code_policy.rs
+++ b/crates/maximus-cli/tests/exit_code_policy.rs
@@ -1,0 +1,135 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn maximus_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+#[test]
+fn default_fail_on_applies_to_warning_findings_across_commands() {
+    let fixture = warning_fixture();
+    let target = fixture.path().to_string_lossy().into_owned();
+
+    let audit_output = maximus_bin()
+        .args(["audit", target.as_str(), "--json"])
+        .output()
+        .expect("audit should run");
+    assert_eq!(audit_output.status.code(), Some(1), "{audit_output:?}");
+    assert_finding_severity(&audit_output, "warn");
+
+    for args in [
+        vec!["doctor", target.as_str()],
+        vec!["fix", target.as_str(), "--dry-run"],
+    ] {
+        let output = maximus_bin().args(args).output().expect("command should run");
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+    }
+}
+
+#[test]
+fn explicit_info_escalates_info_only_findings() {
+    let fixture = info_only_fixture();
+    let target = fixture.path().to_string_lossy().into_owned();
+
+    for args in [
+        vec!["audit", target.as_str(), "--fail-on", "info", "--json"],
+        vec!["doctor", target.as_str(), "--fail-on", "info"],
+        vec!["fix", target.as_str(), "--dry-run", "--fail-on", "info"],
+    ] {
+        let output = maximus_bin().args(args).output().expect("command should run");
+        assert_eq!(output.status.code(), Some(1), "{output:?}");
+    }
+}
+
+#[test]
+fn explicit_none_suppresses_warning_only_findings() {
+    let fixture = warning_fixture();
+    let target = fixture.path().to_string_lossy().into_owned();
+
+    for args in [
+        vec!["audit", target.as_str(), "--fail-on", "none", "--json"],
+        vec!["doctor", target.as_str(), "--fail-on", "none"],
+        vec!["fix", target.as_str(), "--dry-run", "--fail-on", "none"],
+    ] {
+        let output = maximus_bin().args(args).output().expect("command should run");
+        assert_eq!(output.status.code(), Some(0), "{output:?}");
+    }
+}
+
+fn info_only_fixture() -> TempDir {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_env_fixture(fixture.path());
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"
+        {
+          "checks": { "only": ["env"] },
+          "severity": { "env-mismatch": "info" }
+        }
+        "#,
+    );
+
+    fixture
+}
+
+fn warning_fixture() -> TempDir {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+    fixture
+}
+
+fn write_env_fixture(root: &Path) {
+    write(root.join(".env"), "SHARED=base\n");
+    write(root.join(".env.local"), "SHARED=local\n");
+    write(root.join(".env.example"), "SHARED=\n");
+}
+
+fn write_tsconfig_conflict_fixture(root: &Path) {
+    write(
+        root.join("package.json"),
+        r##"{"name":"fixture","imports":{"#app/*":"./src/runtime/*"}}"##,
+    );
+    write(
+        root.join("tsconfig.json"),
+        r##"
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "#app/*": ["./src/lib/*"]
+            }
+          }
+        }
+        "##,
+    );
+    write(root.join("src/runtime/index.ts"), "export {};\n");
+    write(root.join("src/lib/index.ts"), "export {};\n");
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_finding_severity(output: &Output, expected_severity: &str) {
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        findings[0]
+            .as_object()
+            .and_then(|finding| finding.get("severity"))
+            .and_then(Value::as_str),
+        Some(expected_severity)
+    );
+}

--- a/crates/maximus-core/src/config.rs
+++ b/crates/maximus-core/src/config.rs
@@ -47,6 +47,12 @@ pub enum FailOnLevel {
     None,
 }
 
+impl Default for FailOnLevel {
+    fn default() -> Self {
+        Self::Warn
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReportConfig {


### PR DESCRIPTION
배경
- #48에서 FailOnLevel 설정과 실제 process exit code contract가 어긋나지 않도록 Rust CLI를 정리하기로 했습니다.
- Wave 1 범위에서는 독립 PR로 유지하기 위해 main/config/test surface만 최소로 조정했습니다.

변경 사항
- CLI 기본 fail-on 동작과 명시적 fail-on override가 audit/doctor/fix --dry-run 경로에서 일관되게 적용되도록 정리했습니다.
- exit code 회귀를 고정하는 전용 integration test를 추가했습니다.

검증
- cargo test -p maximus-cli --test exit_code_policy
- cargo test -p maximus-cli --test config_and_filtering

브랜치 / 워크트리
- branch: codex/wave1-cli-exit-1
- worktree: /tmp/maximus-wave1/cli-exit-1

이슈 연결
- Closes #48