### PR TITLE
feat: tsconfig checker의 alias와 typeRoots 검사를 강화한다

### DIFF
--- a/crates/maximus-checks/src/tsconfig.rs
+++ b/crates/maximus-checks/src/tsconfig.rs
@@ -142,6 +142,12 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
             &file.dir,
             &config,
         )?;
+        collect_types_and_type_roots_findings(
+            &mut findings,
+            &file.path,
+            &file.dir,
+            compiler_options,
+        )?;
 
         let Some(paths_config) = compiler_options.and_then(|options| options.get("paths")) else {
             continue;
@@ -175,6 +181,7 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
             .unwrap_or_else(|| file.dir.clone());
 
         collect_paths_findings(&mut findings, &file.path, &base_dir, paths_config)?;
+        collect_path_alias_shadowing_findings(&mut findings, &file.path, paths_config);
 
         if let Some(package_file) = find_nearest_package_file(project, &file.dir) {
             if let Some(package_text) = read_text_if_exists(&package_file.path)? {
@@ -643,6 +650,392 @@ fn collect_paths_findings(
     Ok(())
 }
 
+fn collect_path_alias_shadowing_findings(
+    findings: &mut Vec<Finding>,
+    file_path: &Path,
+    paths_config: &Map<String, Value>,
+) {
+    let aliases = paths_config.keys().cloned().collect::<Vec<_>>();
+
+    for alias in &aliases {
+        if !is_package_style_alias(alias) {
+            continue;
+        }
+
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "tsconfig-paths-shadow-package:{}:{alias}",
+                file_path.to_string_lossy()
+            ),
+            title: format!("Path alias \"{alias}\" shadows a package import"),
+            category: Some("tsconfig".to_string()),
+            detail: Some(format!(
+                "\"{alias}\" is a bare package-style specifier, so this alias can override an installed package or workspace package with the same import path."
+            )),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Prefer #internal/* or another dedicated namespace for app-local aliases so package imports stay unambiguous."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    for left_index in 0..aliases.len() {
+        for right_index in left_index + 1..aliases.len() {
+            let left = &aliases[left_index];
+            let right = &aliases[right_index];
+            let Some((shadowing_alias, shadowed_alias)) =
+                determine_shadowing_alias_pair(left, right)
+            else {
+                continue;
+            };
+            if is_exact_specialization_of_wildcard_alias(shadowing_alias, shadowed_alias) {
+                continue;
+            }
+
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-paths-shadow-alias:{}:{shadowing_alias}:{shadowed_alias}",
+                    file_path.to_string_lossy()
+                ),
+                title: format!(
+                    "Path alias \"{shadowing_alias}\" shadows \"{shadowed_alias}\""
+                ),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "Both aliases can match the same import specifier, so TypeScript will prefer \"{shadowing_alias}\" and hide \"{shadowed_alias}\" for those imports."
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Make overlapping aliases disjoint so imports keep a single obvious target."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+    }
+}
+
+fn collect_types_and_type_roots_findings(
+    findings: &mut Vec<Finding>,
+    file_path: &Path,
+    config_dir: &Path,
+    compiler_options: Option<&Map<String, Value>>,
+) -> io::Result<()> {
+    let Some(compiler_options) = compiler_options else {
+        return Ok(());
+    };
+
+    let types = parse_types_option(findings, file_path, compiler_options);
+    let type_roots = parse_type_roots_option(findings, file_path, compiler_options);
+
+    if let Some(type_roots) = type_roots.as_ref() {
+        for type_root in type_roots {
+            let resolved_type_root = resolve_path_with_backslash_support(config_dir, type_root);
+            if path_exists(&resolved_type_root) {
+                continue;
+            }
+
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-typeroots-missing:{}:{type_root}",
+                    file_path.to_string_lossy()
+                ),
+                title: "Configured typeRoots entry does not exist".to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "compilerOptions.typeRoots includes \"{type_root}\", but the resolved path was not found."
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Create the missing types directory or remove stale typeRoots entries before TypeScript silently skips expected declarations."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+    }
+
+    match (types.as_ref(), type_roots.as_ref()) {
+        (Some(types), Some(type_roots)) => {
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-types-typeroots-guidance:{}",
+                    file_path.to_string_lossy()
+                ),
+                title: "compilerOptions.types and typeRoots both narrow ambient type resolution"
+                    .to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "compilerOptions.types only includes {}, and compilerOptions.typeRoots only searches {}, so unlisted ambient packages outside those roots will be hidden from TypeScript.",
+                    format_string_list(types),
+                    format_string_list(type_roots)
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Keep both lists aligned with every global types package your runtime and tests rely on."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+        (Some(types), None) => {
+            let (title, detail, severity) = if types.is_empty() {
+                (
+                    "compilerOptions.types disables automatic @types inclusion".to_string(),
+                    "compilerOptions.types is set to [], so TypeScript will not auto-include any ambient @types packages.".to_string(),
+                    Severity::Warn,
+                )
+            } else {
+                (
+                    "compilerOptions.types limits ambient type packages".to_string(),
+                    format!(
+                        "compilerOptions.types only includes {}, so unlisted ambient @types packages will not be injected automatically.",
+                        format_string_list(types)
+                    ),
+                    Severity::Info,
+                )
+            };
+
+            findings.push(make_finding(FindingInput {
+                id: format!("tsconfig-types-guidance:{}", file_path.to_string_lossy()),
+                title,
+                category: Some("tsconfig".to_string()),
+                detail: Some(detail),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Keep this list in sync with every test and runtime package that should contribute global types."
+                        .to_string(),
+                ),
+                severity: Some(severity),
+            }));
+        }
+        (None, Some(type_roots)) => {
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-typeroots-guidance:{}",
+                    file_path.to_string_lossy()
+                ),
+                title: "compilerOptions.typeRoots disables default @types discovery".to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "compilerOptions.typeRoots only searches {}, so TypeScript will stop using the default node_modules/@types lookup for this config.",
+                    format_string_list(type_roots)
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Include every required ambient types directory or remove typeRoots to restore default discovery."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+        (None, None) => {}
+    }
+
+    Ok(())
+}
+
+fn parse_types_option(
+    findings: &mut Vec<Finding>,
+    file_path: &Path,
+    compiler_options: &Map<String, Value>,
+) -> Option<Vec<String>> {
+    let Some(types_value) = compiler_options.get("types") else {
+        return None;
+    };
+    let Some(types) = types_value.as_array() else {
+        findings.push(make_finding(FindingInput {
+            id: format!("tsconfig-types-shape:{}", file_path.to_string_lossy()),
+            title: "\"compilerOptions.types\" must be an array of package names".to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(
+                "TypeScript expects compilerOptions.types to be an array of string package names."
+                    .to_string(),
+            ),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Rewrite compilerOptions.types as [\"node\", \"jest\"]-style package names or remove it."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Error),
+        }));
+        return None;
+    };
+
+    let mut collected_types = Vec::new();
+    let mut has_invalid_entry = false;
+    for (index, value) in types.iter().enumerate() {
+        let Some(type_name) = value.as_str() else {
+            has_invalid_entry = true;
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-types-entry:{}:{index}",
+                    file_path.to_string_lossy()
+                ),
+                title: "\"compilerOptions.types\" contains a non-string package name"
+                    .to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "{} declares compilerOptions.types[{index}], but TypeScript expects a non-empty string package name.",
+                    file_path.to_string_lossy()
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Rewrite compilerOptions.types as [\"node\", \"jest\"]-style package names or remove it."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Error),
+            }));
+            continue;
+        };
+
+        if type_name.trim().is_empty() {
+            has_invalid_entry = true;
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-types-entry:{}:{index}",
+                    file_path.to_string_lossy()
+                ),
+                title: "\"compilerOptions.types\" contains a non-string package name"
+                    .to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "{} declares compilerOptions.types[{index}], but TypeScript expects a non-empty string package name.",
+                    file_path.to_string_lossy()
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Rewrite compilerOptions.types as [\"node\", \"jest\"]-style package names or remove it."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Error),
+            }));
+            continue;
+        }
+
+        collected_types.push(type_name.trim().to_string());
+    }
+
+    if has_invalid_entry {
+        return None;
+    }
+
+    Some(collected_types)
+}
+
+fn parse_type_roots_option(
+    findings: &mut Vec<Finding>,
+    file_path: &Path,
+    compiler_options: &Map<String, Value>,
+) -> Option<Vec<String>> {
+    let Some(type_roots_value) = compiler_options.get("typeRoots") else {
+        return None;
+    };
+    let Some(type_roots) = type_roots_value.as_array() else {
+        findings.push(make_finding(FindingInput {
+            id: format!("tsconfig-typeroots-shape:{}", file_path.to_string_lossy()),
+            title: "\"compilerOptions.typeRoots\" must be an array of directory paths"
+                .to_string(),
+            category: Some("tsconfig".to_string()),
+            detail: Some(
+                "TypeScript expects compilerOptions.typeRoots to be an array of string directory paths."
+                    .to_string(),
+            ),
+            file: Some(file_path.to_path_buf()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Rewrite compilerOptions.typeRoots as [\"./types\", \"./node_modules/@types\"]-style paths or remove it."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Error),
+        }));
+        return None;
+    };
+
+    let mut collected_type_roots = Vec::new();
+    let mut has_invalid_entry = false;
+    for (index, value) in type_roots.iter().enumerate() {
+        let Some(type_root) = value.as_str() else {
+            has_invalid_entry = true;
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-typeroots-entry:{}:{index}",
+                    file_path.to_string_lossy()
+                ),
+                title: "\"compilerOptions.typeRoots\" contains a non-string path".to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "{} declares compilerOptions.typeRoots[{index}], but TypeScript expects a non-empty string directory path.",
+                    file_path.to_string_lossy()
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Rewrite compilerOptions.typeRoots as [\"./types\", \"./node_modules/@types\"]-style paths or remove it."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Error),
+            }));
+            continue;
+        };
+
+        if type_root.trim().is_empty() {
+            has_invalid_entry = true;
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "tsconfig-typeroots-entry:{}:{index}",
+                    file_path.to_string_lossy()
+                ),
+                title: "\"compilerOptions.typeRoots\" contains a non-string path".to_string(),
+                category: Some("tsconfig".to_string()),
+                detail: Some(format!(
+                    "{} declares compilerOptions.typeRoots[{index}], but TypeScript expects a non-empty string directory path.",
+                    file_path.to_string_lossy()
+                )),
+                file: Some(file_path.to_path_buf()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Rewrite compilerOptions.typeRoots as [\"./types\", \"./node_modules/@types\"]-style paths or remove it."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Error),
+            }));
+            continue;
+        }
+
+        collected_type_roots.push(type_root.trim().to_string());
+    }
+
+    if has_invalid_entry {
+        return None;
+    }
+
+    Some(collected_type_roots)
+}
+
 fn collect_include_exclude_pattern_findings(
     findings: &mut Vec<Finding>,
     file_path: &Path,
@@ -968,13 +1361,12 @@ fn collect_effective_tsconfig_input_files(
         effective_pattern_config.files.as_ref(),
         candidate_extensions,
     )?;
-    let mut exclude_eligible_files = if effective_pattern_config.include.is_some()
-        || effective_pattern_config.files.is_some()
-    {
-        BTreeSet::new()
-    } else {
-        collect_default_pattern_matches(base_dir, candidate_extensions, default_excluded_dirs)?
-    };
+    let mut exclude_eligible_files =
+        if effective_pattern_config.include.is_some() || effective_pattern_config.files.is_some() {
+            BTreeSet::new()
+        } else {
+            collect_default_pattern_matches(base_dir, candidate_extensions, default_excluded_dirs)?
+        };
 
     if let Some(include_field) = effective_pattern_config.include.as_ref() {
         for pattern in &include_field.values {
@@ -1040,8 +1432,7 @@ fn collect_output_source_roots(
                 continue;
             }
 
-            if let Some(source_root) =
-                resolve_pattern_source_root(&include_field.base_dir, pattern)
+            if let Some(source_root) = resolve_pattern_source_root(&include_field.base_dir, pattern)
             {
                 source_roots.insert(source_root);
             }
@@ -1555,7 +1946,8 @@ fn resolve_effective_pattern_config_inner(
     }
     visited.push(normalized_config_path);
 
-    let mut effective_config = match load_extended_tsconfig_document(config_path, config, visited)? {
+    let mut effective_config = match load_extended_tsconfig_document(config_path, config, visited)?
+    {
         ExtendedPatternConfigDocument::Loaded(parent_config_path, parent_config) => {
             resolve_effective_pattern_config_inner(&parent_config_path, &parent_config, visited)?
         }
@@ -1931,6 +2323,159 @@ fn select_effective_tsconfig_target(
     }
 
     Ok(first_string_target)
+}
+
+fn determine_shadowing_alias_pair<'a>(left: &'a str, right: &'a str) -> Option<(&'a str, &'a str)> {
+    if !aliases_overlap(left, right) {
+        return None;
+    }
+
+    let left_specificity = alias_specificity(left);
+    let right_specificity = alias_specificity(right);
+    if left_specificity > right_specificity {
+        return Some((left, right));
+    }
+    if right_specificity > left_specificity {
+        return Some((right, left));
+    }
+
+    None
+}
+
+fn is_exact_specialization_of_wildcard_alias(shadowing_alias: &str, shadowed_alias: &str) -> bool {
+    !shadowing_alias.contains('*')
+        && shadowed_alias.contains('*')
+        && wildcard_pattern_matches(shadowing_alias, shadowed_alias)
+}
+
+fn aliases_overlap(left: &str, right: &str) -> bool {
+    match (left.contains('*'), right.contains('*')) {
+        (false, false) => left == right,
+        (false, true) => wildcard_pattern_matches(left, right),
+        (true, false) => wildcard_pattern_matches(right, left),
+        (true, true) => wildcard_aliases_overlap(left, right),
+    }
+}
+
+fn wildcard_aliases_overlap(left: &str, right: &str) -> bool {
+    if left.matches('*').count() != 1 || right.matches('*').count() != 1 {
+        return wildcard_overlap_samples(left)
+            .into_iter()
+            .chain(wildcard_overlap_samples(right))
+            .any(|candidate| {
+                wildcard_pattern_matches(&candidate, left)
+                    && wildcard_pattern_matches(&candidate, right)
+            });
+    }
+
+    let (left_prefix, left_suffix) = split_wildcard_alias(left);
+    let (right_prefix, right_suffix) = split_wildcard_alias(right);
+    let Some(merged_prefix) = merge_prefixes(left_prefix, right_prefix) else {
+        return false;
+    };
+    let Some(merged_suffix) = merge_suffixes(left_suffix, right_suffix) else {
+        return false;
+    };
+
+    ["", "shadow", "shadow/nested"]
+        .into_iter()
+        .map(|middle| format!("{merged_prefix}{middle}{merged_suffix}"))
+        .any(|candidate| {
+            wildcard_pattern_matches(&candidate, left)
+                && wildcard_pattern_matches(&candidate, right)
+        })
+}
+
+fn wildcard_overlap_samples(pattern: &str) -> Vec<String> {
+    if !pattern.contains('*') {
+        return vec![pattern.to_string()];
+    }
+
+    ["shadow", "shadow/nested"]
+        .into_iter()
+        .map(|replacement| pattern.replace('*', replacement))
+        .collect()
+}
+
+fn split_wildcard_alias(pattern: &str) -> (&str, &str) {
+    let wildcard_index = pattern.find('*').unwrap_or(pattern.len());
+    (&pattern[..wildcard_index], &pattern[wildcard_index + 1..])
+}
+
+fn merge_prefixes<'a>(left: &'a str, right: &'a str) -> Option<&'a str> {
+    if left.starts_with(right) {
+        return Some(left);
+    }
+    if right.starts_with(left) {
+        return Some(right);
+    }
+
+    None
+}
+
+fn merge_suffixes<'a>(left: &'a str, right: &'a str) -> Option<&'a str> {
+    if left.ends_with(right) {
+        return Some(left);
+    }
+    if right.ends_with(left) {
+        return Some(right);
+    }
+
+    None
+}
+
+fn alias_specificity(alias: &str) -> (usize, usize, usize) {
+    let wildcard_count = alias.matches('*').count();
+    let fixed_length = alias.chars().filter(|character| *character != '*').count();
+    let separator_count = alias
+        .chars()
+        .filter(|character| matches!(character, '/' | '\\'))
+        .count();
+
+    (
+        usize::from(wildcard_count == 0),
+        fixed_length + separator_count,
+        alias.len(),
+    )
+}
+
+fn is_package_style_alias(alias: &str) -> bool {
+    let alias = alias.trim_end_matches('*').trim_end_matches(['/', '\\']);
+    if alias.is_empty()
+        || alias.starts_with('#')
+        || alias.starts_with('.')
+        || alias.starts_with('/')
+        || alias.starts_with('\\')
+        || has_url_like_prefix(alias)
+    {
+        return false;
+    }
+
+    if let Some(rest) = alias.strip_prefix('@') {
+        let segments = rest
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect::<Vec<_>>();
+        return segments.len() >= 2
+            && is_package_name_segment(segments[0])
+            && is_package_name_segment(segments[1]);
+    }
+
+    let Some(first_segment) = alias.split('/').next() else {
+        return false;
+    };
+    is_package_name_segment(first_segment)
+}
+
+fn is_package_name_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+}
+
+fn format_string_list(values: &[String]) -> String {
+    serde_json::to_string(values).unwrap_or_else(|_| "[]".to_string())
 }
 
 fn alias_target_exists(base_dir: &Path, target: &str) -> io::Result<bool> {

--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -468,6 +468,285 @@ fn tsconfig_check_treats_paths_targets_as_fallback_candidates() {
 }
 
 #[test]
+fn tsconfig_check_reports_path_alias_shadowing_contracts() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("src/shims/react.ts"),
+        "export const reactShim = true;\n",
+    );
+    write(
+        fixture.path().join("src/vendor/pkg/index.ts"),
+        "export const pkg = true;\n",
+    );
+    write(
+        fixture.path().join("src/app/index.ts"),
+        "export const app = true;\n",
+    );
+    write(
+        fixture.path().join("src/testing/index.ts"),
+        "export const testing = true;\n",
+    );
+    write(
+        fixture.path().join("src/utils/client.ts"),
+        "export const client = true;\n",
+    );
+    write(
+        fixture.path().join("src/hash/internal.ts"),
+        "export const internal = true;\n",
+    );
+    write(
+        fixture.path().join("tsconfig.json"),
+        r##"
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "react": ["./src/shims/react.ts"],
+              "@scope/pkg/*": ["./src/vendor/pkg/*"],
+              "@app/*": ["./src/app/*"],
+              "@app/testing": ["./src/testing/index.ts"],
+              "@app/utils": ["./src/utils/client.ts"],
+              "#internal/*": ["./src/hash/*"]
+            }
+          }
+        }
+        "##,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+    let tsconfig_path = fixture.path().join("tsconfig.json");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-paths-shadow-package:{}:react",
+            tsconfig_path.to_string_lossy()
+        ),
+        Severity::Warn,
+        "Path alias \"react\" shadows a package import",
+        "\"react\" is a bare package-style specifier, so this alias can override an installed package or workspace package with the same import path.",
+        "Prefer #internal/* or another dedicated namespace for app-local aliases so package imports stay unambiguous.",
+        Some(tsconfig_path.clone()),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-paths-shadow-package:{}:@scope/pkg/*",
+            tsconfig_path.to_string_lossy()
+        ),
+        Severity::Warn,
+        "Path alias \"@scope/pkg/*\" shadows a package import",
+        "\"@scope/pkg/*\" is a bare package-style specifier, so this alias can override an installed package or workspace package with the same import path.",
+        "Prefer #internal/* or another dedicated namespace for app-local aliases so package imports stay unambiguous.",
+        Some(tsconfig_path.clone()),
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            finding.id
+                != format!(
+                    "tsconfig-paths-shadow-alias:{}:@app/testing:@app/*",
+                    tsconfig_path.to_string_lossy()
+                )
+        }),
+        "exact aliases should be allowed to specialize a broader wildcard alias"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            finding.id
+                != format!(
+                    "tsconfig-paths-shadow-alias:{}:@app/utils:@app/*",
+                    tsconfig_path.to_string_lossy()
+                )
+        }),
+        "exact aliases should be allowed to specialize a broader wildcard alias"
+    );
+    assert!(
+        outcome.findings.iter().all(|finding| {
+            finding.id
+                != format!(
+                    "tsconfig-paths-shadow-package:{}:#internal/*",
+                    tsconfig_path.to_string_lossy()
+                )
+        }),
+        "#-prefixed aliases should not be treated as package imports"
+    );
+}
+
+#[test]
+fn tsconfig_check_reports_types_and_typeroots_contracts() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("types-only/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "types": ["node", "jest"]
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("empty-types/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "types": []
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("type-roots/types/custom/index.d.ts"),
+        "export {};\n",
+    );
+    write(
+        fixture.path().join("type-roots/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "typeRoots": ["./types", "./missing-types"]
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("types-and-roots/types/node/index.d.ts"),
+        "export {};\n",
+    );
+    write(
+        fixture.path().join("types-and-roots/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "types": ["node"],
+            "typeRoots": ["./types"]
+          }
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("invalid/tsconfig.json"),
+        r#"
+        {
+          "compilerOptions": {
+            "types": "node",
+            "typeRoots": [42, ""]
+          }
+        }
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    let types_only_path = fixture.path().join("types-only/tsconfig.json");
+    assert_has_finding(
+        &outcome.findings,
+        &format!("tsconfig-types-guidance:{}", types_only_path.to_string_lossy()),
+        Severity::Info,
+        "compilerOptions.types limits ambient type packages",
+        "compilerOptions.types only includes [\"node\",\"jest\"], so unlisted ambient @types packages will not be injected automatically.",
+        "Keep this list in sync with every test and runtime package that should contribute global types.",
+        Some(types_only_path),
+    );
+
+    let empty_types_path = fixture.path().join("empty-types/tsconfig.json");
+    assert_has_finding(
+        &outcome.findings,
+        &format!("tsconfig-types-guidance:{}", empty_types_path.to_string_lossy()),
+        Severity::Warn,
+        "compilerOptions.types disables automatic @types inclusion",
+        "compilerOptions.types is set to [], so TypeScript will not auto-include any ambient @types packages.",
+        "Keep this list in sync with every test and runtime package that should contribute global types.",
+        Some(empty_types_path),
+    );
+
+    let type_roots_path = fixture.path().join("type-roots/tsconfig.json");
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-typeroots-missing:{}:./missing-types",
+            type_roots_path.to_string_lossy()
+        ),
+        Severity::Warn,
+        "Configured typeRoots entry does not exist",
+        "compilerOptions.typeRoots includes \"./missing-types\", but the resolved path was not found.",
+        "Create the missing types directory or remove stale typeRoots entries before TypeScript silently skips expected declarations.",
+        Some(type_roots_path.clone()),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-typeroots-guidance:{}",
+            type_roots_path.to_string_lossy()
+        ),
+        Severity::Warn,
+        "compilerOptions.typeRoots disables default @types discovery",
+        "compilerOptions.typeRoots only searches [\"./types\",\"./missing-types\"], so TypeScript will stop using the default node_modules/@types lookup for this config.",
+        "Include every required ambient types directory or remove typeRoots to restore default discovery.",
+        Some(type_roots_path),
+    );
+
+    let combined_path = fixture.path().join("types-and-roots/tsconfig.json");
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-types-typeroots-guidance:{}",
+            combined_path.to_string_lossy()
+        ),
+        Severity::Warn,
+        "compilerOptions.types and typeRoots both narrow ambient type resolution",
+        "compilerOptions.types only includes [\"node\"], and compilerOptions.typeRoots only searches [\"./types\"], so unlisted ambient packages outside those roots will be hidden from TypeScript.",
+        "Keep both lists aligned with every global types package your runtime and tests rely on.",
+        Some(combined_path),
+    );
+
+    let invalid_path = fixture.path().join("invalid/tsconfig.json");
+    assert_has_finding(
+        &outcome.findings,
+        &format!("tsconfig-types-shape:{}", invalid_path.to_string_lossy()),
+        Severity::Error,
+        "\"compilerOptions.types\" must be an array of package names",
+        "TypeScript expects compilerOptions.types to be an array of string package names.",
+        "Rewrite compilerOptions.types as [\"node\", \"jest\"]-style package names or remove it.",
+        Some(invalid_path.clone()),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-typeroots-entry:{}:0",
+            invalid_path.to_string_lossy()
+        ),
+        Severity::Error,
+        "\"compilerOptions.typeRoots\" contains a non-string path",
+        &format!(
+            "{} declares compilerOptions.typeRoots[0], but TypeScript expects a non-empty string directory path.",
+            invalid_path.to_string_lossy()
+        ),
+        "Rewrite compilerOptions.typeRoots as [\"./types\", \"./node_modules/@types\"]-style paths or remove it.",
+        Some(invalid_path.clone()),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-typeroots-entry:{}:1",
+            invalid_path.to_string_lossy()
+        ),
+        Severity::Error,
+        "\"compilerOptions.typeRoots\" contains a non-string path",
+        &format!(
+            "{} declares compilerOptions.typeRoots[1], but TypeScript expects a non-empty string directory path.",
+            invalid_path.to_string_lossy()
+        ),
+        "Rewrite compilerOptions.typeRoots as [\"./types\", \"./node_modules/@types\"]-style paths or remove it.",
+        Some(invalid_path),
+    );
+}
+
+#[test]
 fn tsconfig_check_reports_empty_include_and_useless_exclude_patterns() {
     let fixture = TempDir::new().expect("temp dir should exist");
 
@@ -1073,7 +1352,9 @@ fn tsconfig_check_reports_output_path_overlap_contracts() {
     );
 
     write(
-        fixture.path().join("files-with-unmatched-include/tsconfig.json"),
+        fixture
+            .path()
+            .join("files-with-unmatched-include/tsconfig.json"),
         r#"
         {
           "compilerOptions": {
@@ -1364,7 +1645,9 @@ fn tsconfig_check_inherits_pattern_fields_and_reports_invalid_pattern_entries() 
         "#,
     );
     write(
-        fixture.path().join("invalid-files-directory/src/index.d.ts"),
+        fixture
+            .path()
+            .join("invalid-files-directory/src/index.d.ts"),
         "export declare const ok: true;\n",
     );
     write(


### PR DESCRIPTION
배경
- #45에서 tsconfig Rust checker에 plan 017, 019 범위를 반영해 alias shadowing과 types/typeRoots contract를 강화하기로 했습니다.
- 이번 slice는 Rust checker와 해당 Rust 테스트만 조정하고, JS reference parity 확장은 후속으로 남겨 두었습니다.

변경 사항
- paths alias의 package-style shadowing과 alias 간 shadowing finding을 추가했습니다.
- types/typeRoots shape 검증, 누락된 typeRoots 경로 경고, ambient type resolution guidance finding을 추가했습니다.

검증
- cargo test -p maximus-checks --test tsconfig_checks
- node --test test/tsconfig-check.test.js

브랜치 / 워크트리
- branch: codex/wave1-chk-ts-1
- worktree: /tmp/maximus-wave1/chk-ts-1

이슈 연결
- Closes #45