### PR TITLE
[REG-1] 모듈/프레임워크 정합성 체크 추가

### DIFF
--- a/crates/maximus-checks/src/jsx_config.rs
+++ b/crates/maximus-checks/src/jsx_config.rs
@@ -1,0 +1,127 @@
+use std::io;
+
+use maximus_core::{make_finding, FindingInput, ProjectSnapshot, Severity};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{
+    package_file_for_directory, read_effective_compiler_options, read_package_json,
+    tsconfig_entry_file_for_directory,
+};
+
+#[derive(Clone, Copy)]
+enum FrameworkRuntime {
+    Preact,
+    Solid,
+}
+
+impl FrameworkRuntime {
+    fn dependency_name(self) -> &'static str {
+        match self {
+            FrameworkRuntime::Preact => "preact",
+            FrameworkRuntime::Solid => "solid-js",
+        }
+    }
+
+    fn jsx_import_source(self) -> &'static str {
+        self.dependency_name()
+    }
+}
+
+pub fn run_jsx_config_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for directory in &project.directories {
+        let Some(package_file) = package_file_for_directory(directory) else {
+            continue;
+        };
+        let Some(package_json) = read_package_json(&package_file.path) else {
+            continue;
+        };
+        let Some(framework_runtime) = detect_framework_runtime(&package_json) else {
+            continue;
+        };
+        let Some(tsconfig_file) = tsconfig_entry_file_for_directory(directory) else {
+            continue;
+        };
+        let Some(compiler_options) = read_effective_compiler_options(&tsconfig_file.path)? else {
+            continue;
+        };
+
+        let jsx_mode = compiler_options.get("jsx").and_then(Value::as_str);
+        if !uses_automatic_jsx_runtime(jsx_mode) {
+            continue;
+        }
+
+        let jsx_import_source = compiler_options
+            .get("jsxImportSource")
+            .and_then(Value::as_str);
+
+        if jsx_import_source == Some(framework_runtime.jsx_import_source()) {
+            continue;
+        }
+
+        let existing_import_source = jsx_import_source
+            .map(|source| format!("It currently points at {source}."))
+            .unwrap_or_else(|| "No jsxImportSource is configured yet.".to_string());
+
+        findings.push(make_finding(FindingInput {
+            id: format!("jsx-config:{}", tsconfig_file.path.to_string_lossy()),
+            title: format!(
+                "{} JSX runtime should declare jsxImportSource",
+                framework_runtime.dependency_name()
+            ),
+            category: Some("jsx-config".to_string()),
+            detail: Some(format!(
+                "package.json depends on {}, but compilerOptions.jsxImportSource is missing or different. {}",
+                framework_runtime.dependency_name(),
+                existing_import_source
+            )),
+            file: Some(tsconfig_file.path.clone()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(format!(
+                "Set compilerOptions.jsxImportSource to \"{}\" so the JSX transform matches the framework runtime.",
+                framework_runtime.jsx_import_source()
+            )),
+            severity: Some(Severity::Info),
+        }));
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn detect_framework_runtime(package_json: &Value) -> Option<FrameworkRuntime> {
+    for runtime in [FrameworkRuntime::Preact, FrameworkRuntime::Solid] {
+        if package_depends_on(package_json, runtime.dependency_name()) {
+            return Some(runtime);
+        }
+    }
+
+    None
+}
+
+fn package_depends_on(package_json: &Value, dependency_name: &str) -> bool {
+    [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ]
+    .into_iter()
+    .any(|section| {
+        package_json
+            .get(section)
+            .and_then(Value::as_object)
+            .map(|dependencies| dependencies.contains_key(dependency_name))
+            .unwrap_or(false)
+    })
+}
+
+fn uses_automatic_jsx_runtime(jsx_mode: Option<&str>) -> bool {
+    matches!(jsx_mode, Some("react-jsx") | Some("react-jsxdev"))
+}

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -4,7 +4,10 @@ mod check_outcome;
 mod config_duplicates;
 mod env;
 mod eslint_prettier;
+mod jsx_config;
 pub mod lockfiles;
+mod module_system;
+mod monorepo_tsconfig;
 pub mod package_entrypoints;
 pub mod registry;
 pub mod structure;
@@ -14,6 +17,9 @@ pub use check_outcome::CheckOutcome;
 pub use config_duplicates::run_config_duplicate_check;
 pub use env::{render_created_env_example, render_synced_env_example, run_env_check};
 pub use eslint_prettier::run_eslint_prettier_check;
+pub use jsx_config::run_jsx_config_check;
+pub use module_system::run_module_system_check;
+pub use monorepo_tsconfig::run_monorepo_tsconfig_check;
 pub use registry::{
     audit_project, audit_project_with_config, audit_project_with_config_root, registered_check_ids,
     run_registered_checks, run_registered_checks_with_config,

--- a/crates/maximus-checks/src/module_system.rs
+++ b/crates/maximus-checks/src/module_system.rs
@@ -1,0 +1,83 @@
+use std::io;
+
+use maximus_core::{make_finding, FindingInput, ProjectSnapshot, Severity};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{
+    package_file_for_directory, read_effective_compiler_options, read_package_json,
+    tsconfig_entry_file_for_directory,
+};
+
+pub fn run_module_system_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for directory in &project.directories {
+        let Some(package_file) = package_file_for_directory(directory) else {
+            continue;
+        };
+        let Some(package_json) = read_package_json(&package_file.path) else {
+            continue;
+        };
+        let Some(package_type) = package_json.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(tsconfig_file) = tsconfig_entry_file_for_directory(directory) else {
+            continue;
+        };
+        let Some(compiler_options) = read_effective_compiler_options(&tsconfig_file.path)? else {
+            continue;
+        };
+
+        let module_setting = compiler_options.get("module").and_then(Value::as_str);
+
+        if let Some((severity, title, detail, hint)) =
+            module_system_finding(package_type, module_setting)
+        {
+            findings.push(make_finding(FindingInput {
+                id: format!("module-system:{}", tsconfig_file.path.to_string_lossy()),
+                title: title.to_string(),
+                category: Some("module-system".to_string()),
+                detail: Some(detail),
+                file: Some(tsconfig_file.path.clone()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(hint.to_string()),
+                severity: Some(severity),
+            }));
+        }
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn module_system_finding(
+    package_type: &str,
+    module_setting: Option<&str>,
+) -> Option<(Severity, &'static str, String, &'static str)> {
+    match (package_type, module_setting) {
+        ("module", Some("commonjs")) | ("module", Some("amd")) | ("module", Some("umd")) => Some((
+            Severity::Error,
+            "Package ESM type conflicts with tsconfig module output",
+            format!(
+                "package.json type is \"module\", but compilerOptions.module is {:?}.",
+                module_setting.unwrap()
+            ),
+            "Use an ESM-aware module target or switch package.json type back to commonjs so the runtime and compiler agree.",
+        )),
+        ("commonjs", Some("esnext")) | ("commonjs", Some("preserve")) => Some((
+            Severity::Warn,
+            "Package CommonJS type conflicts with tsconfig module output",
+            format!(
+                "package.json type is \"commonjs\", but compilerOptions.module is {:?}.",
+                module_setting.unwrap()
+            ),
+            "Use a CommonJS module target or update package.json type to match the emitted module system.",
+        )),
+        _ => None,
+    }
+}

--- a/crates/maximus-checks/src/monorepo_tsconfig.rs
+++ b/crates/maximus-checks/src/monorepo_tsconfig.rs
@@ -1,0 +1,159 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use maximus_core::{
+    make_finding, parse_jsonc, read_text_if_exists, FindingInput, ProjectSnapshot, Severity,
+};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{package_file_for_directory, tsconfig_entry_file_for_directory};
+
+const SHARED_BASE_TSCONFIG: &str = "tsconfig.base.json";
+
+pub fn run_monorepo_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+    let root_base_path = project.root_dir.join(SHARED_BASE_TSCONFIG);
+
+    if project.package_files.len() <= 1 || !root_base_path.is_file() {
+        return Ok(CheckOutcome {
+            findings,
+            fixes: Vec::new(),
+            planned_fixes: Vec::new(),
+        });
+    }
+
+    for directory in &project.directories {
+        if directory.relative_dir == "." {
+            continue;
+        }
+
+        if package_file_for_directory(directory).is_none() {
+            continue;
+        }
+
+        let Some(tsconfig_file) = tsconfig_entry_file_for_directory(directory) else {
+            continue;
+        };
+
+        let Some(text) = read_text_if_exists(&tsconfig_file.path)? else {
+            continue;
+        };
+        let Ok(config) = parse_jsonc::<Value>(&text, &tsconfig_file.path.to_string_lossy()) else {
+            continue;
+        };
+
+        if tsconfig_extends_root_base(&tsconfig_file.path, &config, &root_base_path)? {
+            continue;
+        }
+
+        let extends_description = config
+            .get("extends")
+            .and_then(Value::as_str)
+            .map(|value| format!("It currently extends {value}."))
+            .unwrap_or_else(|| "It does not extend a shared base config.".to_string());
+
+        findings.push(make_finding(FindingInput {
+            id: format!("monorepo-tsconfig-drift:{}", tsconfig_file.path.to_string_lossy()),
+            title: "Package tsconfig drifts from the shared base".to_string(),
+            category: Some("monorepo-tsconfig".to_string()),
+            detail: Some(format!(
+                "{} package config should extend tsconfig.base.json so shared compiler settings stay aligned.",
+                extends_description
+            )),
+            file: Some(tsconfig_file.path.clone()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Point package-level tsconfig files at the repo root tsconfig.base.json before adding local overrides."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn tsconfig_extends_root_base(
+    config_path: &Path,
+    config: &Value,
+    root_base_path: &Path,
+) -> io::Result<bool> {
+    let mut visited = HashSet::new();
+    tsconfig_extends_root_base_inner(config_path, config, root_base_path, &mut visited)
+}
+
+fn tsconfig_extends_root_base_inner(
+    config_path: &Path,
+    config: &Value,
+    root_base_path: &Path,
+    visited: &mut HashSet<PathBuf>,
+) -> io::Result<bool> {
+    let Some(extends) = config.get("extends").and_then(Value::as_str) else {
+        return Ok(false);
+    };
+
+    let parent_path = resolve_tsconfig_extends_path(config_path, extends);
+    let normalized_parent_path = normalize_existing_path(&parent_path);
+    let normalized_root_base = normalize_existing_path(root_base_path);
+
+    if normalized_parent_path == normalized_root_base {
+        return Ok(true);
+    }
+
+    if !visited.insert(normalized_parent_path.clone()) {
+        return Ok(false);
+    }
+
+    let Some(text) = read_text_if_exists(&normalized_parent_path)? else {
+        return Ok(false);
+    };
+    let Ok(parent_config) = parse_jsonc::<Value>(&text, &normalized_parent_path.to_string_lossy())
+    else {
+        return Ok(false);
+    };
+
+    tsconfig_extends_root_base_inner(
+        &normalized_parent_path,
+        &parent_config,
+        &normalized_root_base,
+        visited,
+    )
+}
+
+fn resolve_tsconfig_extends_path(config_path: &Path, extends: &str) -> PathBuf {
+    let base_dir = config_path.parent().unwrap_or(config_path);
+    let candidate = Path::new(extends);
+    let resolved = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        base_dir.join(candidate)
+    };
+
+    if resolved.is_file() {
+        return resolved;
+    }
+
+    let json_candidate = resolved.with_extension("json");
+    if json_candidate.is_file() {
+        return json_candidate;
+    }
+
+    let directory_candidate = resolved.join("tsconfig.json");
+    if directory_candidate.is_file() {
+        return directory_candidate;
+    }
+
+    resolved
+}
+
+fn normalize_existing_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
+use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use maximus_core::{
     discover_project, discover_project_with_ignore_root, parse_jsonc, read_text_if_exists,
@@ -7,9 +9,13 @@ use maximus_core::{
     ConfigSeverity, MaximusConfig, PlannedFix, ProjectDirectory, ProjectFile, ProjectSnapshot,
     Severity,
 };
+use serde_json::{Map, Value};
 
 use crate::check_outcome::CheckOutcome;
+use crate::jsx_config::run_jsx_config_check;
 use crate::lockfiles::run_lockfiles_check_with_ignore_root;
+use crate::module_system::run_module_system_check;
+use crate::monorepo_tsconfig::run_monorepo_tsconfig_check;
 use crate::package_entrypoints::run_package_entrypoints_check;
 use crate::{
     build_structure_report, run_config_duplicate_check, run_env_check, run_eslint_prettier_check,
@@ -48,6 +54,18 @@ const REGISTERED_CHECKS: &[RegisteredCheck] = &[
         run: run_tsconfig_check_registered,
     },
     RegisteredCheck {
+        id: "module-system",
+        run: run_module_system_check_registered,
+    },
+    RegisteredCheck {
+        id: "monorepo-tsconfig",
+        run: run_monorepo_tsconfig_check_registered,
+    },
+    RegisteredCheck {
+        id: "jsx-config",
+        run: run_jsx_config_check_registered,
+    },
+    RegisteredCheck {
         id: "lockfiles",
         run: run_lockfiles_check_registered,
     },
@@ -63,6 +81,9 @@ pub fn registered_check_ids() -> &'static [&'static str] {
         "env",
         "eslint-prettier",
         "tsconfig",
+        "module-system",
+        "monorepo-tsconfig",
+        "jsx-config",
         "lockfiles",
         "package-entrypoints",
     ]
@@ -186,9 +207,151 @@ pub(crate) fn package_file_for_directory(directory: &ProjectDirectory) -> Option
         .find(|file| file.kind == maximus_core::FileKind::Package)
 }
 
+pub(crate) fn tsconfig_entry_file_for_directory(
+    directory: &ProjectDirectory,
+) -> Option<&ProjectFile> {
+    directory
+        .files_by_kind
+        .get(&maximus_core::FileKind::Tsconfig)
+        .and_then(|files| {
+            files
+                .iter()
+                .find(|file| file.name == "tsconfig.json" || file.name == "jsconfig.json")
+        })
+}
+
 pub(crate) fn read_package_json(file_path: &Path) -> Option<serde_json::Value> {
     let text = read_text_if_exists(file_path).ok().flatten()?;
     parse_jsonc::<serde_json::Value>(&text, &file_path.to_string_lossy()).ok()
+}
+
+pub(crate) fn read_effective_compiler_options(
+    file_path: &Path,
+) -> io::Result<Option<Map<String, Value>>> {
+    let Some(config) = read_tsconfig_json(file_path)? else {
+        return Ok(None);
+    };
+    let mut visited = HashSet::new();
+    read_effective_compiler_options_inner(file_path, &config, &mut visited)
+}
+
+fn read_effective_compiler_options_inner(
+    config_path: &Path,
+    config: &Value,
+    visited: &mut HashSet<PathBuf>,
+) -> io::Result<Option<Map<String, Value>>> {
+    let normalized_path = normalize_tsconfig_path(config_path);
+    if !visited.insert(normalized_path) {
+        return Ok(None);
+    }
+
+    let mut compiler_options = match load_extended_tsconfig_document(config_path, config, visited)?
+    {
+        Some((parent_config_path, parent_config)) => {
+            read_effective_compiler_options_inner(&parent_config_path, &parent_config, visited)?
+                .unwrap_or_default()
+        }
+        None => Map::new(),
+    };
+
+    if let Some(config_options) = config.get("compilerOptions").and_then(Value::as_object) {
+        for (key, value) in config_options {
+            compiler_options.insert(key.clone(), value.clone());
+        }
+    }
+
+    Ok(Some(compiler_options))
+}
+
+fn read_tsconfig_json(file_path: &Path) -> io::Result<Option<Value>> {
+    let Some(text) = read_text_if_exists(file_path)? else {
+        return Ok(None);
+    };
+
+    Ok(parse_jsonc::<Value>(&text, &file_path.to_string_lossy()).ok())
+}
+
+fn load_extended_tsconfig_document(
+    config_path: &Path,
+    config: &Value,
+    visited: &HashSet<PathBuf>,
+) -> io::Result<Option<(PathBuf, Value)>> {
+    let Some(extends_path) = config.get("extends").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let Some(parent_config_path) = resolve_extends_config_path(
+        config_path.parent().unwrap_or_else(|| Path::new(".")),
+        extends_path,
+    ) else {
+        return Ok(None);
+    };
+
+    if visited.contains(&normalize_tsconfig_path(&parent_config_path)) {
+        return Ok(None);
+    }
+
+    let Some(parent_config) = read_tsconfig_json(&parent_config_path)? else {
+        return Ok(None);
+    };
+
+    Ok(Some((parent_config_path, parent_config)))
+}
+
+fn resolve_extends_config_path(base_dir: &Path, extends_path: &str) -> Option<PathBuf> {
+    let extends_candidate = Path::new(extends_path);
+    let is_local_extends = extends_candidate.is_absolute()
+        || extends_path.starts_with("./")
+        || extends_path.starts_with("../")
+        || extends_path.starts_with(".\\")
+        || extends_path.starts_with("..\\");
+
+    if is_local_extends {
+        return resolve_tsconfig_candidate(&base_dir.join(extends_path.replace('\\', "/")))
+            .ok()
+            .flatten();
+    }
+
+    for ancestor in base_dir.ancestors() {
+        let candidate = ancestor.join("node_modules").join(extends_path);
+        if let Ok(Some(resolved)) = resolve_tsconfig_candidate(&candidate) {
+            return Some(resolved);
+        }
+    }
+
+    None
+}
+
+fn resolve_tsconfig_candidate(candidate: &Path) -> io::Result<Option<PathBuf>> {
+    if candidate.exists() {
+        let metadata = fs::metadata(candidate)?;
+        if metadata.is_dir() {
+            let directory_target = candidate.join("tsconfig.json");
+            if directory_target.exists() {
+                return Ok(Some(directory_target));
+            }
+            return Ok(None);
+        }
+
+        return Ok(Some(candidate.to_path_buf()));
+    }
+
+    if candidate.extension().is_none() {
+        let file_target = candidate.with_extension("json");
+        if file_target.exists() {
+            return Ok(Some(file_target));
+        }
+    }
+
+    let directory_target = candidate.join("tsconfig.json");
+    if directory_target.exists() {
+        return Ok(Some(directory_target));
+    }
+
+    Ok(None)
+}
+
+fn normalize_tsconfig_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(crate) fn has_object_key(value: &serde_json::Value, key: &str) -> bool {
@@ -235,6 +398,30 @@ fn run_tsconfig_check_registered(
     _ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
     run_tsconfig_check(project)
+}
+
+fn run_module_system_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_module_system_check(project)
+}
+
+fn run_monorepo_tsconfig_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_monorepo_tsconfig_check(project)
+}
+
+fn run_jsx_config_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_jsx_config_check(project)
 }
 
 fn run_lockfiles_check_registered(

--- a/crates/maximus-checks/tests/coherence_checks.rs
+++ b/crates/maximus-checks/tests/coherence_checks.rs
@@ -1,0 +1,408 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::{
+    run_jsx_config_check, run_module_system_check, run_monorepo_tsconfig_check,
+    run_registered_checks,
+};
+use maximus_core::{discover_project, Severity};
+use tempfile::TempDir;
+
+#[test]
+fn module_system_check_reports_module_type_conflict_and_stays_quiet_when_aligned() {
+    let conflict = TempDir::new().expect("temp dir should exist");
+
+    write(
+        conflict.path().join("package.json"),
+        r#"{ "type": "module" }"#,
+    );
+    write(
+        conflict.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "module": "commonjs" } }"#,
+    );
+
+    let project = discover_project(conflict.path()).expect("project should discover");
+    let outcome = run_module_system_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("module-system:{}", conflict.path().join("tsconfig.json").to_string_lossy()),
+        Severity::Error,
+        "Package ESM type conflicts with tsconfig module output",
+        "package.json type is \"module\", but compilerOptions.module is \"commonjs\".",
+        "Use an ESM-aware module target or switch package.json type back to commonjs so the runtime and compiler agree.",
+        Some(conflict.path().join("tsconfig.json")),
+    );
+
+    let aligned = TempDir::new().expect("temp dir should exist");
+
+    write(
+        aligned.path().join("package.json"),
+        r#"{ "type": "module" }"#,
+    );
+    write(
+        aligned.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "module": "nodenext" } }"#,
+    );
+
+    let project = discover_project(aligned.path()).expect("project should discover");
+    let outcome = run_module_system_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+
+    let commonjs_nodenext = TempDir::new().expect("temp dir should exist");
+
+    write(
+        commonjs_nodenext.path().join("package.json"),
+        r#"{ "type": "commonjs" }"#,
+    );
+    write(
+        commonjs_nodenext.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "module": "nodenext" } }"#,
+    );
+
+    let project = discover_project(commonjs_nodenext.path()).expect("project should discover");
+    let outcome = run_module_system_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn module_system_check_reads_inherited_module_setting_from_extended_tsconfig() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "type": "module" }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "module": "commonjs" } }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json" }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_module_system_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("module-system:{}", fixture.path().join("tsconfig.json").to_string_lossy()),
+        Severity::Error,
+        "Package ESM type conflicts with tsconfig module output",
+        "package.json type is \"module\", but compilerOptions.module is \"commonjs\".",
+        "Use an ESM-aware module target or switch package.json type back to commonjs so the runtime and compiler agree.",
+        Some(fixture.path().join("tsconfig.json")),
+    );
+}
+
+#[test]
+fn monorepo_tsconfig_check_reports_drift_and_accepts_shared_base_extends() {
+    let conflict = TempDir::new().expect("temp dir should exist");
+
+    write(
+        conflict.path().join("package.json"),
+        r#"{ "name": "repo", "private": true }"#,
+    );
+    write(
+        conflict.path().join("packages/app/package.json"),
+        r#"{ "name": "@repo/app" }"#,
+    );
+    write(
+        conflict.path().join("packages/lib/package.json"),
+        r#"{ "name": "@repo/lib" }"#,
+    );
+    write(
+        conflict.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "strict": true } }"#,
+    );
+    write(
+        conflict.path().join("packages/app/tsconfig.json"),
+        r#"{ "compilerOptions": { "target": "es2020" } }"#,
+    );
+
+    let project = discover_project(conflict.path()).expect("project should discover");
+    let outcome = run_monorepo_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "monorepo-tsconfig-drift:{}",
+            conflict.path().join("packages/app/tsconfig.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Package tsconfig drifts from the shared base",
+        "It does not extend a shared base config. package config should extend tsconfig.base.json so shared compiler settings stay aligned.",
+        "Point package-level tsconfig files at the repo root tsconfig.base.json before adding local overrides.",
+        Some(conflict.path().join("packages/app/tsconfig.json")),
+    );
+
+    let aligned = TempDir::new().expect("temp dir should exist");
+
+    write(
+        aligned.path().join("package.json"),
+        r#"{ "name": "repo", "private": true }"#,
+    );
+    write(
+        aligned.path().join("packages/app/package.json"),
+        r#"{ "name": "@repo/app" }"#,
+    );
+    write(
+        aligned.path().join("packages/lib/package.json"),
+        r#"{ "name": "@repo/lib" }"#,
+    );
+    write(
+        aligned.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "strict": true } }"#,
+    );
+    write(
+        aligned.path().join("packages/app/tsconfig.json"),
+        r#"{ "extends": "../../tsconfig.base.json", "compilerOptions": { "target": "es2020" } }"#,
+    );
+
+    let project = discover_project(aligned.path()).expect("project should discover");
+    let outcome = run_monorepo_tsconfig_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn monorepo_tsconfig_check_ignores_auxiliary_package_configs_without_entry_config() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "name": "repo", "private": true }"#,
+    );
+    write(
+        fixture.path().join("packages/app/package.json"),
+        r#"{ "name": "@repo/app" }"#,
+    );
+    write(
+        fixture.path().join("packages/lib/package.json"),
+        r#"{ "name": "@repo/lib" }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "strict": true } }"#,
+    );
+    write(
+        fixture.path().join("packages/app/tsconfig.base.json"),
+        r#"{ "extends": "../../tsconfig.base.json" }"#,
+    );
+    write(
+        fixture.path().join("packages/app/tsconfig.app.json"),
+        r#"{ "extends": "./tsconfig.base.json" }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_monorepo_tsconfig_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn jsx_config_check_reports_framework_hint_and_accepts_explicit_import_source() {
+    let conflict = TempDir::new().expect("temp dir should exist");
+
+    write(
+        conflict.path().join("package.json"),
+        r#"{ "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        conflict.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "jsx": "react-jsx" } }"#,
+    );
+
+    let project = discover_project(conflict.path()).expect("project should discover");
+    let outcome = run_jsx_config_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("jsx-config:{}", conflict.path().join("tsconfig.json").to_string_lossy()),
+        Severity::Info,
+        "preact JSX runtime should declare jsxImportSource",
+        "package.json depends on preact, but compilerOptions.jsxImportSource is missing or different. No jsxImportSource is configured yet.",
+        "Set compilerOptions.jsxImportSource to \"preact\" so the JSX transform matches the framework runtime.",
+        Some(conflict.path().join("tsconfig.json")),
+    );
+
+    let aligned = TempDir::new().expect("temp dir should exist");
+
+    write(
+        aligned.path().join("package.json"),
+        r#"{ "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        aligned.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" } }"#,
+    );
+
+    let project = discover_project(aligned.path()).expect("project should discover");
+    let outcome = run_jsx_config_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+
+    let classic_runtime = TempDir::new().expect("temp dir should exist");
+
+    write(
+        classic_runtime.path().join("package.json"),
+        r#"{ "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        classic_runtime.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "jsx": "preserve" } }"#,
+    );
+
+    let project = discover_project(classic_runtime.path()).expect("project should discover");
+    let outcome = run_jsx_config_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn jsx_config_check_reads_inherited_jsx_settings_from_extended_tsconfig() {
+    let conflict = TempDir::new().expect("temp dir should exist");
+
+    write(
+        conflict.path().join("package.json"),
+        r#"{ "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        conflict.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "jsx": "react-jsx" } }"#,
+    );
+    write(
+        conflict.path().join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json" }"#,
+    );
+
+    let project = discover_project(conflict.path()).expect("project should discover");
+    let outcome = run_jsx_config_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("jsx-config:{}", conflict.path().join("tsconfig.json").to_string_lossy()),
+        Severity::Info,
+        "preact JSX runtime should declare jsxImportSource",
+        "package.json depends on preact, but compilerOptions.jsxImportSource is missing or different. No jsxImportSource is configured yet.",
+        "Set compilerOptions.jsxImportSource to \"preact\" so the JSX transform matches the framework runtime.",
+        Some(conflict.path().join("tsconfig.json")),
+    );
+
+    let aligned = TempDir::new().expect("temp dir should exist");
+
+    write(
+        aligned.path().join("package.json"),
+        r#"{ "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        aligned.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" } }"#,
+    );
+    write(
+        aligned.path().join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json" }"#,
+    );
+
+    let project = discover_project(aligned.path()).expect("project should discover");
+    let outcome = run_jsx_config_check(&project).expect("check should run");
+    assert!(outcome.findings.is_empty());
+}
+
+#[test]
+fn module_and_jsx_checks_ignore_auxiliary_tsconfig_files() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "type": "commonjs", "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "module": "esnext", "jsx": "react-jsx" } }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+
+    let module_outcome = run_module_system_check(&project).expect("check should run");
+    assert!(module_outcome.findings.is_empty());
+
+    let jsx_outcome = run_jsx_config_check(&project).expect("check should run");
+    assert!(jsx_outcome.findings.is_empty());
+}
+
+#[test]
+fn registered_checks_include_new_coherence_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "name": "repo", "private": true, "type": "module", "dependencies": { "preact": "^10.0.0" } }"#,
+    );
+    write(
+        fixture.path().join("packages/app/package.json"),
+        r#"{ "name": "@repo/app" }"#,
+    );
+    write(
+        fixture.path().join("packages/lib/package.json"),
+        r#"{ "name": "@repo/lib" }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "strict": true } }"#,
+    );
+    write(
+        fixture.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "module": "commonjs", "jsx": "react-jsx" } }"#,
+    );
+    write(
+        fixture.path().join("packages/app/tsconfig.json"),
+        r#"{ "compilerOptions": { "target": "es2020" } }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_registered_checks(&project).expect("registry should run");
+    let finding_ids = outcome
+        .findings
+        .iter()
+        .map(|finding| finding.id.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(finding_ids
+        .iter()
+        .any(|id| id.starts_with("module-system:")));
+    assert!(finding_ids
+        .iter()
+        .any(|id| id.starts_with("monorepo-tsconfig-drift:")));
+    assert!(finding_ids.iter().any(|id| id.starts_with("jsx-config:")));
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    detail: &str,
+    hint: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.detail, detail);
+    assert_eq!(finding.hint, hint);
+    assert_eq!(finding.file, file);
+    assert!(!finding.fixable);
+    assert!(finding.fix_ids.is_empty());
+}


### PR DESCRIPTION
## 배경
REG-1 범위에서 모듈 시스템 일관성, 모노레포 tsconfig 드리프트, JSX 프레임워크 힌트를 Rust registry에 등록했습니다.

## 변경 사항
- module_system, monorepo_tsconfig, jsx_config checker를 추가했습니다.
- registry.rs와 lib.rs에 새 checker를 wiring 했습니다.
- severity 케이스와 quiet 케이스를 고정하는 focused integration test를 추가했습니다.

## 검증
- cargo test -p maximus-checks --test coherence_checks
- cargo test -p maximus-checks --test basic_checks

## 브랜치 / 워크트리
- branch: codex/wave2-reg-1
- worktree: /tmp/maximus-wave2/reg-1

## 이슈 연결
- Refs #62
