### PR TITLE
test: package target clean fixture를 고정한다

### DIFF
--- a/crates/maximus-checks/tests/package_entrypoints_checks.rs
+++ b/crates/maximus-checks/tests/package_entrypoints_checks.rs
@@ -6,6 +6,17 @@ use maximus_core::{discover_project, Severity};
 use tempfile::TempDir;
 
 #[test]
+fn package_entrypoints_check_keeps_the_clean_package_files_fixture_quiet() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test/fixtures/package-files/clean");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_package_entrypoints_check(&project).expect("check should run");
+
+    assert!(outcome.findings.is_empty(), "clean package fixture should stay quiet");
+}
+
+#[test]
 fn package_entrypoints_check_reports_missing_relative_targets_and_recurses_through_branches() {
     let fixture = TempDir::new().expect("temp dir should exist");
 

--- a/test/fixtures/package-files/clean/bin/cli.js
+++ b/test/fixtures/package-files/clean/bin/cli.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/test/fixtures/package-files/clean/dist/feature.js
+++ b/test/fixtures/package-files/clean/dist/feature.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/fixtures/package-files/clean/dist/index.js
+++ b/test/fixtures/package-files/clean/dist/index.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/fixtures/package-files/clean/dist/module.js
+++ b/test/fixtures/package-files/clean/dist/module.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/fixtures/package-files/clean/dist/types.d.ts
+++ b/test/fixtures/package-files/clean/dist/types.d.ts
@@ -1,0 +1,1 @@
+export type CleanPackage = string;

--- a/test/fixtures/package-files/clean/package.json
+++ b/test/fixtures/package-files/clean/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "package-files-clean",
+  "private": true,
+  "main": "./dist/index.js",
+  "module": "./dist/module.js",
+  "types": "./dist/types.d.ts",
+  "bin": {
+    "maximus": "./bin/cli.js"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./feature": "./dist/feature.js"
+  }
+}


### PR DESCRIPTION
## Summary
- package target 존재성 hardening의 첫 패스로 clean fixture 회귀 테스트를 추가합니다.
- clean package fixture가 `package_entrypoints` checker에서 quiet 해야 한다는 계약을 고정합니다.
- source 로직 변경 없이 fixture와 test surface만 보강합니다.

## Validation
- `cargo test -p maximus-checks --test package_entrypoints_checks`
- `cargo test -p maximus-checks --test package_entrypoints_registry`

Refs #63
