### PR TITLE
fix(ci): release bump 안전장치 추가

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -66,14 +66,17 @@ jobs:
 
       - name: Assert checked out release target
         shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [[ -n "${{ inputs.release_sha }}" ]]; then
-            test "$(git rev-parse HEAD)" = "${{ inputs.release_sha }}"
-            git fetch --depth=1 origin "refs/tags/${{ inputs.release_tag }}:refs/tags/${{ inputs.release_tag }}"
-            test "$(git rev-list -n 1 "${{ inputs.release_tag }}")" = "${{ inputs.release_sha }}"
+          if [[ -n "$RELEASE_SHA" ]]; then
+            test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+            git fetch --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            test "$(git rev-list -n 1 "$RELEASE_TAG")" = "$RELEASE_SHA"
           else
             checked_ref="$(git describe --tags --exact-match HEAD)"
-            test "$checked_ref" = "${{ inputs.release_tag }}"
+            test "$checked_ref" = "$RELEASE_TAG"
           fi
 
       # GitHub Actions does not allow dynamic expressions in step-level `uses:`.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,6 +16,8 @@ on:
       - ".github/actions/marketplace-wrapper/action.yml"
       - ".github/workflows/action-smoke.yml"
       - ".github/workflows/dev.yml"
+      - ".github/workflows/manual-release-bump.yml"
+      - ".github/workflows/release-candidate.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/release-drafter.yml"
       - ".github/workflows/rust-release-binaries.yml"
@@ -42,6 +44,8 @@ on:
       - ".github/actions/marketplace-wrapper/action.yml"
       - ".github/workflows/action-smoke.yml"
       - ".github/workflows/dev.yml"
+      - ".github/workflows/manual-release-bump.yml"
+      - ".github/workflows/release-candidate.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/release-drafter.yml"
       - ".github/workflows/rust-release-binaries.yml"
@@ -221,4 +225,4 @@ jobs:
         run: node ./scripts/validate-rust-release-wiring.mjs
 
       - name: Run focused release wiring test
-        run: node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/npm-error-classifiers.test.js
+        run: node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/release-candidate-metadata.test.js test/release-helpers.test.js test/npm-error-classifiers.test.js test/bump-release-version.test.js

--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -1,0 +1,317 @@
+name: Manual Release Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Target release tag or version, for example v0.1.1 or 0.1.1-alpha.2
+        required: true
+        type: string
+      dry_run:
+        description: Validate and prepare the bump without pushing a branch or opening a PR
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: manual-release-bump-master-${{ startsWith(inputs.tag, 'v') && inputs.tag || format('v{0}', inputs.tag) }}
+  cancel-in-progress: false
+
+jobs:
+  bump_release_version:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Resolve bump metadata
+        id: meta
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          tag="$INPUT_TAG"
+          if [[ "$tag" != v* ]]; then
+            tag="v$tag"
+          fi
+
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "tag must look like v1.2.3 or v1.2.3-alpha.1"
+            exit 1
+          fi
+
+          current_version=$(node -p "require('./package.json').version")
+          expected_version="${tag#v}"
+          branch=$(node --input-type=module -e "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1]));" "$tag")
+
+          {
+            echo "currentVersion=$current_version"
+            echo "version=$expected_version"
+            echo "tag=$tag"
+            echo "branch=$branch"
+            echo "title=chore: ${expected_version} 수동 bump"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply version bump
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: node ./scripts/bump-release-version.mjs "$RELEASE_TAG"
+
+      - name: Verify changed files before package verification
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { packageManifestPaths } from "./scripts/bump-release-version.mjs";
+
+          const changedFiles = execFileSync("git", ["diff", "--name-only"], { encoding: "utf8" })
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .sort();
+          const expectedFiles = [...packageManifestPaths].sort();
+
+          if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
+            throw new Error(`Unexpected changed files: ${changedFiles.join(", ")}`);
+          }
+          NODE
+
+      - name: Verify package
+        run: npm test
+
+      - name: Verify changed files after package verification
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { packageManifestPaths } from "./scripts/bump-release-version.mjs";
+
+          const changedFiles = execFileSync("git", ["diff", "--name-only"], { encoding: "utf8" })
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .sort();
+          const expectedFiles = [...packageManifestPaths].sort();
+
+          if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
+            throw new Error(`Unexpected changed files after verification: ${changedFiles.join(", ")}`);
+          }
+          NODE
+
+      - name: Stop after dry run
+        if: ${{ inputs.dry_run }}
+        run: echo "Dry run requested; skipping branch push and PR creation."
+
+      - name: Configure git author
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure skip-changelog label exists
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          if gh label list --search "skip-changelog" --json name --jq 'map(select(.name == "skip-changelog")) | length > 0' | grep -q true; then
+            exit 0
+          fi
+
+          gh label create "skip-changelog" \
+            --color "6E7781" \
+            --description "Exclude automated release prep PRs from release notes."
+
+      - name: Resolve existing open PR
+        if: ${{ !inputs.dry_run }}
+        id: existing_pr
+        shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          EXPECTED_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          pr_json=$(gh pr list \
+            --head "$BUMP_BRANCH" \
+            --state open \
+            --json number,url,baseRefName,labels)
+
+          pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty')
+          pr_url=$(printf '%s' "$pr_json" | jq -r '.[0].url // empty')
+          pr_base=$(printf '%s' "$pr_json" | jq -r '.[0].baseRefName // empty')
+          has_skip_changelog=$(printf '%s' "$pr_json" | jq -r 'if (.[0].labels // []) | map(.name) | index("skip-changelog") then "true" else "false" end')
+
+          if [ -n "$pr_number" ] && [ "$pr_base" != "master" ]; then
+            echo "Existing PR $pr_url targets base '$pr_base', expected 'master'."
+            exit 1
+          fi
+
+          if [ -n "$pr_number" ]; then
+            git fetch origin \
+              "refs/heads/master:refs/remotes/origin/master" \
+              "refs/heads/${BUMP_BRANCH}:refs/remotes/origin/${BUMP_BRANCH}"
+
+            # shellcheck disable=SC2016
+            node --input-type=module -e '
+              import { execFileSync } from "node:child_process";
+              import { packageManifestPaths } from "./scripts/bump-release-version.mjs";
+
+              const branch = process.argv[1];
+              const expectedVersion = process.argv[2];
+              const diffFiles = execFileSync(
+                "git",
+                ["diff", "--name-only", `refs/remotes/origin/master...refs/remotes/origin/${branch}`],
+                { encoding: "utf8" },
+              )
+                .trim()
+                .split("\n")
+                .filter(Boolean)
+                .sort();
+              const expectedFiles = [...packageManifestPaths].sort();
+
+              if (JSON.stringify(diffFiles) !== JSON.stringify(expectedFiles)) {
+                throw new Error(`Existing PR is not a manifest-only bump: ${diffFiles.join(", ")}`);
+              }
+
+              for (const relativePath of packageManifestPaths) {
+                const manifest = JSON.parse(
+                  execFileSync("git", ["show", `refs/remotes/origin/${branch}:${relativePath}`], {
+                    encoding: "utf8",
+                  }),
+                );
+
+                if (manifest.version !== expectedVersion) {
+                  throw new Error(`${relativePath} version mismatch: ${manifest.version}`);
+                }
+              }
+            ' "$BUMP_BRANCH" "$EXPECTED_VERSION"
+          fi
+
+          if [ -n "$pr_number" ] && [ "$has_skip_changelog" != "true" ]; then
+            gh pr edit "$pr_number" --add-label skip-changelog
+          fi
+
+          {
+            echo "number=$pr_number"
+            echo "url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare bump branch
+        if: ${{ !inputs.dry_run && steps.existing_pr.outputs.number == '' }}
+        shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          BUMP_TITLE: ${{ steps.meta.outputs.title }}
+        run: |
+          lease_args=()
+
+          if git ls-remote --exit-code --heads origin "$BUMP_BRANCH" >/dev/null 2>&1; then
+            echo "Remote branch $BUMP_BRANCH already exists; refreshing it with the verified bump commit."
+            git fetch origin "refs/heads/${BUMP_BRANCH}:refs/remotes/origin/${BUMP_BRANCH}"
+            lease_args+=(--force-with-lease="refs/heads/${BUMP_BRANCH}:$(git rev-parse "refs/remotes/origin/${BUMP_BRANCH}")")
+          fi
+
+          git switch -C "$BUMP_BRANCH"
+          git add package.json npm/*/package.json
+          git commit -m "$BUMP_TITLE"
+          git push "${lease_args[@]}" -u origin "$BUMP_BRANCH"
+
+      - name: Dispatch CI for bump branch
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+        run: gh workflow run dev.yml --ref "$BUMP_BRANCH"
+
+      - name: Create or reuse draft PR
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          BUMP_TITLE: ${{ steps.meta.outputs.title }}
+          CURRENT_VERSION: ${{ steps.meta.outputs.currentVersion }}
+          DEFAULT_GH_TOKEN: ${{ github.token }}
+          EXISTING_PR_URL: ${{ steps.existing_pr.outputs.url }}
+          PR_CREATE_TOKEN: ${{ secrets.MAXIMUS_RELEASE_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          printf '%s\n' \
+            "## 배경 / Background" \
+            "" \
+            "- manual release bump workflow로 \`${CURRENT_VERSION}\`에서 \`${RELEASE_VERSION}\`으로 승격합니다." \
+            "- 실제 tag / publish는 이 PR merge 이후 별도 \`release.yml\` workflow에서 진행합니다." \
+            "" \
+            "## 변경 사항 / Changes" \
+            "" \
+            "- root wrapper와 platform package manifest version을 \`${RELEASE_VERSION}\`으로 맞췄습니다." \
+            "- root optionalDependencies도 같은 버전으로 정렬했습니다." \
+            "" \
+            "## 검증 / Verification" \
+            "" \
+            "- \`node ./scripts/bump-release-version.mjs ${RELEASE_TAG}\`" \
+            "- \`npm test\`" \
+            "- bump branch에 대해 \`maximus-dev\` workflow를 dispatch했습니다." \
+            "" \
+            "## 리스크 / Risks" \
+            "" \
+            "- 실제 tag / publish는 아직 실행하지 않았습니다." \
+            "- merge 후 \`Release Candidate Core Verification\` 과 같은 commit의 \`maximus-dev\` workflow 결과를 확인한 뒤 tag를 생성해야 합니다." \
+            > pr-body.md
+
+          if [ -n "$PR_CREATE_TOKEN" ]; then
+            export GH_TOKEN="$PR_CREATE_TOKEN"
+            token_source="MAXIMUS_RELEASE_BOT_TOKEN"
+          else
+            export GH_TOKEN="$DEFAULT_GH_TOKEN"
+            token_source="github.token"
+          fi
+
+          if [ -n "$EXISTING_PR_URL" ]; then
+            echo "Reusing existing PR: $EXISTING_PR_URL"
+            exit 0
+          fi
+
+          if pr_url=$(gh pr create \
+            --draft \
+            --base master \
+            --head "$BUMP_BRANCH" \
+            --title "$BUMP_TITLE" \
+            --body-file pr-body.md \
+            --label skip-changelog 2>/tmp/maximus-gh-pr-create-error.txt); then
+            echo "Created draft PR: $pr_url"
+            exit 0
+          fi
+
+          compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/master...${BUMP_BRANCH}?expand=1"
+
+          {
+            echo "### Manual release bump failed to create a PR"
+            echo
+            echo "The bump branch was pushed, but the workflow could not open a draft PR."
+            echo
+            echo "- branch: \`${BUMP_BRANCH}\`"
+            echo "- title: \`${BUMP_TITLE}\`"
+            echo "- token source: \`$token_source\`"
+            echo "- compare URL: $compare_url"
+            echo
+            echo "Either enable repository Actions permission to create pull requests, or configure \`MAXIMUS_RELEASE_BOT_TOKEN\` with pull request creation permission."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          cat /tmp/maximus-gh-pr-create-error.txt
+          echo "::error::Unable to create a draft PR for $BUMP_BRANCH. See the step summary for required repository or token changes."
+          exit 1

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,166 @@
+name: Release Candidate Core Verification
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+      - npm/**/package.json
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Commit SHA to verify as a release candidate
+        required: true
+        type: string
+
+concurrency:
+  group: release-candidate-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify_release_candidate:
+    name: Verify Release Candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NPM_CONFIG_CACHE: .npm-cache
+
+    steps:
+      - name: Validate manual target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          if ! [[ "$TARGET_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "target_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+      - name: Checkout pinned release candidate commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Confirm checked out commit matches target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          checked_out_sha=$(git rev-parse HEAD)
+          if [ "$checked_out_sha" != "$TARGET_SHA" ]; then
+            echo "Expected checkout to resolve to $TARGET_SHA, got $checked_out_sha"
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Resolve release candidate metadata
+        id: meta
+        env:
+          RELEASE_EVENT_BEFORE: ${{ github.event.before }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: node ./scripts/release-candidate-metadata.mjs
+
+      - name: Ensure release tag does not already exist
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            echo "Release tag $RELEASE_TAG already exists."
+            exit 1
+          fi
+
+      - name: Verify package manifest alignment
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import { packageManifestPaths } from "./scripts/bump-release-version.mjs";
+
+          const rootManifest = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const versionMismatches = [];
+
+          for (const relativePath of packageManifestPaths) {
+            const manifest = JSON.parse(fs.readFileSync(relativePath, "utf8"));
+            if (manifest.version !== rootManifest.version) {
+              versionMismatches.push(`${relativePath}:${manifest.version}`);
+            }
+          }
+
+          const optionalDependencyMismatches = Object.entries(rootManifest.optionalDependencies ?? {})
+            .filter(([, version]) => version !== rootManifest.version)
+            .map(([name, version]) => `${name}@${version}`);
+
+          if (versionMismatches.length > 0 || optionalDependencyMismatches.length > 0) {
+            throw new Error(
+              [
+                versionMismatches.length > 0
+                  ? `Manifest version mismatches: ${versionMismatches.join(", ")}`
+                  : "",
+                optionalDependencyMismatches.length > 0
+                  ? `optionalDependencies mismatches: ${optionalDependencyMismatches.join(", ")}`
+                  : "",
+              ]
+                .filter(Boolean)
+                .join(" | "),
+            );
+          }
+          NODE
+
+      - name: Validate release wiring contract
+        run: node ./scripts/validate-rust-release-wiring.mjs
+
+      - name: Run focused release wiring tests
+        run: node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/release-candidate-metadata.test.js test/release-helpers.test.js test/npm-error-classifiers.test.js test/bump-release-version.test.js
+
+      - name: Run node test suite
+        run: npm test
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Run Rust workspace tests
+        run: cargo test --workspace
+
+      - name: Pack root wrapper
+        shell: bash
+        run: |
+          pack_root="$RUNNER_TEMP/maximus-release-candidate-pack"
+          rm -rf "$pack_root"
+          mkdir -p "$pack_root"
+          env npm_config_cache="$pack_root/.npm-cache" npm pack --json --pack-destination "$pack_root" > "$pack_root/pack.json"
+
+      - name: Smoke packed wrapper
+        run: node ./scripts/run-packed-wrapper-smoke.mjs "$RUNNER_TEMP/maximus-release-candidate-pack/pack.json" ./test/fixtures/clean-project
+
+      - name: Publish release candidate summary
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          VERIFIED_SHA: ${{ steps.meta.outputs.verifiedSha }}
+          VERIFY_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.ref_name }}
+        run: |
+          {
+            echo "### Release candidate core checks passed"
+            echo
+            echo "- ref: \`${VERIFY_REF}\`"
+            echo "- verified commit: \`${VERIFIED_SHA}\`"
+            echo "- version: \`${RELEASE_VERSION}\`"
+            echo "- next tag: \`${RELEASE_TAG}\`"
+            echo
+            echo "Before creating the real tag, also confirm the same commit is green in the \`maximus-dev\` workflow."
+            echo "Create the release tag only after maintainer confirmation and only from \`${VERIFIED_SHA}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import { realpathSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertReleaseUpgrade, resolveReleasePlan } from "./lib/release.mjs";
+
+export const packageManifestPaths = [
+  "package.json",
+  "npm/maximus-darwin-arm64/package.json",
+  "npm/maximus-darwin-x64/package.json",
+  "npm/maximus-linux-arm64-gnu/package.json",
+  "npm/maximus-linux-x64-gnu/package.json",
+];
+
+export function normalizeReleaseTag(input) {
+  return input.startsWith("v") ? input : `v${input}`;
+}
+
+export function createManualBumpBranchName(input, baseRef = "master") {
+  const normalizedTag = normalizeReleaseTag(input);
+  const branchBase = baseRef
+    .replace(/[./+]/g, "-")
+    .replace(/[^0-9A-Za-z-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const branchVersion = normalizedTag
+    .slice(1)
+    .replace(/[.+]/g, "-")
+    .replace(/[^0-9A-Za-z-]/g, "-");
+  const branchHash = crypto
+    .createHash("sha256")
+    .update(`${baseRef}\0${normalizedTag}`)
+    .digest("hex")
+    .slice(0, 8);
+
+  return `codex/manual-bump-${branchBase}-v${branchVersion}-${branchHash}`;
+}
+
+export function updatePackageManifest(pkg, version) {
+  const nextPkg = {
+    ...pkg,
+    version,
+  };
+
+  if (pkg.optionalDependencies && typeof pkg.optionalDependencies === "object") {
+    nextPkg.optionalDependencies = Object.fromEntries(
+      Object.entries(pkg.optionalDependencies).map(([name]) => [name, version]),
+    );
+  }
+
+  return nextPkg;
+}
+
+export async function bumpPackageVersion(input, repoRoot = process.cwd()) {
+  const normalizedTag = normalizeReleaseTag(input);
+  const plan = resolveReleasePlan(normalizedTag);
+  const rootManifestPath = path.join(repoRoot, "package.json");
+  const rootManifest = JSON.parse(await fs.readFile(rootManifestPath, "utf8"));
+  assertReleaseUpgrade(rootManifest.version, plan.version);
+
+  const updatedManifestPaths = [];
+  for (const relativePath of packageManifestPaths) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    const manifest = JSON.parse(await fs.readFile(absolutePath, "utf8"));
+    const nextManifest = updatePackageManifest(manifest, plan.version);
+    await fs.writeFile(absolutePath, `${JSON.stringify(nextManifest, null, 2)}\n`);
+    updatedManifestPaths.push(absolutePath);
+  }
+
+  return {
+    version: plan.version,
+    tag: plan.tag,
+    isPrerelease: plan.isPrerelease,
+    manifestPaths: updatedManifestPaths,
+  };
+}
+
+async function main() {
+  const input = process.argv[2];
+  const repoRoot = process.argv[3] ?? process.cwd();
+
+  if (!input) {
+    console.error("Usage: node ./scripts/bump-release-version.mjs <tag-or-version> [repo-root]");
+    process.exit(1);
+  }
+
+  const result = await bumpPackageVersion(input, repoRoot);
+  console.log(`tag=${result.tag}`);
+  console.log(`version=${result.version}`);
+  console.log(`isPrerelease=${result.isPrerelease}`);
+  console.log(`manifestCount=${result.manifestPaths.length}`);
+}
+
+function isDirectExecutionEntry() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url))
+      === realpathSync(path.resolve(process.argv[1]))
+    );
+  } catch {
+    return false;
+  }
+}
+
+const isDirectExecution = isDirectExecutionEntry();
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/lib/release.mjs
+++ b/scripts/lib/release.mjs
@@ -1,0 +1,112 @@
+const NUMERIC_IDENTIFIER_PATTERN = "(?:0|[1-9][0-9]*)";
+const PRERELEASE_IDENTIFIER_PATTERN =
+  "(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";
+const PRERELEASE_PATTERN = `(?:-${PRERELEASE_IDENTIFIER_PATTERN}(?:\\.${PRERELEASE_IDENTIFIER_PATTERN})*)?`;
+const RELEASE_TAG_PATTERN = new RegExp(
+  `^v${NUMERIC_IDENTIFIER_PATTERN}\\.${NUMERIC_IDENTIFIER_PATTERN}\\.${NUMERIC_IDENTIFIER_PATTERN}${PRERELEASE_PATTERN}$`,
+);
+const RELEASE_VERSION_PATTERN = new RegExp(
+  `^(?<major>${NUMERIC_IDENTIFIER_PATTERN})\\.(?<minor>${NUMERIC_IDENTIFIER_PATTERN})\\.(?<patch>${NUMERIC_IDENTIFIER_PATTERN})(?:-(?<prerelease>${PRERELEASE_IDENTIFIER_PATTERN}(?:\\.${PRERELEASE_IDENTIFIER_PATTERN})*))?$`,
+);
+
+export function resolveReleasePlan(tag) {
+  if (!RELEASE_TAG_PATTERN.test(tag)) {
+    throw new Error("Tag must look like v1.2.3 or v1.2.3-beta.1");
+  }
+
+  const version = tag.slice(1);
+  const isPrerelease = version.includes("-");
+
+  return {
+    tag,
+    version,
+    isPrerelease,
+    npmDistTag: isPrerelease ? "next" : "latest",
+  };
+}
+
+function parseReleaseVersion(version) {
+  const match = RELEASE_VERSION_PATTERN.exec(version);
+
+  if (!match?.groups) {
+    throw new Error(`Version must look like 1.2.3 or 1.2.3-beta.1: ${version}`);
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease ? match.groups.prerelease.split(".") : [],
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftIsNumeric = /^[0-9]+$/.test(left);
+  const rightIsNumeric = /^[0-9]+$/.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return Number(left) === Number(right) ? 0 : Number(left) < Number(right) ? -1 : 1;
+  }
+
+  if (leftIsNumeric !== rightIsNumeric) {
+    return leftIsNumeric ? -1 : 1;
+  }
+
+  if (left === right) {
+    return 0;
+  }
+
+  return left < right ? -1 : 1;
+}
+
+export function compareReleaseVersions(leftVersion, rightVersion) {
+  const left = parseReleaseVersion(leftVersion);
+  const right = parseReleaseVersion(rightVersion);
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) {
+      return left[key] < right[key] ? -1 : 1;
+    }
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const comparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+export function assertReleaseUpgrade(currentVersion, nextVersion) {
+  if (compareReleaseVersions(currentVersion, nextVersion) >= 0) {
+    throw new Error(
+      `Target version ${nextVersion} must be greater than current version ${currentVersion}`,
+    );
+  }
+}

--- a/scripts/release-candidate-metadata.mjs
+++ b/scripts/release-candidate-metadata.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertReleaseUpgrade, resolveReleasePlan } from "./lib/release.mjs";
+
+const fullShaPattern = /^[0-9A-Fa-f]{40}$/;
+
+function git(repoRoot, args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: options.quiet ? ["ignore", "pipe", "ignore"] : ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function gitSucceeds(repoRoot, args) {
+  try {
+    git(repoRoot, args, { quiet: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readCurrentPackageVersion(repoRoot) {
+  const packageJson = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  return packageJson.version;
+}
+
+function readPackageVersionAt(repoRoot, ref) {
+  const packageJson = git(repoRoot, ["show", `${ref}:package.json`]);
+  return JSON.parse(packageJson).version;
+}
+
+function resolvePushPreviousVersion(repoRoot, beforeSha) {
+  if (!fullShaPattern.test(beforeSha ?? "")) {
+    throw new Error("github.event.before must be a full 40-character commit SHA.");
+  }
+
+  if (!gitSucceeds(repoRoot, ["cat-file", "-e", `${beforeSha}:package.json`])) {
+    throw new Error("github.event.before must contain package.json for release upgrade validation.");
+  }
+
+  return readPackageVersionAt(repoRoot, beforeSha);
+}
+
+function resolveManualPreviousVersion(repoRoot, targetSha, verifiedSha, fetchMaster) {
+  if (!fullShaPattern.test(targetSha ?? "")) {
+    throw new Error("target_sha must be a full 40-character commit SHA.");
+  }
+
+  if (verifiedSha !== targetSha) {
+    throw new Error(`Expected checkout to resolve to ${targetSha}, got ${verifiedSha}`);
+  }
+
+  if (fetchMaster) {
+    git(repoRoot, ["fetch", "origin", "refs/heads/master:refs/remotes/origin/master"]);
+  }
+
+  if (!gitSucceeds(repoRoot, ["merge-base", "--is-ancestor", verifiedSha, "refs/remotes/origin/master"])) {
+    throw new Error("target_sha must already be reachable from origin/master before tagging.");
+  }
+
+  const parentSha = git(repoRoot, ["rev-parse", `${verifiedSha}^`]);
+  if (!gitSucceeds(repoRoot, ["cat-file", "-e", `${parentSha}:package.json`])) {
+    throw new Error("target_sha parent must contain package.json.");
+  }
+
+  return readPackageVersionAt(repoRoot, parentSha);
+}
+
+export async function resolveReleaseCandidateMetadata({
+  repoRoot = process.cwd(),
+  eventName,
+  beforeSha = "",
+  targetSha = "",
+  fetchMaster = true,
+} = {}) {
+  const version = await readCurrentPackageVersion(repoRoot);
+  const plan = resolveReleasePlan(`v${version}`);
+  const verifiedSha = git(repoRoot, ["rev-parse", "HEAD"]);
+  let previousVersion = "";
+
+  if (eventName === "push") {
+    previousVersion = resolvePushPreviousVersion(repoRoot, beforeSha);
+  } else if (eventName === "workflow_dispatch") {
+    previousVersion = resolveManualPreviousVersion(repoRoot, targetSha, verifiedSha, fetchMaster);
+  } else {
+    throw new Error(`Unsupported release candidate event: ${eventName}`);
+  }
+
+  if (previousVersion) {
+    assertReleaseUpgrade(previousVersion, plan.version);
+  }
+
+  return {
+    version: plan.version,
+    tag: plan.tag,
+    previousVersion,
+    verifiedSha,
+  };
+}
+
+async function writeGithubOutputs(metadata) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    [
+      `version=${metadata.version}`,
+      `tag=${metadata.tag}`,
+      `previousVersion=${metadata.previousVersion}`,
+      `verifiedSha=${metadata.verifiedSha}`,
+    ].join("\n") + "\n",
+    "utf8",
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  try {
+    const metadata = await resolveReleaseCandidateMetadata({
+      eventName: process.env.RELEASE_EVENT_NAME ?? process.env.GITHUB_EVENT_NAME,
+      beforeSha: process.env.RELEASE_EVENT_BEFORE ?? process.env.GITHUB_EVENT_BEFORE,
+      targetSha: process.env.TARGET_SHA,
+    });
+    await writeGithubOutputs(metadata);
+    console.log(
+      `Resolved release candidate ${metadata.tag} at ${metadata.verifiedSha} (previous: ${metadata.previousVersion || "unknown"}).`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendFile } from "node:fs/promises";
 import { assertReleaseWorkflowContext } from "./assert-release-workflow-context.mjs";
+import { resolveReleasePlan } from "./lib/release.mjs";
 
 export async function buildReleasePlan({
   repoRoot = process.cwd(),
@@ -17,14 +18,12 @@ export async function buildReleasePlan({
     githubRefName,
     requestedReleaseTag,
   });
-
-  const isPrerelease = context.packageVersion.includes("-");
-  const distTag = isPrerelease ? "next" : "latest";
+  const plan = resolveReleasePlan(context.releaseTag);
 
   return {
     ...context,
-    distTag,
-    isPrerelease,
+    distTag: plan.npmDistTag,
+    isPrerelease: plan.isPrerelease,
   };
 }
 

--- a/scripts/validate-rust-release-wiring.mjs
+++ b/scripts/validate-rust-release-wiring.mjs
@@ -18,6 +18,8 @@ const requiredFiles = {
   devWorkflow: ".github/workflows/dev.yml",
   actionSmokeWorkflow: ".github/workflows/action-smoke.yml",
   releaseWorkflow: ".github/workflows/release.yml",
+  releaseCandidateWorkflow: ".github/workflows/release-candidate.yml",
+  manualReleaseBumpWorkflow: ".github/workflows/manual-release-bump.yml",
   rustReleaseWorkflow: ".github/workflows/rust-release-binaries.yml",
   releaseDrafterWorkflow: ".github/workflows/release-drafter.yml",
   releaseDrafterConfig: ".github/release-drafter.yml",
@@ -28,6 +30,9 @@ const requiredFiles = {
   releaseRunbook: "docs/release-operator-runbook.md",
   releaseContextAssertion: "scripts/assert-release-workflow-context.mjs",
   releasePlan: "scripts/release-plan.mjs",
+  releaseCandidateMetadata: "scripts/release-candidate-metadata.mjs",
+  releaseHelpers: "scripts/lib/release.mjs",
+  releaseBumpScript: "scripts/bump-release-version.mjs",
   npmLookupClassifier: "scripts/classify-npm-lookup-error.mjs",
   npmPublishClassifier: "scripts/classify-npm-publish-error.mjs",
   nativeRuntimeAssertion: "scripts/assert-installed-native-runtime.mjs",
@@ -40,6 +45,8 @@ export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
   validateMarketplaceWrapperAction(fileContents.marketplaceWrapperAction);
   validateDevWorkflow(fileContents.devWorkflow);
   validateActionSmokeWorkflow(fileContents.actionSmokeWorkflow);
+  validateReleaseCandidateWorkflow(fileContents.releaseCandidateWorkflow);
+  validateManualReleaseBumpWorkflow(fileContents.manualReleaseBumpWorkflow);
   validateRustReleaseWorkflow(fileContents.rustReleaseWorkflow);
   validateReleaseWorkflow(fileContents.releaseWorkflow);
   validateReleaseDrafterWorkflow(fileContents.releaseDrafterWorkflow);
@@ -50,6 +57,9 @@ export async function validateRustReleaseWiring(repoRoot = process.cwd()) {
   validateReleaseRunbook(fileContents.releaseRunbook);
   validateReleaseContextAssertion(fileContents.releaseContextAssertion);
   validateReleasePlanScript(fileContents.releasePlan);
+  validateReleaseCandidateMetadata(fileContents.releaseCandidateMetadata);
+  validateReleaseHelpers(fileContents.releaseHelpers);
+  validateReleaseBumpScript(fileContents.releaseBumpScript);
   validateNpmLookupClassifier(fileContents.npmLookupClassifier);
   validateNpmPublishClassifier(fileContents.npmPublishClassifier);
   validateNativeRuntimeAssertion(fileContents.nativeRuntimeAssertion);
@@ -97,6 +107,8 @@ function validateDevWorkflow(devText) {
     "action.yml",
     ".github/actions/marketplace-wrapper/action.yml",
     ".github/workflows/action-smoke.yml",
+    ".github/workflows/manual-release-bump.yml",
+    ".github/workflows/release-candidate.yml",
     ".github/workflows/release.yml",
     ".github/workflows/rust-release-binaries.yml",
     "docs/github-action-marketplace.md",
@@ -111,7 +123,7 @@ function validateDevWorkflow(devText) {
 
   assertContains(devText, "release-wiring:", "release wiring job");
   assertContains(devText, "node ./scripts/validate-rust-release-wiring.mjs", "release wiring validation command");
-  assertContains(devText, "node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/npm-error-classifiers.test.js", "release wiring node test command");
+  assertContains(devText, "node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/release-candidate-metadata.test.js test/release-helpers.test.js test/npm-error-classifiers.test.js test/bump-release-version.test.js", "release wiring node test command");
 }
 
 function validateMarketplaceWrapperAction(actionText) {
@@ -130,14 +142,24 @@ function validateActionSmokeWorkflow(actionSmokeText) {
   assertContains(actionSmokeText, "release_tag:", "action smoke release tag input");
   assertContains(actionSmokeText, "release_sha:", "action smoke release sha input");
   assertContains(actionSmokeText, "ref: ${{ inputs.release_sha || inputs.release_tag }}", "action smoke checkout ref");
-  assertContains(actionSmokeText, 'test "$(git rev-parse HEAD)" = "${{ inputs.release_sha }}"', "action smoke sha comparison");
-  assertContains(actionSmokeText, 'git fetch --depth=1 origin "refs/tags/${{ inputs.release_tag }}:refs/tags/${{ inputs.release_tag }}"', "action smoke tag fetch");
-  assertContains(actionSmokeText, 'test "$(git rev-list -n 1 "${{ inputs.release_tag }}")" = "${{ inputs.release_sha }}"', "action smoke tag to sha comparison");
+  assertContains(actionSmokeText, "RELEASE_SHA: ${{ inputs.release_sha }}", "action smoke release sha env handoff");
+  assertContains(actionSmokeText, "RELEASE_TAG: ${{ inputs.release_tag }}", "action smoke release tag env handoff");
+  assertContains(actionSmokeText, 'test "$(git rev-parse HEAD)" = "$RELEASE_SHA"', "action smoke sha comparison");
+  assertContains(actionSmokeText, 'git fetch --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"', "action smoke tag fetch");
+  assertContains(actionSmokeText, 'test "$(git rev-list -n 1 "$RELEASE_TAG")" = "$RELEASE_SHA"', "action smoke tag to sha comparison");
   assertContains(actionSmokeText, 'git describe --tags --exact-match HEAD', "action smoke exact tag assertion");
   assertContains(actionSmokeText, "uses: ./", "action smoke local tag checkout usage");
   assertContains(actionSmokeText, "uses: ./.github/actions/marketplace-wrapper", "action smoke marketplace wrapper usage");
   assertContains(actionSmokeText, "dynamic expressions in step-level `uses:`", "action smoke dynamic uses rationale");
   assertContains(actionSmokeText, "registry-url: ${{ inputs.registry_url }}", "action smoke registry passthrough");
+  assert.ok(
+    !actionSmokeText.includes('"${{ inputs.release_sha }}"'),
+    "action smoke workflow should not interpolate release_sha directly inside bash",
+  );
+  assert.ok(
+    !actionSmokeText.includes('"${{ inputs.release_tag }}"'),
+    "action smoke workflow should not interpolate release_tag directly inside bash",
+  );
   assert.ok(
     !actionSmokeText.includes("uses: JeremyDev87/maximus@v0.1.0"),
     "action smoke should not pin a static published action tag",
@@ -155,6 +177,45 @@ function validateRustReleaseWorkflow(rustReleaseText) {
   for (const packageName of platformPackages) {
     assertContains(rustReleaseText, packageName, `rust release matrix entry for ${packageName}`);
   }
+}
+
+function validateReleaseCandidateWorkflow(releaseCandidateText) {
+  assertContains(releaseCandidateText, "workflow_dispatch:", "release candidate manual trigger");
+  assertContains(releaseCandidateText, "target_sha:", "release candidate target sha input");
+  assertContains(releaseCandidateText, "TARGET_SHA: ${{ inputs.target_sha }}", "release candidate target sha env handoff");
+  assertContains(releaseCandidateText, "Ensure release tag does not already exist", "release candidate tag guard");
+  assertContains(releaseCandidateText, "Verify package manifest alignment", "release candidate manifest alignment gate");
+  assertContains(releaseCandidateText, "node ./scripts/release-candidate-metadata.mjs", "release candidate metadata resolver");
+  assertContains(releaseCandidateText, "node ./scripts/validate-rust-release-wiring.mjs", "release candidate release wiring validation");
+  assertContains(releaseCandidateText, "test/release-candidate-metadata.test.js", "release candidate metadata test coverage");
+  assertContains(releaseCandidateText, "test/release-helpers.test.js", "release helper test coverage");
+  assertContains(releaseCandidateText, "test/bump-release-version.test.js", "release candidate bump script test coverage");
+  assertContains(releaseCandidateText, "cargo test --workspace", "release candidate rust tests");
+  assertContains(releaseCandidateText, "node ./scripts/run-packed-wrapper-smoke.mjs", "release candidate packed wrapper smoke");
+  assert.ok(
+    !releaseCandidateText.includes('"${{ inputs.target_sha }}"'),
+    "release candidate workflow should not interpolate target_sha directly inside bash",
+  );
+  assert.ok(
+    !releaseCandidateText.includes("shouldVerify"),
+    "release candidate workflow should not skip verification when only platform manifests changed",
+  );
+}
+
+function validateManualReleaseBumpWorkflow(manualReleaseBumpText) {
+  assertContains(manualReleaseBumpText, "workflow_dispatch:", "manual bump workflow trigger");
+  assertContains(manualReleaseBumpText, "dry_run:", "manual bump dry-run input");
+  assertContains(manualReleaseBumpText, "INPUT_TAG: ${{ inputs.tag }}", "manual bump tag env handoff");
+  assertContains(manualReleaseBumpText, 'tag="$INPUT_TAG"', "manual bump tag shell variable usage");
+  assertContains(manualReleaseBumpText, "tag must look like v1.2.3", "manual bump tag validation");
+  assertContains(manualReleaseBumpText, "node ./scripts/bump-release-version.mjs", "manual bump script usage");
+  assertContains(manualReleaseBumpText, "gh workflow run dev.yml --ref", "manual bump CI dispatch");
+  assertContains(manualReleaseBumpText, "skip-changelog", "manual bump skip-changelog label");
+  assertContains(manualReleaseBumpText, "Unable to create a draft PR", "manual bump hard-fail PR creation");
+  assert.ok(
+    !manualReleaseBumpText.includes('tag="${{ inputs.tag }}"'),
+    "manual bump workflow should not interpolate input tag directly inside bash",
+  );
 }
 
 function validateReleaseWorkflow(releaseText) {
@@ -279,9 +340,30 @@ function validateReleaseContextAssertion(releaseContextAssertionText) {
 
 function validateReleasePlanScript(releasePlanText) {
   assertContains(releasePlanText, "distTag", "release plan dist-tag logic");
-  assertContains(releasePlanText, "next", "release plan prerelease dist-tag");
-  assertContains(releasePlanText, "latest", "release plan stable dist-tag");
   assertContains(releasePlanText, "isPrerelease", "release plan prerelease flag");
+  assertContains(releasePlanText, 'resolveReleasePlan', "release plan helper wiring");
+}
+
+function validateReleaseCandidateMetadata(releaseCandidateMetadataText) {
+  assertContains(releaseCandidateMetadataText, "assertReleaseUpgrade", "release candidate upgrade assertion");
+  assertContains(releaseCandidateMetadataText, "github.event.before must contain package.json for release upgrade validation", "release candidate push fail-closed guard");
+  assertContains(releaseCandidateMetadataText, "merge-base", "release candidate master ancestry gate");
+  assertContains(releaseCandidateMetadataText, "refs/remotes/origin/master", "release candidate master ref gate");
+  assertContains(releaseCandidateMetadataText, "`${verifiedSha}^`", "release candidate parent version check");
+  assertContains(releaseCandidateMetadataText, "target_sha must already be reachable from origin/master before tagging", "release candidate unmerged target guard");
+}
+
+function validateReleaseHelpers(releaseHelpersText) {
+  assertContains(releaseHelpersText, 'npmDistTag: isPrerelease ? "next" : "latest"', "release helper dist-tag mapping");
+  assertContains(releaseHelpersText, "compareReleaseVersions", "release helper version comparison");
+  assertContains(releaseHelpersText, "assertReleaseUpgrade", "release helper upgrade assertion");
+  assertContains(releaseHelpersText, "PRERELEASE_IDENTIFIER_PATTERN", "release helper strict prerelease identifiers");
+}
+
+function validateReleaseBumpScript(releaseBumpScriptText) {
+  assertContains(releaseBumpScriptText, "packageManifestPaths", "release bump manifest path list");
+  assertContains(releaseBumpScriptText, "createManualBumpBranchName", "release bump branch naming");
+  assertContains(releaseBumpScriptText, "assertReleaseUpgrade", "release bump upgrade guard");
 }
 
 function validateNpmLookupClassifier(lookupClassifierText) {

--- a/test/bump-release-version.test.js
+++ b/test/bump-release-version.test.js
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import {
+  bumpPackageVersion,
+  createManualBumpBranchName,
+  packageManifestPaths,
+} from "../scripts/bump-release-version.mjs";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+test("bumpPackageVersion updates root and platform package manifests together", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-bump-version-"));
+
+  await writeJson(path.join(repoRoot, "package.json"), {
+    name: "@jeremyfellaz/maximus",
+    version: "0.1.0",
+    optionalDependencies: {
+      "@jeremyfellaz/maximus-darwin-arm64": "0.1.0",
+      "@jeremyfellaz/maximus-darwin-x64": "0.1.0",
+      "@jeremyfellaz/maximus-linux-arm64-gnu": "0.1.0",
+      "@jeremyfellaz/maximus-linux-x64-gnu": "0.1.0",
+    },
+  });
+
+  for (const relativePath of packageManifestPaths.slice(1)) {
+    await writeJson(path.join(repoRoot, relativePath), {
+      name: `pkg-${relativePath}`,
+      version: "0.1.0",
+    });
+  }
+
+  const result = await bumpPackageVersion("v0.1.1", repoRoot);
+  assert.equal(result.version, "0.1.1");
+  assert.equal(result.tag, "v0.1.1");
+  assert.equal(result.manifestPaths.length, packageManifestPaths.length);
+
+  for (const relativePath of packageManifestPaths) {
+    const manifest = JSON.parse(await readFile(path.join(repoRoot, relativePath), "utf8"));
+    assert.equal(manifest.version, "0.1.1");
+  }
+
+  const rootManifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  assert.deepEqual(Object.values(rootManifest.optionalDependencies), [
+    "0.1.1",
+    "0.1.1",
+    "0.1.1",
+    "0.1.1",
+  ]);
+});
+
+test("createManualBumpBranchName is deterministic per tag and base", () => {
+  assert.equal(
+    createManualBumpBranchName("v0.1.1", "master"),
+    createManualBumpBranchName("v0.1.1", "master"),
+  );
+  assert.notEqual(
+    createManualBumpBranchName("v0.1.1", "master"),
+    createManualBumpBranchName("v0.1.2", "master"),
+  );
+});
+
+test("bump module can be imported from node eval with tag argv", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1]));",
+      "v0.1.1",
+    ],
+    { cwd: projectRoot, encoding: "utf8" },
+  );
+
+  assert.match(output, /^codex\/manual-bump-master-v0-1-1-[0-9a-f]{8}\n$/);
+});

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -5,7 +5,7 @@ import { validateRustReleaseWiring } from "../scripts/validate-rust-release-wiri
 test("Rust release wiring validation passes for the checked-in GitHub automation files", async () => {
   const summary = await validateRustReleaseWiring(process.cwd());
 
-  assert.equal(summary.checkedFiles.length, 19);
+  assert.equal(summary.checkedFiles.length, 24);
   assert.deepEqual(summary.platformPackages, [
     "@jeremyfellaz/maximus-darwin-arm64",
     "@jeremyfellaz/maximus-darwin-x64",

--- a/test/release-candidate-metadata.test.js
+++ b/test/release-candidate-metadata.test.js
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+
+import { resolveReleaseCandidateMetadata } from "../scripts/release-candidate-metadata.mjs";
+
+function git(repoRoot, args) {
+  return execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" }).trim();
+}
+
+async function writePackageJson(repoRoot, version) {
+  await writeFile(
+    path.join(repoRoot, "package.json"),
+    JSON.stringify({ name: "@jeremyfellaz/maximus", version }, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+async function createReleaseRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-candidate-"));
+  git(repoRoot, ["init", "-b", "master"]);
+  git(repoRoot, ["config", "user.email", "test@example.com"]);
+  git(repoRoot, ["config", "user.name", "Test User"]);
+
+  await writePackageJson(repoRoot, "0.1.0");
+  git(repoRoot, ["add", "package.json"]);
+  git(repoRoot, ["commit", "-m", "initial release"]);
+  const previousSha = git(repoRoot, ["rev-parse", "HEAD"]);
+
+  await writePackageJson(repoRoot, "0.1.1");
+  git(repoRoot, ["add", "package.json"]);
+  git(repoRoot, ["commit", "-m", "release 0.1.1"]);
+  const releaseSha = git(repoRoot, ["rev-parse", "HEAD"]);
+
+  const remoteRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-candidate-remote-"));
+  git(remoteRoot, ["init", "--bare"]);
+  git(repoRoot, ["remote", "add", "origin", remoteRoot]);
+  git(repoRoot, ["push", "-u", "origin", "master"]);
+  git(repoRoot, ["fetch", "origin", "refs/heads/master:refs/remotes/origin/master"]);
+
+  return { repoRoot, previousSha, releaseSha };
+}
+
+test("workflow_dispatch metadata compares the target commit against its parent version", async () => {
+  const { repoRoot, releaseSha } = await createReleaseRepo();
+
+  const metadata = await resolveReleaseCandidateMetadata({
+    repoRoot,
+    eventName: "workflow_dispatch",
+    targetSha: releaseSha,
+    fetchMaster: false,
+  });
+
+  assert.equal(metadata.version, "0.1.1");
+  assert.equal(metadata.tag, "v0.1.1");
+  assert.equal(metadata.previousVersion, "0.1.0");
+  assert.equal(metadata.verifiedSha, releaseSha);
+});
+
+test("workflow_dispatch metadata rejects targets that are not on origin/master", async () => {
+  const { repoRoot, previousSha } = await createReleaseRepo();
+  git(repoRoot, ["switch", "-c", "unmerged-release", previousSha]);
+  await writePackageJson(repoRoot, "0.1.2");
+  git(repoRoot, ["add", "package.json"]);
+  git(repoRoot, ["commit", "-m", "unmerged release"]);
+  const unmergedSha = git(repoRoot, ["rev-parse", "HEAD"]);
+
+  await assert.rejects(
+    resolveReleaseCandidateMetadata({
+      repoRoot,
+      eventName: "workflow_dispatch",
+      targetSha: unmergedSha,
+      fetchMaster: false,
+    }),
+    /target_sha must already be reachable from origin\/master/,
+  );
+});
+
+test("push metadata compares the current version against github.event.before", async () => {
+  const { repoRoot, previousSha, releaseSha } = await createReleaseRepo();
+
+  const metadata = await resolveReleaseCandidateMetadata({
+    repoRoot,
+    eventName: "push",
+    beforeSha: previousSha,
+  });
+
+  assert.equal(metadata.version, "0.1.1");
+  assert.equal(metadata.tag, "v0.1.1");
+  assert.equal(metadata.previousVersion, "0.1.0");
+  assert.equal(metadata.verifiedSha, releaseSha);
+});
+
+test("push metadata fails closed when github.event.before cannot be inspected", async () => {
+  const { repoRoot } = await createReleaseRepo();
+
+  await assert.rejects(
+    resolveReleaseCandidateMetadata({
+      repoRoot,
+      eventName: "push",
+      beforeSha: "0000000000000000000000000000000000000000",
+    }),
+    /github\.event\.before must contain package\.json/,
+  );
+});

--- a/test/release-helpers.test.js
+++ b/test/release-helpers.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertReleaseUpgrade,
+  compareReleaseVersions,
+  resolveReleasePlan,
+} from "../scripts/lib/release.mjs";
+
+test("resolveReleasePlan maps stable and prerelease tags to npm dist-tags", () => {
+  assert.deepEqual(resolveReleasePlan("v1.2.3"), {
+    tag: "v1.2.3",
+    version: "1.2.3",
+    isPrerelease: false,
+    npmDistTag: "latest",
+  });
+  assert.deepEqual(resolveReleasePlan("v1.2.3-beta.1"), {
+    tag: "v1.2.3-beta.1",
+    version: "1.2.3-beta.1",
+    isPrerelease: true,
+    npmDistTag: "next",
+  });
+});
+
+test("release helpers reject invalid semver prerelease identifiers", () => {
+  for (const tag of [
+    "v01.2.3",
+    "v1.02.3",
+    "v1.2.03",
+    "v1.2.3-.",
+    "v1.2.3-alpha..1",
+    "v1.2.3-01",
+  ]) {
+    assert.throws(() => resolveReleasePlan(tag), /Tag must look like/);
+  }
+});
+
+test("compareReleaseVersions follows stable and prerelease ordering", () => {
+  assert.equal(compareReleaseVersions("1.2.3-alpha.1", "1.2.3-alpha.2"), -1);
+  assert.equal(compareReleaseVersions("1.2.3-alpha.2", "1.2.3-beta.1"), -1);
+  assert.equal(compareReleaseVersions("1.2.3-beta.1", "1.2.3"), -1);
+  assert.equal(compareReleaseVersions("1.2.3", "1.2.4"), -1);
+  assert.equal(compareReleaseVersions("1.2.3", "1.2.3"), 0);
+});
+
+test("assertReleaseUpgrade rejects equal or lower target versions", () => {
+  assert.doesNotThrow(() => assertReleaseUpgrade("1.2.3", "1.2.4"));
+  assert.throws(() => assertReleaseUpgrade("1.2.3", "1.2.3"), /must be greater/);
+  assert.throws(() => assertReleaseUpgrade("1.2.3", "1.2.3-beta.1"), /must be greater/);
+});

--- a/test/release-workflow-context.test.js
+++ b/test/release-workflow-context.test.js
@@ -1,67 +1,93 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { assertReleaseWorkflowContext } from "../scripts/assert-release-workflow-context.mjs";
 
+async function writePackageJson(dir, version) {
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "@jeremyfellaz/maximus", version }, null, 2),
+    "utf8",
+  );
+}
+
 test("release workflow context accepts matching release tags", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-context-stable-"));
+  await writePackageJson(repoRoot, "1.2.3");
+
   const summary = await assertReleaseWorkflowContext({
-    repoRoot: process.cwd(),
+    repoRoot,
     eventName: "push",
-    githubRef: "refs/tags/v0.1.0",
-    githubRefName: "v0.1.0",
-    requestedReleaseTag: "v0.1.0",
+    githubRef: "refs/tags/v1.2.3",
+    githubRefName: "v1.2.3",
+    requestedReleaseTag: "v1.2.3",
   });
 
-  assert.equal(summary.packageVersion, "0.1.0");
-  assert.equal(summary.releaseTag, "v0.1.0");
+  assert.equal(summary.packageVersion, "1.2.3");
+  assert.equal(summary.releaseTag, "v1.2.3");
 });
 
 test("release workflow context accepts workflow dispatch when the selected tag ref is provided", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-context-dispatch-"));
+  await writePackageJson(repoRoot, "1.2.3-alpha.1");
+
   const summary = await assertReleaseWorkflowContext({
-    repoRoot: process.cwd(),
+    repoRoot,
     eventName: "workflow_dispatch",
-    githubRef: "refs/tags/v0.1.0",
-    githubRefName: "v0.1.0",
-    requestedReleaseTag: "v0.1.0",
+    githubRef: "refs/tags/v1.2.3-alpha.1",
+    githubRefName: "v1.2.3-alpha.1",
+    requestedReleaseTag: "v1.2.3-alpha.1",
   });
 
-  assert.equal(summary.packageVersion, "0.1.0");
-  assert.equal(summary.releaseTag, "v0.1.0");
+  assert.equal(summary.packageVersion, "1.2.3-alpha.1");
+  assert.equal(summary.releaseTag, "v1.2.3-alpha.1");
 });
 
 test("release workflow context rejects non-tag refs", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-context-nontag-"));
+  await writePackageJson(repoRoot, "1.2.3");
+
   await assert.rejects(
     assertReleaseWorkflowContext({
-      repoRoot: process.cwd(),
+      repoRoot,
       eventName: "workflow_dispatch",
       githubRef: "refs/heads/master",
       githubRefName: "master",
-      requestedReleaseTag: "v0.1.0",
+      requestedReleaseTag: "v1.2.3",
     }),
     /must run from a tag ref/,
   );
 });
 
 test("release workflow context rejects mismatched selected tags", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-context-selected-mismatch-"));
+  await writePackageJson(repoRoot, "1.2.3");
+
   await assert.rejects(
     assertReleaseWorkflowContext({
-      repoRoot: process.cwd(),
+      repoRoot,
       eventName: "workflow_dispatch",
-      githubRef: "refs/tags/v0.1.0",
-      githubRefName: "v0.1.0",
-      requestedReleaseTag: "v0.1.1",
+      githubRef: "refs/tags/v1.2.3",
+      githubRefName: "v1.2.3",
+      requestedReleaseTag: "v1.2.4",
     }),
     /does not match release tag/,
   );
 });
 
 test("release workflow context rejects package version mismatches", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-release-context-version-mismatch-"));
+  await writePackageJson(repoRoot, "1.2.3");
+
   await assert.rejects(
     assertReleaseWorkflowContext({
-      repoRoot: process.cwd(),
+      repoRoot,
       eventName: "push",
-      githubRef: "refs/tags/v0.2.0",
-      githubRefName: "v0.2.0",
-      requestedReleaseTag: "v0.2.0",
+      githubRef: "refs/tags/v1.2.4",
+      githubRefName: "v1.2.4",
+      requestedReleaseTag: "v1.2.4",
     }),
     /does not match package\.json version/,
   );


### PR DESCRIPTION
## 배경

Kratos release에서 확인한 실패 패턴을 Maximus release 경로에 반영합니다. 핵심은 version bump PR 생성, candidate commit 검증, tag publish 사이를 명확히 분리하는 것입니다.

## 변경 사항

- `manual-release-bump.yml`을 추가해 version-only bump branch/PR을 만들고 PR 생성 실패를 hard fail로 처리합니다.
- `release-candidate.yml`을 추가해 tag 생성 전 exact candidate SHA를 검증합니다.
- release helper와 bump script를 추가하고, 기존 release wiring validator와 CI path filter에 포함했습니다.
- release plan의 dist-tag 판정을 공용 helper로 분리했습니다.

## 검증

- `git diff --check`
- `actionlint .github/workflows/manual-release-bump.yml .github/workflows/release-candidate.yml .github/workflows/release.yml .github/workflows/dev.yml`
- `node --test test/release-workflow-context.test.js test/github-action-wiring.test.js test/release-plan.test.js test/npm-error-classifiers.test.js test/bump-release-version.test.js`
- `node ./scripts/validate-rust-release-wiring.mjs`
- `cargo test --workspace`
- `node ./scripts/run-packed-wrapper-smoke.mjs /tmp/maximus-release-pack/root-pack.json test/fixtures/clean-project`

## 참고

- 로컬 macOS에서 `npm test`는 기존 `wrapper accepts execute-only installed runtime binaries` 1건이 실패합니다. 이번 변경 파일과 무관한 기존 wrapper runtime 테스트이며, release candidate에 직접 필요한 packed wrapper smoke는 별도로 통과했습니다.
- release tag 생성과 publish는 실행하지 않았습니다.
