### PR TITLE
feat: CLI 출력 포맷 추가

### DIFF
--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -192,13 +192,10 @@ function parseCompatInvocation(args) {
     };
   }
 
-  const [command, ...rest] = args;
   if (
-    command === "help"
-    || command === "--help"
-    || command === "-h"
-    || rest.includes("--help")
-    || rest.includes("-h")
+    args[0] === "help"
+    || args.includes("--help")
+    || args.includes("-h")
   ) {
     return {
       mode: "compat-help",
@@ -207,19 +204,16 @@ function parseCompatInvocation(args) {
     };
   }
 
+  let command;
   let pathArg;
   const unsupportedFlags = [];
-  const valueFlags = new Set(["--only", "--skip", "--fail-on", "--fix-id", "--fix-prefix"]);
+  const commandNames = new Set(["audit", "doctor", "fix"]);
+  const valueFlags = new Set(["--only", "--skip", "--fail-on", "--fix-id", "--fix-prefix", "--format"]);
   const passthroughFlags = new Set(["--dry-run", "--json"]);
-  const isFixCommand = command === "fix";
-  const hasDryRun = rest.includes("--dry-run");
 
-  if (isFixCommand && !hasDryRun) {
-    unsupportedFlags.push("fix (without --dry-run)");
-  }
-
-  for (let index = 0; index < rest.length; index += 1) {
-    const token = rest[index];
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const valueFlagWithEquals = Array.from(valueFlags).find((flag) => token.startsWith(`${flag}=`));
 
     if (valueFlags.has(token)) {
       unsupportedFlags.push(token);
@@ -227,8 +221,13 @@ function parseCompatInvocation(args) {
       continue;
     }
 
-    if (token === "--diff") {
-      unsupportedFlags.push(token);
+    if (valueFlagWithEquals) {
+      unsupportedFlags.push(valueFlagWithEquals);
+      continue;
+    }
+
+    if (token === "--diff" || token.startsWith("--diff=")) {
+      unsupportedFlags.push("--diff");
       continue;
     }
 
@@ -236,9 +235,21 @@ function parseCompatInvocation(args) {
       continue;
     }
 
+    if (command === undefined && commandNames.has(token)) {
+      command = token;
+      continue;
+    }
+
     if (pathArg === undefined) {
       pathArg = token;
     }
+  }
+
+  const isFixCommand = command === "fix";
+  const hasDryRun = args.includes("--dry-run");
+
+  if (isFixCommand && !hasDryRun) {
+    unsupportedFlags.push("fix (without --dry-run)");
   }
 
   return {
@@ -359,7 +370,7 @@ function formatCompatHelp() {
     "  maximus fix [path] --dry-run [--json]",
     "  maximus help",
     "",
-    "Rust is the canonical Maximus runtime. When no Rust runtime is available, the bundled JS compatibility path stays as frozen reference-only fallback for legacy-compatible commands without Maximus config files or Rust-only flags. `--only`, `--skip`, `--fail-on`, `--diff`, `--fix-id`, and `--fix-prefix` require the Rust runtime, and `fix` is only available with `--dry-run`.",
+    "Rust is the canonical Maximus runtime. When no Rust runtime is available, the bundled JS compatibility path stays as frozen reference-only fallback for legacy-compatible commands without Maximus config files or Rust-only flags. `--only`, `--skip`, `--fail-on`, `--diff`, `--fix-id`, `--fix-prefix`, and `--format` require the Rust runtime, and `fix` is only available with `--dry-run`.",
   ].join("\n");
 }
 

--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -9,9 +9,23 @@ pub struct Flags {
     pub fix_ids: Vec<String>,
     pub fix_prefixes: Vec<String>,
     pub help: bool,
-    pub json: bool,
+    pub output_format: OutputFormat,
     pub only_checks: Option<Vec<String>>,
     pub skip_checks: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+    Markdown,
+    Sarif,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Text
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -24,6 +38,8 @@ pub struct ParsedArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgsError {
     EmptyValue(&'static str),
+    ConflictingValue(&'static str, &'static str),
+    InvalidValue(&'static str, String, &'static str),
     MissingValue(&'static str),
 }
 
@@ -31,6 +47,14 @@ impl Display for ArgsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyValue(flag) => write!(f, "Option \"{flag}\" requires a non-empty value."),
+            Self::ConflictingValue(left, right) => write!(
+                f,
+                "Option \"{left}\" cannot be combined with option \"{right}\"."
+            ),
+            Self::InvalidValue(flag, value, expected) => write!(
+                f,
+                "Option \"{flag}\" received unsupported value \"{value}\". Use one of: {expected}."
+            ),
             Self::MissingValue(flag) => write!(f, "Option \"{flag}\" requires a value."),
         }
     }
@@ -43,6 +67,7 @@ where
 {
     let mut args = Vec::new();
     let mut flags = Flags::default();
+    let mut output_format_source = None;
     let mut tokens = argv.into_iter().map(Into::into);
 
     while let Some(token) = tokens.next() {
@@ -71,6 +96,16 @@ where
                     .get_or_insert_with(Vec::new)
                     .extend(values);
             }
+            Some("--format") => {
+                let value = next_option_value(tokens.next(), "--format")?;
+                let output_format = parse_output_format(&value)?;
+                set_output_format(
+                    &mut flags,
+                    &mut output_format_source,
+                    output_format,
+                    "--format",
+                )?;
+            }
             Some("--skip") => {
                 let value = next_option_value(tokens.next(), "--skip")?;
                 let values = split_csv_values(&value, "--skip")?;
@@ -79,7 +114,14 @@ where
                     .get_or_insert_with(Vec::new)
                     .extend(values);
             }
-            Some("--json") => flags.json = true,
+            Some("--json") => {
+                set_output_format(
+                    &mut flags,
+                    &mut output_format_source,
+                    OutputFormat::Json,
+                    "--json",
+                )?;
+            }
             Some("--help") | Some("-h") => flags.help = true,
             _ => args.push(token),
         }
@@ -125,11 +167,43 @@ fn split_csv_values(value: &OsString, flag: &'static str) -> Result<Vec<String>,
     Ok(values)
 }
 
+fn parse_output_format(value: &OsString) -> Result<OutputFormat, ArgsError> {
+    match value.to_string_lossy().as_ref() {
+        "text" => Ok(OutputFormat::Text),
+        "json" => Ok(OutputFormat::Json),
+        "markdown" => Ok(OutputFormat::Markdown),
+        "sarif" => Ok(OutputFormat::Sarif),
+        value => Err(ArgsError::InvalidValue(
+            "--format",
+            value.to_string(),
+            "text, json, markdown, sarif",
+        )),
+    }
+}
+
+fn set_output_format(
+    flags: &mut Flags,
+    source: &mut Option<&'static str>,
+    output_format: OutputFormat,
+    flag: &'static str,
+) -> Result<(), ArgsError> {
+    if source.is_some() && flags.output_format != output_format {
+        return Err(ArgsError::ConflictingValue(
+            source.unwrap_or("--format"),
+            flag,
+        ));
+    }
+
+    flags.output_format = output_format;
+    *source = Some(flag);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
 
-    use super::{parse_args, ArgsError, Flags, ParsedArgs};
+    use super::{parse_args, ArgsError, Flags, OutputFormat, ParsedArgs};
 
     #[test]
     fn parse_args_collects_known_flags_and_positionals() {
@@ -148,7 +222,7 @@ mod tests {
                     fix_ids: Vec::new(),
                     fix_prefixes: Vec::new(),
                     help: false,
-                    json: true,
+                    output_format: OutputFormat::Json,
                     only_checks: None,
                     skip_checks: None,
                 },
@@ -203,6 +277,40 @@ mod tests {
         );
         assert_eq!(parsed.flags.fix_prefixes, vec!["env-example:".to_string()]);
         assert!(parsed.flags.diff);
+    }
+
+    #[test]
+    fn parse_args_collects_format_output_values() {
+        let parsed = parse_args(["audit", "--format", "markdown"]).expect("args should parse");
+        assert_eq!(parsed.flags.output_format, OutputFormat::Markdown);
+
+        let parsed = parse_args(["audit", "--format", "sarif"]).expect("args should parse");
+        assert_eq!(parsed.flags.output_format, OutputFormat::Sarif);
+
+        let parsed = parse_args(["audit", "--format", "json"]).expect("args should parse");
+        assert_eq!(parsed.flags.output_format, OutputFormat::Json);
+
+        let parsed = parse_args(["audit", "--format", "text"]).expect("args should parse");
+        assert_eq!(parsed.flags.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn parse_args_errors_when_output_format_flags_conflict() {
+        let error = parse_args(["audit", "--json", "--format", "markdown"])
+            .expect_err("conflicting output formats should fail");
+
+        assert_eq!(error, ArgsError::ConflictingValue("--json", "--format"));
+    }
+
+    #[test]
+    fn parse_args_errors_when_output_format_value_is_invalid() {
+        let error = parse_args(["audit", "--format", "xml"])
+            .expect_err("unknown output format should fail");
+
+        assert_eq!(
+            error,
+            ArgsError::InvalidValue("--format", "xml".to_string(), "text, json, markdown, sarif")
+        );
     }
 
     #[test]

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -3,6 +3,8 @@ mod exit_codes;
 mod fail_policy;
 mod report_diff;
 mod report_json;
+mod report_markdown;
+mod report_sarif;
 mod report_text;
 
 use std::env;
@@ -18,7 +20,7 @@ use maximus_core::{
     AuditResult, FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
 };
 
-use crate::args::{parse_args, ArgsError, Flags};
+use crate::args::{parse_args, ArgsError, Flags, OutputFormat};
 
 #[derive(Debug, Clone)]
 struct ResolvedConfig {
@@ -136,11 +138,7 @@ fn run_audit_command(
     let audited =
         audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
 
-    if flags.json {
-        println!("{}", report_json::render_audit_result(&audited.result)?);
-    } else {
-        println!("{}", report_text::format_audit_report(&audited.result));
-    }
+    print_audit_report(flags, &audited.result)?;
 
     let fail_on = effective_fail_on_level(&resolved.config);
     Ok(fail_policy::exit_code(&audited.result.summary, &fail_on))
@@ -154,11 +152,7 @@ fn run_doctor_command(
     let audited =
         audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
 
-    if flags.json {
-        println!("{}", report_json::render_audit_result(&audited.result)?);
-    } else {
-        println!("{}", report_text::format_doctor_report(&audited.result));
-    }
+    print_doctor_report(flags, &audited.result)?;
 
     let fail_on = effective_fail_on_level(&resolved.config);
     Ok(fail_policy::exit_code(&audited.result.summary, &fail_on))
@@ -206,43 +200,136 @@ fn run_fix_command(
         audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?.result
     };
 
-    if flags.json {
-        println!(
-            "{}",
-            report_json::render_fix_result(
-                flags.dry_run,
-                target_dir,
-                &selected_initial,
-                &applied,
-                &final_result,
-                previewed.as_deref(),
-            )?
-        );
+    let selected_for_report = if selector.is_empty() && !flags.diff {
+        None
     } else {
-        let selected_for_report = if selector.is_empty() && !flags.diff {
-            None
-        } else {
-            Some(selected_initial.fixes.as_slice())
-        };
-        let preview_report = previewed
-            .as_ref()
-            .map(|previews| report_diff::render_fix_preview(target_dir, previews));
-        println!(
-            "{}",
-            report_text::format_fix_result(
-                flags.dry_run,
-                target_dir,
-                &selected_initial,
-                &applied,
-                &final_result,
-                selected_for_report,
-                preview_report.as_deref(),
-            )
-        );
-    }
+        Some(selected_initial.fixes.as_slice())
+    };
+    let preview_report = previewed
+        .as_ref()
+        .map(|previews| report_diff::render_fix_preview(target_dir, previews));
+    print_fix_report(
+        flags,
+        target_dir,
+        &selected_initial,
+        &applied,
+        &final_result,
+        selected_for_report,
+        preview_report.as_deref(),
+        previewed.as_deref(),
+    )?;
 
     let fail_on = effective_fail_on_level(&resolved.config);
     Ok(fail_policy::exit_code(&final_result.summary, &fail_on))
+}
+
+fn print_audit_report(flags: &Flags, result: &AuditResult) -> Result<(), CliError> {
+    match flags.output_format {
+        crate::args::OutputFormat::Text => {
+            println!("{}", report_text::format_audit_report(result));
+        }
+        crate::args::OutputFormat::Json => {
+            println!("{}", report_json::render_audit_result(result)?);
+        }
+        crate::args::OutputFormat::Markdown => {
+            println!("{}", report_markdown::format_audit_report(result));
+        }
+        crate::args::OutputFormat::Sarif => {
+            println!("{}", report_sarif::render_audit_result(result)?);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_doctor_report(flags: &Flags, result: &AuditResult) -> Result<(), CliError> {
+    match flags.output_format {
+        crate::args::OutputFormat::Text => {
+            println!("{}", report_text::format_doctor_report(result));
+        }
+        crate::args::OutputFormat::Json => {
+            println!("{}", report_json::render_audit_result(result)?);
+        }
+        crate::args::OutputFormat::Markdown => {
+            println!("{}", report_markdown::format_doctor_report(result));
+        }
+        crate::args::OutputFormat::Sarif => {
+            println!("{}", report_sarif::render_doctor_result(result)?);
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_fix_report(
+    flags: &Flags,
+    target_dir: &std::path::Path,
+    initial: &AuditResult,
+    applied: &[maximus_core::AppliedFix],
+    final_result: &AuditResult,
+    selected_fixes: Option<&[FixPlan]>,
+    preview_report: Option<&str>,
+    previews: Option<&[maximus_core::PreviewedFix]>,
+) -> Result<(), CliError> {
+    match flags.output_format {
+        crate::args::OutputFormat::Text => {
+            println!(
+                "{}",
+                report_text::format_fix_result(
+                    flags.dry_run,
+                    target_dir,
+                    initial,
+                    applied,
+                    final_result,
+                    selected_fixes,
+                    preview_report,
+                )
+            );
+        }
+        crate::args::OutputFormat::Json => {
+            println!(
+                "{}",
+                report_json::render_fix_result(
+                    flags.dry_run,
+                    target_dir,
+                    initial,
+                    applied,
+                    final_result,
+                    previews,
+                )?
+            );
+        }
+        crate::args::OutputFormat::Markdown => {
+            println!(
+                "{}",
+                report_markdown::format_fix_result(
+                    flags.dry_run,
+                    target_dir,
+                    initial,
+                    applied,
+                    final_result,
+                    selected_fixes,
+                    preview_report,
+                )
+            );
+        }
+        crate::args::OutputFormat::Sarif => {
+            println!(
+                "{}",
+                report_sarif::render_fix_result(
+                    flags.dry_run,
+                    target_dir,
+                    initial,
+                    applied,
+                    final_result,
+                    previews,
+                )?
+            );
+        }
+    }
+
+    Ok(())
 }
 
 fn resolve_effective_config(
@@ -327,6 +414,12 @@ fn validate_command_flags(command: Option<&str>, flags: &Flags) -> Result<(), Cl
     if flags.diff && !flags.dry_run {
         return Err(CliError::InvalidArguments(
             "Option \"--diff\" requires \"fix --dry-run\".".to_string(),
+        ));
+    }
+
+    if command == Some("fix") && matches!(flags.output_format, OutputFormat::Sarif) {
+        return Err(CliError::InvalidArguments(
+            "Option \"--format sarif\" is only available for \"audit\" and \"doctor\".".to_string(),
         ));
     }
 

--- a/crates/maximus-cli/src/report_markdown.rs
+++ b/crates/maximus-cli/src/report_markdown.rs
@@ -1,0 +1,470 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::Path;
+
+use maximus_core::{AppliedFix, AuditResult, FixPlan, Severity, StructureReport};
+
+pub fn format_audit_report(result: &AuditResult) -> String {
+    let mut lines = vec![
+        "# Maximus audit".to_string(),
+        String::new(),
+        format!("- Target: `{}`", display_path(&result.root_dir)),
+        format!("- Status: `{}`", result.summary.status),
+        format!(
+            "- Findings: `{}` error, `{}` warnings, `{}` info",
+            result.summary.blocking_findings,
+            result.summary.warning_findings,
+            result.summary.info_findings
+        ),
+        format!("- Fixes available: `{}`", result.summary.fixes_available),
+        String::new(),
+        "## Structure".to_string(),
+        format!("{}.", describe_structure(&result.structure)),
+    ];
+
+    if result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("## Findings".to_string());
+        lines.push("- No config drift detected.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("## Findings".to_string());
+        lines.extend(format_findings(result));
+    }
+
+    if !result.structure.recommendations.is_empty() {
+        lines.push(String::new());
+        lines.push("## Recommendations".to_string());
+        for recommendation in &result.structure.recommendations {
+            lines.push(format!("- {recommendation}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+pub fn format_doctor_report(result: &AuditResult) -> String {
+    let mut lines = vec![
+        "# Maximus doctor".to_string(),
+        String::new(),
+        format!("- Target: `{}`", display_path(&result.root_dir)),
+        format!("- Diagnosis: `{}`", result.summary.status),
+        format!("- Project shape: {}", describe_structure(&result.structure)),
+        String::new(),
+        "## Prescription".to_string(),
+    ];
+
+    let manual_findings = result
+        .findings
+        .iter()
+        .filter(|finding| !finding.fixable)
+        .count();
+    let fixable_findings = result
+        .findings
+        .iter()
+        .filter(|finding| finding.fixable)
+        .count();
+
+    if fixable_findings > 0 {
+        lines.push(format!(
+            "- Run `maximus fix` to apply {} safe fix(es).",
+            result.summary.fixes_available
+        ));
+    } else {
+        lines.push("- No automatic fixes are currently available.".to_string());
+    }
+
+    if manual_findings > 0 {
+        lines.push(format!(
+            "- Review {manual_findings} manual issue(s) in priority order below."
+        ));
+    } else {
+        lines.push("- No manual follow-up is required right now.".to_string());
+    }
+
+    if result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("## Findings".to_string());
+        lines.push("- No config drift detected.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("## Top Priorities".to_string());
+        lines.extend(format_top_priorities(result));
+        lines.push(String::new());
+        lines.push("## Findings".to_string());
+        lines.extend(format_findings(result));
+    }
+
+    if !result.structure.recommendations.is_empty() {
+        lines.push(String::new());
+        lines.push("## Recommended Structure".to_string());
+        for recommendation in &result.structure.recommendations {
+            lines.push(format!("- {recommendation}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+pub fn format_fix_result(
+    dry_run: bool,
+    target_dir: &Path,
+    initial: &AuditResult,
+    applied: &[AppliedFix],
+    final_result: &AuditResult,
+    selected_fixes: Option<&[FixPlan]>,
+    preview_report: Option<&str>,
+) -> String {
+    let mut lines = vec![
+        "# Maximus fix".to_string(),
+        String::new(),
+        format!("- Target: `{}`", display_path(target_dir)),
+    ];
+
+    if dry_run {
+        if let Some(selected_fixes) = selected_fixes.filter(|fixes| !fixes.is_empty()) {
+            lines.push(format!(
+                "- Dry run: `{}` safe fix(es) selected.",
+                selected_fixes.len()
+            ));
+        } else {
+            lines.push(format!(
+                "- Dry run: `{}` safe fix(es) available.",
+                initial.summary.fixes_available
+            ));
+        }
+    } else {
+        lines.push(format!("- Applied: `{}` fix(es).", applied.len()));
+    }
+
+    if !applied.is_empty() {
+        lines.push(String::new());
+        lines.push("## Changes".to_string());
+        for fix in applied {
+            lines.push(format!("- {}", fix.title));
+            for file in &fix.files {
+                lines.push(format!("  - file: `{}`", display_path(file)));
+            }
+        }
+    }
+
+    if dry_run {
+        if let Some(selected_fixes) = selected_fixes.filter(|fixes| !fixes.is_empty()) {
+            lines.push(String::new());
+            lines.push("## Planned Changes".to_string());
+            for fix in selected_fixes {
+                lines.push(format!("- {}", fix.title));
+                for file in &fix.files {
+                    lines.push(format!("  - file: `{}`", display_path(file)));
+                }
+            }
+        }
+    }
+
+    if let Some(preview_report) = preview_report.filter(|report| !report.is_empty()) {
+        lines.push(String::new());
+        lines.push("## Preview Diffs".to_string());
+        lines.push("```diff".to_string());
+        lines.extend(preview_report.lines().map(ToOwned::to_owned));
+        lines.push("```".to_string());
+    }
+
+    lines.push(String::new());
+    lines.push(format!(
+        "- Post-check: `{}` error, `{}` warnings, `{}` info",
+        final_result.summary.blocking_findings,
+        final_result.summary.warning_findings,
+        final_result.summary.info_findings
+    ));
+
+    if final_result.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("## Remaining Findings".to_string());
+        lines.push("- Project is currently clean.".to_string());
+    } else {
+        lines.push(String::new());
+        lines.push("## Remaining Findings".to_string());
+        lines.extend(format_findings(final_result));
+    }
+
+    lines.join("\n")
+}
+
+fn format_top_priorities(result: &AuditResult) -> Vec<String> {
+    result
+        .findings
+        .iter()
+        .take(3)
+        .enumerate()
+        .flat_map(|(index, finding)| {
+            let mut lines = vec![format!(
+                "{}. **[{}]** {}",
+                index + 1,
+                severity_label(&finding.severity),
+                finding.title
+            )];
+
+            if let Some(file) = &finding.file {
+                lines.push(format!(
+                    "   - file: `{}`",
+                    format_relative_file(&result.root_dir, file)
+                ));
+            }
+
+            if !finding.hint.is_empty() {
+                lines.push(format!("   - next: {}", finding.hint));
+            } else if !finding.detail.is_empty() {
+                lines.push(format!("   - next: {}", finding.detail));
+            }
+
+            lines
+        })
+        .collect()
+}
+
+fn format_findings(result: &AuditResult) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    for finding in &result.findings {
+        lines.push(format!(
+            "- **[{}]** {}",
+            severity_label(&finding.severity),
+            finding.title
+        ));
+
+        if let Some(file) = &finding.file {
+            lines.push(format!(
+                "  - file: `{}`",
+                format_relative_file(&result.root_dir, file)
+            ));
+        }
+
+        if !finding.detail.is_empty() {
+            lines.push(format!("  - detail: {}", finding.detail));
+        }
+
+        if !finding.hint.is_empty() {
+            lines.push(format!("  - hint: {}", finding.hint));
+        }
+    }
+
+    lines
+}
+
+fn describe_structure(structure: &StructureReport) -> String {
+    let repo_type = if structure.is_monorepo {
+        "monorepo"
+    } else {
+        "single package"
+    };
+
+    format!(
+        "{repo_type}, {} package(s), {} config file(s), {} env folder(s)",
+        structure.package_count, structure.config_files, structure.env_directories
+    )
+}
+
+fn format_relative_file(root_dir: &Path, file_path: &Path) -> String {
+    relative_path_like_js(root_dir, file_path)
+        .map(|value| {
+            if value.is_empty() {
+                ".".to_string()
+            } else {
+                value
+            }
+        })
+        .unwrap_or_else(|| display_path(file_path))
+}
+
+fn relative_path_like_js(root_dir: &Path, file_path: &Path) -> Option<String> {
+    if root_dir == file_path {
+        return Some(String::new());
+    }
+
+    if let Ok(relative) = file_path.strip_prefix(root_dir) {
+        return Some(path_string(relative));
+    }
+
+    let root_components = root_dir.components().collect::<Vec<_>>();
+    let file_components = file_path.components().collect::<Vec<_>>();
+
+    let mut shared_len = 0usize;
+    while shared_len < root_components.len()
+        && shared_len < file_components.len()
+        && root_components[shared_len] == file_components[shared_len]
+    {
+        shared_len += 1;
+    }
+
+    if shared_len == 0 {
+        return None;
+    }
+
+    let mut relative = std::path::PathBuf::new();
+
+    for component in &root_components[shared_len..] {
+        if matches!(component, std::path::Component::Normal(_)) {
+            relative.push("..");
+        }
+    }
+
+    for component in &file_components[shared_len..] {
+        relative.push(component.as_os_str());
+    }
+
+    Some(path_string(&relative))
+}
+
+fn severity_label(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warn => "warn",
+        Severity::Info => "info",
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path_string(path)
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use maximus_core::{AuditResult, AuditSummary, Finding, Severity, StructureReport};
+
+    use super::{format_audit_report, format_doctor_report, format_fix_result};
+
+    #[test]
+    fn audit_markdown_uses_sectioned_layout() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let report = format_audit_report(&result);
+
+        assert!(report.contains("# Maximus audit"));
+        assert!(report.contains("## Structure"));
+        assert!(report.contains("## Findings"));
+        assert!(report.contains("- Target: `/tmp/project`"));
+    }
+
+    #[test]
+    fn doctor_markdown_lists_top_priorities() {
+        let root_dir = PathBuf::from("/tmp/project");
+        let result = AuditResult {
+            root_dir: root_dir.clone(),
+            summary: AuditSummary {
+                status: "blocking issues".to_string(),
+                total_findings: 4,
+                blocking_findings: 1,
+                warning_findings: 1,
+                info_findings: 2,
+                fixable_findings: 1,
+                fixes_available: 1,
+                config_files: 2,
+                package_count: 1,
+                env_directories: 1,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 1,
+                config_files: 2,
+                recommendations: Vec::new(),
+            },
+            findings: vec![
+                Finding {
+                    id: "err-1".to_string(),
+                    severity: Severity::Error,
+                    category: "tsconfig".to_string(),
+                    title: "First error".to_string(),
+                    detail: "first detail".to_string(),
+                    file: Some(root_dir.join("tsconfig.json")),
+                    hint: "fix the first issue".to_string(),
+                    fixable: false,
+                    fix_ids: Vec::new(),
+                },
+                Finding {
+                    id: "warn-1".to_string(),
+                    severity: Severity::Warn,
+                    category: "env".to_string(),
+                    title: "Second warning".to_string(),
+                    detail: "second detail".to_string(),
+                    file: Some(root_dir.join(".env")),
+                    hint: "run maximus fix".to_string(),
+                    fixable: true,
+                    fix_ids: vec!["env-create-example".to_string()],
+                },
+                Finding {
+                    id: "info-1".to_string(),
+                    severity: Severity::Info,
+                    category: "tsconfig".to_string(),
+                    title: "Third note".to_string(),
+                    detail: "third detail".to_string(),
+                    file: Some(root_dir.join("packages/app/tsconfig.json")),
+                    hint: String::new(),
+                    fixable: false,
+                    fix_ids: Vec::new(),
+                },
+            ],
+            fixes: Vec::new(),
+        };
+
+        let report = format_doctor_report(&result);
+
+        assert!(report.contains("## Top Priorities"));
+        assert!(report.contains("1. **[error]** First error"));
+        assert!(report.contains("   - file: `tsconfig.json`"));
+    }
+
+    #[test]
+    fn fix_markdown_wraps_preview_diff_blocks() {
+        let root_dir = PathBuf::from("/tmp/project");
+        let result = sample_result(root_dir.clone());
+        let report = format_fix_result(
+            true,
+            &root_dir,
+            &result,
+            &[],
+            &result,
+            None,
+            Some("--- /dev/null\n+++ .env.example\n@@ -0,0 +1,1 @@\n+API_URL="),
+        );
+
+        assert!(report.contains("## Preview Diffs"));
+        assert!(report.contains("```diff"));
+        assert!(report.contains("+API_URL="));
+    }
+
+    fn sample_result(root_dir: PathBuf) -> AuditResult {
+        AuditResult {
+            root_dir,
+            summary: AuditSummary {
+                status: "clean".to_string(),
+                total_findings: 0,
+                blocking_findings: 0,
+                warning_findings: 0,
+                info_findings: 0,
+                fixable_findings: 0,
+                fixes_available: 0,
+                config_files: 1,
+                package_count: 1,
+                env_directories: 0,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 0,
+                config_files: 1,
+                recommendations: vec![
+                    "Current config surface looks healthy. Keep shared rules centralized as the repo grows."
+                        .to_string(),
+                ],
+            },
+            findings: Vec::new(),
+            fixes: Vec::new(),
+        }
+    }
+}

--- a/crates/maximus-cli/src/report_sarif.rs
+++ b/crates/maximus-cli/src/report_sarif.rs
@@ -1,0 +1,369 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::path::Path;
+
+use maximus_core::{AppliedFix, AuditResult, PreviewedFix, Severity};
+use serde_json::{json, Value};
+
+pub fn render_audit_result(result: &AuditResult) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&build_log("audit", result, None, None, None, None))
+}
+
+pub fn render_doctor_result(result: &AuditResult) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&build_log("doctor", result, None, None, None, None))
+}
+
+pub fn render_fix_result(
+    dry_run: bool,
+    target_dir: &Path,
+    initial: &AuditResult,
+    applied: &[AppliedFix],
+    final_result: &AuditResult,
+    preview: Option<&[PreviewedFix]>,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&build_fix_log(
+        dry_run,
+        target_dir,
+        initial,
+        applied,
+        final_result,
+        preview,
+    ))
+}
+
+fn build_log(
+    kind: &str,
+    result: &AuditResult,
+    dry_run: Option<bool>,
+    target_dir: Option<&Path>,
+    applied: Option<&[AppliedFix]>,
+    preview: Option<&[PreviewedFix]>,
+) -> Value {
+    json!({
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "maximus",
+                    "version": env!("CARGO_PKG_VERSION"),
+                }
+            },
+            "results": result.findings.iter().map(|finding| finding_to_result(&result.root_dir, finding)).collect::<Vec<_>>(),
+            "properties": {
+                "reportKind": kind,
+                "rootDir": result.root_dir,
+                "summary": result.summary,
+                "structure": result.structure,
+                "dryRun": dry_run,
+                "targetDir": target_dir.map(display_path),
+                "applied": applied.map(serializable_applied_fixes),
+                "preview": preview.map(serializable_previewed_fixes),
+            }
+        }]
+    })
+}
+
+fn build_fix_log(
+    dry_run: bool,
+    target_dir: &Path,
+    initial: &AuditResult,
+    applied: &[AppliedFix],
+    final_result: &AuditResult,
+    preview: Option<&[PreviewedFix]>,
+) -> Value {
+    json!({
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "maximus",
+                    "version": env!("CARGO_PKG_VERSION"),
+                }
+            },
+            "results": final_result.findings.iter().map(|finding| finding_to_result(&final_result.root_dir, finding)).collect::<Vec<_>>(),
+            "properties": {
+                "reportKind": "fix",
+                "dryRun": dry_run,
+                "targetDir": display_path(target_dir),
+                "initial": {
+                    "rootDir": initial.root_dir,
+                    "summary": initial.summary,
+                    "structure": initial.structure,
+                },
+                "final": {
+                    "rootDir": final_result.root_dir,
+                    "summary": final_result.summary,
+                    "structure": final_result.structure,
+                },
+                "applied": serializable_applied_fixes(applied),
+                "preview": preview.map(serializable_previewed_fixes),
+            }
+        }]
+    })
+}
+
+fn finding_to_result(root_dir: &Path, finding: &maximus_core::Finding) -> Value {
+    let level = match finding.severity {
+        Severity::Error => "error",
+        Severity::Warn => "warning",
+        Severity::Info => "note",
+    };
+
+    json!({
+        "ruleId": finding.category,
+        "level": level,
+        "message": {
+            "text": if finding.detail.is_empty() {
+                finding.title.clone()
+            } else {
+                format!("{}: {}", finding.title, finding.detail)
+            }
+        },
+        "locations": finding.file.as_ref().map(|file| vec![json!({
+            "physicalLocation": {
+                "artifactLocation": {
+                    "uri": format_relative_file(root_dir, file),
+                }
+            }
+        })]).unwrap_or_default(),
+        "properties": {
+            "findingId": finding.id,
+            "category": finding.category,
+            "title": finding.title,
+            "detail": finding.detail,
+            "hint": finding.hint,
+            "fixable": finding.fixable,
+            "fixIds": finding.fix_ids,
+        }
+    })
+}
+
+fn serializable_applied_fixes(applied: &[AppliedFix]) -> Vec<Value> {
+    applied
+        .iter()
+        .map(|fix| {
+            json!({
+                "id": fix.id,
+                "title": fix.title,
+                "files": fix.files,
+                "outcome": fix.outcome,
+            })
+        })
+        .collect()
+}
+
+fn serializable_previewed_fixes(previews: &[PreviewedFix]) -> Vec<Value> {
+    previews
+        .iter()
+        .map(|preview| {
+            json!({
+                "id": preview.id,
+                "title": preview.title,
+                "files": preview.files,
+                "diffs": preview.previews.iter().map(|file| json!({
+                    "path": file.path,
+                    "existedBefore": file.existed_before,
+                    "before": file.before,
+                    "after": file.after,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect()
+}
+
+fn format_relative_file(root_dir: &Path, file_path: &Path) -> String {
+    relative_path_like_js(root_dir, file_path)
+        .map(|value| {
+            if value.is_empty() {
+                ".".to_string()
+            } else {
+                value
+            }
+        })
+        .unwrap_or_else(|| display_path(file_path))
+}
+
+fn relative_path_like_js(root_dir: &Path, file_path: &Path) -> Option<String> {
+    if root_dir == file_path {
+        return Some(String::new());
+    }
+
+    if let Ok(relative) = file_path.strip_prefix(root_dir) {
+        return Some(path_string(relative));
+    }
+
+    let root_components = root_dir.components().collect::<Vec<_>>();
+    let file_components = file_path.components().collect::<Vec<_>>();
+
+    let mut shared_len = 0usize;
+    while shared_len < root_components.len()
+        && shared_len < file_components.len()
+        && root_components[shared_len] == file_components[shared_len]
+    {
+        shared_len += 1;
+    }
+
+    if shared_len == 0 {
+        return None;
+    }
+
+    let mut relative = std::path::PathBuf::new();
+
+    for component in &root_components[shared_len..] {
+        if matches!(component, std::path::Component::Normal(_)) {
+            relative.push("..");
+        }
+    }
+
+    for component in &file_components[shared_len..] {
+        relative.push(component.as_os_str());
+    }
+
+    Some(path_string(&relative))
+}
+
+fn display_path(path: &Path) -> String {
+    path_string(path)
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use maximus_core::{
+        AppliedFix, AuditResult, AuditSummary, Finding, PreviewedFix, Severity, StructureReport,
+    };
+    use serde_json::Value;
+
+    use super::{render_audit_result, render_doctor_result, render_fix_result};
+
+    #[test]
+    fn audit_sarif_contains_expected_top_level_shape() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_audit_result(&result).expect("sarif should render");
+        let value: Value = serde_json::from_str(&json).expect("sarif should parse");
+
+        assert_eq!(value["version"], "2.1.0");
+        assert_eq!(value["runs"][0]["tool"]["driver"]["name"], "maximus");
+        assert_eq!(value["runs"][0]["properties"]["reportKind"], "audit");
+        assert_eq!(value["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn doctor_sarif_labels_report_kind_as_doctor() {
+        let result = sample_result(PathBuf::from("/tmp/project"));
+        let json = render_doctor_result(&result).expect("sarif should render");
+        let value: Value = serde_json::from_str(&json).expect("sarif should parse");
+
+        assert_eq!(value["runs"][0]["properties"]["reportKind"], "doctor");
+    }
+
+    #[test]
+    fn fix_sarif_includes_fix_properties() {
+        let root_dir = PathBuf::from("/tmp/project");
+        let result = AuditResult {
+            root_dir: root_dir.clone(),
+            summary: AuditSummary {
+                status: "clean".to_string(),
+                total_findings: 0,
+                blocking_findings: 0,
+                warning_findings: 0,
+                info_findings: 0,
+                fixable_findings: 0,
+                fixes_available: 0,
+                config_files: 1,
+                package_count: 1,
+                env_directories: 0,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 0,
+                config_files: 1,
+                recommendations: Vec::new(),
+            },
+            findings: vec![Finding {
+                id: "env-1".to_string(),
+                severity: Severity::Warn,
+                category: "env".to_string(),
+                title: "Missing example".to_string(),
+                detail: "create .env.example".to_string(),
+                file: Some(root_dir.join(".env.example")),
+                hint: "run maximus fix".to_string(),
+                fixable: true,
+                fix_ids: vec!["env-create-example".to_string()],
+            }],
+            fixes: Vec::new(),
+        };
+
+        let json = render_fix_result(
+            true,
+            &root_dir,
+            &result,
+            &[AppliedFix {
+                id: "env-1".to_string(),
+                title: "Create .env.example".to_string(),
+                files: vec![root_dir.join(".env.example")],
+                outcome: "created".to_string(),
+            }],
+            &result,
+            Some(&[PreviewedFix {
+                id: "env-1".to_string(),
+                title: "Create .env.example".to_string(),
+                files: vec![root_dir.join(".env.example")],
+                previews: vec![maximus_core::FixFilePreview {
+                    path: root_dir.join(".env.example"),
+                    existed_before: false,
+                    before: String::new(),
+                    after: "API_URL=\n".to_string(),
+                }],
+            }]),
+        )
+        .expect("sarif should render");
+        let value: Value = serde_json::from_str(&json).expect("sarif should parse");
+
+        assert_eq!(value["runs"][0]["properties"]["reportKind"], "fix");
+        assert_eq!(value["runs"][0]["properties"]["dryRun"], true);
+        assert_eq!(
+            value["runs"][0]["properties"]["applied"][0]["outcome"],
+            "created"
+        );
+        assert_eq!(value["runs"][0]["results"][0]["ruleId"], "env");
+    }
+
+    fn sample_result(root_dir: PathBuf) -> AuditResult {
+        AuditResult {
+            root_dir,
+            summary: AuditSummary {
+                status: "clean".to_string(),
+                total_findings: 0,
+                blocking_findings: 0,
+                warning_findings: 0,
+                info_findings: 0,
+                fixable_findings: 0,
+                fixes_available: 0,
+                config_files: 1,
+                package_count: 1,
+                env_directories: 0,
+            },
+            structure: StructureReport {
+                is_monorepo: false,
+                package_count: 1,
+                env_directories: 0,
+                config_files: 1,
+                recommendations: vec![
+                    "Current config surface looks healthy. Keep shared rules centralized as the repo grows."
+                        .to_string(),
+                ],
+            },
+            findings: Vec::new(),
+            fixes: Vec::new(),
+        }
+    }
+}

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -11,9 +11,9 @@ pub fn format_help() -> String {
         "Bring order to chaotic configs.",
         "",
         "Usage",
-        "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-        "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+        "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+        "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
         "  maximus help",
     ]
     .join("\n")
@@ -370,9 +370,9 @@ mod tests {
                 "Bring order to chaotic configs.",
                 "",
                 "Usage",
-                "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-                "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+                "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+                "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
                 "  maximus help",
             ]
             .join("\n")

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -22,9 +22,9 @@ fn no_args_prints_help() {
             "Bring order to chaotic configs.",
             "",
             "Usage",
-            "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-            "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]",
-            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--json]",
+            "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+            "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
+            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
             "  maximus help",
             "",
         ]
@@ -43,7 +43,7 @@ fn help_subcommand_prints_usage() {
     assert!(String::from_utf8(output.stdout)
         .expect("stdout should be utf8")
         .contains(
-            "maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--json]"
+            "maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]"
         ));
 }
 
@@ -65,6 +65,65 @@ fn audit_json_routes_to_clean_skeleton_result() {
     assert_eq!(value["structure"]["configFiles"], 1);
     assert_eq!(value["findings"], Value::Array(Vec::new()));
     assert_eq!(value["fixes"], Value::Array(Vec::new()));
+}
+
+#[test]
+fn audit_format_markdown_routes_to_markdown_report() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.to_string_lossy().as_ref(),
+            "--format",
+            "markdown",
+        ])
+        .output()
+        .expect("audit markdown should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.starts_with("# Maximus audit\n"));
+    assert!(stdout.contains("- Status: `clean`"));
+}
+
+#[test]
+fn audit_format_sarif_routes_to_sarif_report() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.to_string_lossy().as_ref(),
+            "--format",
+            "sarif",
+        ])
+        .output()
+        .expect("audit sarif should run");
+
+    assert!(output.status.success());
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("audit sarif output should be valid");
+    assert_eq!(value["version"], "2.1.0");
+    assert_eq!(value["runs"][0]["properties"]["reportKind"], "audit");
+}
+
+#[test]
+fn doctor_format_sarif_routes_to_doctor_sarif_report() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args([
+            "doctor",
+            fixture.to_string_lossy().as_ref(),
+            "--format",
+            "sarif",
+        ])
+        .output()
+        .expect("doctor sarif should run");
+
+    assert!(output.status.success());
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("doctor sarif output should be valid");
+    assert_eq!(value["version"], "2.1.0");
+    assert_eq!(value["runs"][0]["properties"]["reportKind"], "doctor");
 }
 
 #[test]
@@ -211,6 +270,27 @@ fn fix_dry_run_json_keeps_js_top_level_contract() {
     assert!(value.get("initial").is_some());
     assert!(value.get("applied").is_some());
     assert!(value.get("final").is_some());
+}
+
+#[test]
+fn fix_format_sarif_fails_closed() {
+    let fixture = fixture_path();
+    let output = maximus_bin()
+        .args([
+            "fix",
+            fixture.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--format",
+            "sarif",
+        ])
+        .output()
+        .expect("fix sarif rejection should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "Maximus failed: Option \"--format sarif\" is only available for \"audit\" and \"doctor\".\n"
+    );
 }
 
 #[test]

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -303,6 +303,66 @@ test("wrapper blocks the frozen JS fallback when Rust-only flags are requested",
   assert.match(result.stderr, /--only/);
 });
 
+test("wrapper blocks output format flags on the frozen JS fallback", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-format-flag-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    ".",
+    "--format",
+    "json",
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required/);
+  assert.match(result.stderr, /--format/);
+
+  const leadingResult = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "--format",
+    "json",
+    "audit",
+    ".",
+  ]);
+
+  assert.equal(leadingResult.code, 1);
+  assert.equal(leadingResult.stdout.trim(), "");
+  assert.match(leadingResult.stderr, /A Rust runtime is required/);
+  assert.match(leadingResult.stderr, /--format/);
+});
+
 test("wrapper treats dash-prefixed paths as positionals on the frozen JS fallback", async (t) => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-dash-path-"));
   t.after(async () => {
@@ -392,6 +452,59 @@ test("wrapper blocks the frozen JS fallback when a Maximus config file is presen
   );
 
   const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /A Rust runtime is required when a Maximus config file is present/);
+  assert.match(result.stderr, /maximus\.config\.json/);
+});
+
+test("wrapper blocks the frozen JS fallback for doctor target config files", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-wrapper-doctor-config-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  const targetDir = path.join(rootDir, "target-project");
+  await mkdir(path.join(rootDir, "bin"), { recursive: true });
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(targetDir, { recursive: true });
+
+  await cp(path.join(process.cwd(), "bin", "maximus.js"), path.join(rootDir, "bin", "maximus.js"));
+  await writeFile(
+    path.join(rootDir, "src", "cli.js"),
+    [
+      "export async function runCli(args) {",
+      "  console.log(JSON.stringify({ runtime: 'js', args }));",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    path.join(targetDir, "maximus.config.json"),
+    '{ "checks": { "only": ["env"] } }\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "bootstrap.mjs"),
+    [
+      'import path from "node:path";',
+      'import { pathToFileURL } from "node:url";',
+      "",
+      'Object.defineProperty(process, "platform", { value: "win32" });',
+      'Object.defineProperty(process, "arch", { value: "x64" });',
+      "",
+      'await import(pathToFileURL(path.join(process.cwd(), "bin", "maximus.js")));',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "doctor",
+    targetDir,
+  ]);
 
   assert.equal(result.code, 1);
   assert.equal(result.stdout.trim(), "");
@@ -621,6 +734,7 @@ test("wrapper prints help before checking config files on the frozen JS fallback
   assert.match(result.stdout, /Usage/);
   assert.match(result.stdout, /maximus fix \[path\] --dry-run \[--json\]/);
   assert.doesNotMatch(result.stdout, /--only <checks>/);
+  assert.match(result.stdout, /--format.*require the Rust runtime/);
   assert.match(result.stdout, /require the Rust runtime/);
   assert.equal(result.stderr.trim(), "");
 });


### PR DESCRIPTION
## 요약
- CLI에 `--format text|json|markdown|sarif` 출력 계약을 추가합니다.
- audit/doctor markdown 및 SARIF 출력을 지원하고, 기존 `--json` 호환은 유지합니다.
- `fix --format sarif`는 fail-closed로 막고, doctor SARIF는 `reportKind: doctor`로 라벨링합니다.

## 검증
- `cargo test -p maximus-cli --test cli_help`
- `cargo test -p maximus-cli --test config_and_filtering`
- `cargo test -p maximus-cli --test mvp_parity`
- `$devils-advocate-review-loop` 재리뷰: Critical/High 없음

Closes #69
