### PR TITLE
fix: env gitignore 보호 규칙 보정

### DIFF
--- a/crates/maximus-checks/src/env.rs
+++ b/crates/maximus-checks/src/env.rs
@@ -1,12 +1,13 @@
 use std::collections::BTreeSet;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use maximus_core::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, make_finding,
     parse_env, plan_create_env_example, plan_sync_env_example, read_text_if_exists,
-    render_env_template, sort_findings, unique_fixes, FileKind, FindingInput, FixPlan,
-    ProjectFile, ProjectSnapshot, Severity,
+    render_env_template, sort_findings, unique_fixes, FileKind, FindingInput, FixPlan, ProjectFile,
+    ProjectSnapshot, Severity,
 };
 
 use crate::check_outcome::CheckOutcome;
@@ -15,6 +16,7 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
     let mut findings = Vec::new();
     let mut fixes = Vec::new();
     let mut planned_fixes = Vec::new();
+    let gitignore_traversal_root = find_gitignore_traversal_root(&project.root_dir);
 
     for directory in &project.directories {
         let env_files = directory
@@ -63,8 +65,7 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                     fix_ids: Vec::new(),
                     fixable: false,
                     hint: Some(
-                        "Keep one declaration per env file so overrides stay explicit."
-                            .to_string(),
+                        "Keep one declaration per env file so overrides stay explicit.".to_string(),
                     ),
                     severity: Some(Severity::Error),
                 }));
@@ -112,6 +113,41 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
             .collect::<Vec<_>>();
         let contract_keys = collect_contract_keys(&concrete_records);
 
+        let gitignore_sources =
+            read_ancestor_gitignore_sources(&gitignore_traversal_root, &directory.dir)?;
+
+        for record in &concrete_records {
+            let is_tracked = is_path_tracked_by_git(&gitignore_traversal_root, &record.file.path);
+            let is_protected = !is_tracked
+                && is_path_protected_by_exact_gitignore(&gitignore_sources, &record.file.path);
+
+            if is_protected {
+                continue;
+            }
+
+            findings.push(make_finding(FindingInput {
+                id: format!("env-gitignore:{}", record.file.path.to_string_lossy()),
+                title: format!(
+                    "Concrete env file \"{}\" is not protected by .gitignore",
+                    record.file.name
+                ),
+                category: Some("env".to_string()),
+                detail: Some(format_gitignore_protection_hint(
+                    &project.root_dir,
+                    &directory.dir,
+                    &record.file.path,
+                )),
+                file: Some(record.file.path.clone()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Protect concrete env files with an exact .gitignore entry before committing secrets."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+
         if !contract_keys.is_empty() && example_record.is_none() {
             let output_path = directory.dir.join(".env.example");
 
@@ -120,7 +156,9 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                 title: "Missing .env.example contract".to_string(),
                 category: Some("env".to_string()),
                 detail: Some("Runtime env files exist, but .env.example is missing.".to_string()),
-                file: concrete_records.first().map(|record| record.file.path.clone()),
+                file: concrete_records
+                    .first()
+                    .map(|record| record.file.path.clone()),
                 fix_ids: vec![format!(
                     "env-example:create:{}",
                     directory.dir.to_string_lossy()
@@ -260,7 +298,9 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
             }
         }
 
-        let base_env = parsed_records.iter().find(|record| record.file.name == ".env");
+        let base_env = parsed_records
+            .iter()
+            .find(|record| record.file.name == ".env");
         let local_env = parsed_records
             .iter()
             .find(|record| record.file.name == ".env.local");
@@ -373,4 +413,333 @@ fn score_contract_record(file_name: &str) -> usize {
         ".env.dist" => 3,
         _ => 4,
     }
+}
+
+fn find_gitignore_traversal_root(root_dir: &Path) -> PathBuf {
+    let mut current = Some(root_dir);
+
+    while let Some(dir) = current {
+        if std::fs::symlink_metadata(dir.join(".git")).is_ok() {
+            return dir.to_path_buf();
+        }
+
+        current = dir.parent();
+    }
+
+    root_dir.to_path_buf()
+}
+
+fn read_ancestor_gitignore_sources(
+    root_dir: &Path,
+    directory_dir: &Path,
+) -> io::Result<Vec<(PathBuf, String)>> {
+    let mut sources = Vec::new();
+    let mut current = root_dir.to_path_buf();
+
+    loop {
+        if let Some(text) = read_text_if_exists(&current.join(".gitignore"))? {
+            sources.push((current.clone(), text));
+        }
+
+        if current == directory_dir {
+            break;
+        }
+
+        let Ok(relative) = directory_dir.strip_prefix(root_dir) else {
+            break;
+        };
+        let next_depth = current
+            .strip_prefix(root_dir)
+            .ok()
+            .map(|path| path.components().count() + 1)
+            .unwrap_or(1);
+        let Some(next_component) = relative.components().nth(next_depth - 1) else {
+            break;
+        };
+        current.push(next_component.as_os_str());
+    }
+
+    Ok(sources)
+}
+
+fn is_path_protected_by_exact_gitignore(
+    gitignore_sources: &[(PathBuf, String)],
+    target_path: &Path,
+) -> bool {
+    let mut protected = None;
+    let file_name = target_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    for (ignore_root, gitignore_text) in gitignore_sources {
+        let relative_path = normalize_path(
+            target_path
+                .strip_prefix(ignore_root)
+                .unwrap_or(target_path)
+                .to_string_lossy()
+                .as_ref(),
+        );
+
+        for pattern in parse_exact_gitignore_patterns(gitignore_text) {
+            if pattern_matches_file(&pattern, &relative_path, &file_name) {
+                protected = Some(!pattern.negated);
+            }
+        }
+    }
+
+    protected.unwrap_or(false)
+}
+
+fn is_path_tracked_by_git(repo_root: &Path, target_path: &Path) -> bool {
+    let Ok(relative_path) = target_path.strip_prefix(repo_root) else {
+        return false;
+    };
+
+    Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("ls-files")
+        .arg("--error-unmatch")
+        .arg("--")
+        .arg(relative_path)
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+struct ExactGitignorePattern {
+    pattern: String,
+    negated: bool,
+    anchored: bool,
+    directory_only: bool,
+}
+
+fn parse_exact_gitignore_patterns(text: &str) -> Vec<ExactGitignorePattern> {
+    text.lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| {
+            let negated = line.starts_with('!');
+            let raw_pattern = line.strip_prefix('!').unwrap_or(line);
+            let Some(pattern) = normalize_gitignore_pattern(raw_pattern) else {
+                return None;
+            };
+            Some(ExactGitignorePattern {
+                pattern: pattern.value,
+                negated,
+                anchored: pattern.anchored,
+                directory_only: pattern.directory_only,
+            })
+        })
+        .collect()
+}
+
+fn format_gitignore_protection_hint(
+    root_dir: &Path,
+    directory_dir: &Path,
+    file_path: &Path,
+) -> String {
+    let current_gitignore_display =
+        relative_display_path(root_dir, &directory_dir.join(".gitignore"));
+    let current_pattern = file_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let root_pattern = relative_display_path(root_dir, file_path);
+
+    if directory_dir == root_dir || root_pattern == current_pattern {
+        return format!(
+            r#"Add "{}" to {}."#,
+            current_pattern, current_gitignore_display
+        );
+    }
+
+    format!(
+        r#"Add "{}" to {} or "{}" to .gitignore."#,
+        current_pattern, current_gitignore_display, root_pattern
+    )
+}
+
+struct NormalizedGitignorePattern {
+    value: String,
+    anchored: bool,
+    directory_only: bool,
+}
+
+fn normalize_gitignore_pattern(pattern: &str) -> Option<NormalizedGitignorePattern> {
+    let normalized = normalize_path(pattern).trim_start_matches("./").to_string();
+    let anchored = normalized.starts_with('/');
+    let directory_only = normalized.ends_with('/');
+    let value = normalized
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string();
+
+    if value.is_empty() {
+        return None;
+    }
+
+    Some(NormalizedGitignorePattern {
+        value,
+        anchored,
+        directory_only,
+    })
+}
+
+fn pattern_matches_file(
+    pattern: &ExactGitignorePattern,
+    relative_path: &str,
+    file_name: &str,
+) -> bool {
+    if pattern.directory_only {
+        return directory_pattern_matches_file(pattern, relative_path);
+    }
+
+    directory_pattern_matches_file(pattern, relative_path)
+        || gitignore_pattern_matches(&pattern.pattern, relative_path)
+        || (!pattern.anchored
+            && !pattern.pattern.contains('/')
+            && gitignore_pattern_matches(&pattern.pattern, file_name))
+}
+
+fn directory_pattern_matches_file(pattern: &ExactGitignorePattern, relative_path: &str) -> bool {
+    let Some((directory_path, _)) = relative_path.rsplit_once('/') else {
+        return false;
+    };
+    let directories = directory_ancestors(directory_path);
+
+    if !pattern.anchored && !pattern.pattern.contains('/') {
+        return directories.iter().any(|directory| {
+            Path::new(directory)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| gitignore_pattern_matches(&pattern.pattern, name))
+        });
+    }
+
+    directories
+        .iter()
+        .any(|directory| gitignore_pattern_matches(&pattern.pattern, directory))
+}
+
+fn directory_ancestors(directory_path: &str) -> Vec<String> {
+    let mut directories = Vec::new();
+    let mut current = String::new();
+
+    for segment in directory_path.split('/') {
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(segment);
+        directories.push(current.clone());
+    }
+
+    directories
+}
+
+fn gitignore_pattern_matches(pattern: &str, value: &str) -> bool {
+    let pattern_chars = pattern.chars().collect::<Vec<_>>();
+    let value_chars = value.chars().collect::<Vec<_>>();
+    let mut memo = vec![vec![None; value_chars.len() + 1]; pattern_chars.len() + 1];
+
+    fn matches(
+        pattern_index: usize,
+        value_index: usize,
+        pattern_chars: &[char],
+        value_chars: &[char],
+        memo: &mut [Vec<Option<bool>>],
+    ) -> bool {
+        if let Some(result) = memo[pattern_index][value_index] {
+            return result;
+        }
+
+        let result = if pattern_index >= pattern_chars.len() {
+            value_index >= value_chars.len()
+        } else if pattern_index + 1 < pattern_chars.len()
+            && pattern_chars[pattern_index] == '*'
+            && pattern_chars[pattern_index + 1] == '*'
+        {
+            let after_globstar = pattern_index + 2;
+            if after_globstar < pattern_chars.len() && pattern_chars[after_globstar] == '/' {
+                let mut matched = matches(
+                    after_globstar + 1,
+                    value_index,
+                    pattern_chars,
+                    value_chars,
+                    memo,
+                );
+                let mut index = value_index;
+                while !matched && index < value_chars.len() {
+                    if value_chars[index] == '/' {
+                        matched = matches(
+                            after_globstar + 1,
+                            index + 1,
+                            pattern_chars,
+                            value_chars,
+                            memo,
+                        );
+                    }
+                    index += 1;
+                }
+                matched
+            } else {
+                let mut matched = false;
+                let mut index = value_index;
+                while !matched && index <= value_chars.len() {
+                    matched = matches(after_globstar, index, pattern_chars, value_chars, memo);
+                    index += 1;
+                }
+                matched
+            }
+        } else if pattern_chars[pattern_index] == '*' {
+            let mut matched = matches(
+                pattern_index + 1,
+                value_index,
+                pattern_chars,
+                value_chars,
+                memo,
+            );
+            let mut index = value_index;
+            while !matched && index < value_chars.len() && value_chars[index] != '/' {
+                matched = matches(
+                    pattern_index + 1,
+                    index + 1,
+                    pattern_chars,
+                    value_chars,
+                    memo,
+                );
+                index += 1;
+            }
+            matched
+        } else if pattern_chars[pattern_index] == '?' {
+            value_index < value_chars.len()
+                && value_chars[value_index] != '/'
+                && matches(
+                    pattern_index + 1,
+                    value_index + 1,
+                    pattern_chars,
+                    value_chars,
+                    memo,
+                )
+        } else {
+            value_index < value_chars.len()
+                && pattern_chars[pattern_index] == value_chars[value_index]
+                && matches(
+                    pattern_index + 1,
+                    value_index + 1,
+                    pattern_chars,
+                    value_chars,
+                    memo,
+                )
+        };
+
+        memo[pattern_index][value_index] = Some(result);
+        result
+    }
+
+    matches(0, 0, &pattern_chars, &value_chars, &mut memo)
+}
+
+fn normalize_path(value: &str) -> String {
+    value.replace('\\', "/")
 }

--- a/crates/maximus-checks/tests/env_checks.rs
+++ b/crates/maximus-checks/tests/env_checks.rs
@@ -1,17 +1,19 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-#[path = "../src/env.rs"]
-mod env;
 #[path = "../src/check_outcome.rs"]
 mod check_outcome;
+#[path = "../src/env.rs"]
+mod env;
 
 use env::{render_created_env_example, render_synced_env_example, run_env_check};
 use maximus_core::{apply_fix, discover_project, FixOperation, FixPlan, Severity};
 use tempfile::TempDir;
 
 #[test]
-fn env_check_matches_js_findings_for_duplicates_invalid_sync_secret_override_and_missing_concrete() {
+fn env_check_matches_js_findings_for_duplicates_invalid_sync_secret_override_and_missing_concrete()
+{
     let fixture = TempDir::new().expect("temp dir should exist");
 
     write(
@@ -46,7 +48,10 @@ fn env_check_matches_js_findings_for_duplicates_invalid_sync_secret_override_and
     );
     assert_has_finding(
         &outcome.findings,
-        &format!("env-invalid:{}:4", fixture.path().join(".env").to_string_lossy()),
+        &format!(
+            "env-invalid:{}:4",
+            fixture.path().join(".env").to_string_lossy()
+        ),
         Severity::Warn,
         "Invalid env syntax",
         "Line 4 could not be parsed as KEY=value.",
@@ -64,7 +69,10 @@ fn env_check_matches_js_findings_for_duplicates_invalid_sync_secret_override_and
         "Run \"maximus fix\" to append the missing keys to .env.example.",
         Some(fixture.path().join(".env.example")),
         true,
-        &[format!("env-example:sync:{}", fixture.path().to_string_lossy())],
+        &[format!(
+            "env-example:sync:{}",
+            fixture.path().to_string_lossy()
+        )],
     );
     assert_has_finding(
         &outcome.findings,
@@ -149,6 +157,320 @@ fn env_check_plans_example_creation_when_runtime_env_files_exist_without_contrac
 }
 
 #[test]
+fn env_check_reports_unprotected_concrete_env_files_and_respects_root_and_nested_gitignore_entries()
+{
+    let root_fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        root_fixture.path().join(".env"),
+        "API_URL=https://example.test\n",
+    );
+
+    let root_project = discover_project(root_fixture.path()).expect("project should discover");
+    let root_outcome = run_env_check(&root_project).expect("check should run");
+
+    assert_has_finding(
+        &root_outcome.findings,
+        &format!(
+            "env-gitignore:{}",
+            root_fixture.path().join(".env").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Concrete env file \".env\" is not protected by .gitignore",
+        "Add \".env\" to .gitignore.",
+        "Protect concrete env files with an exact .gitignore entry before committing secrets.",
+        Some(root_fixture.path().join(".env")),
+        false,
+        &[],
+    );
+
+    write(root_fixture.path().join(".gitignore"), ".env\n");
+    let protected_project = discover_project(root_fixture.path()).expect("project should discover");
+    let protected_outcome = run_env_check(&protected_project).expect("check should run");
+
+    assert!(
+        !protected_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "root .gitignore should protect .env"
+    );
+
+    write(root_fixture.path().join(".gitignore"), ".env\n!.env\n");
+    let negated_project = discover_project(root_fixture.path()).expect("project should discover");
+    let negated_outcome = run_env_check(&negated_project).expect("check should run");
+
+    assert!(
+        negated_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "later .gitignore negation should make .env unprotected"
+    );
+
+    let leading_space_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        leading_space_fixture.path().join(".env"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(leading_space_fixture.path().join(".gitignore"), " .env\n");
+
+    let leading_space_project =
+        discover_project(leading_space_fixture.path()).expect("project should discover");
+    let leading_space_outcome = run_env_check(&leading_space_project).expect("check should run");
+
+    assert!(
+        leading_space_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "leading-space .gitignore pattern should not protect .env"
+    );
+
+    let glob_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        glob_fixture.path().join(".env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(glob_fixture.path().join(".env.example"), "API_TOKEN=\n");
+    write(
+        glob_fixture.path().join(".gitignore"),
+        ".env*\n!.env.example\n",
+    );
+
+    let glob_project = discover_project(glob_fixture.path()).expect("project should discover");
+    let glob_outcome = run_env_check(&glob_project).expect("check should run");
+
+    assert!(
+        !glob_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "glob .gitignore pattern should protect .env.local"
+    );
+
+    let globstar_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        globstar_fixture.path().join("apps/web/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        globstar_fixture.path().join(".gitignore"),
+        "**/.env.local\n",
+    );
+
+    let globstar_project =
+        discover_project(globstar_fixture.path()).expect("project should discover");
+    let globstar_outcome = run_env_check(&globstar_project).expect("check should run");
+
+    assert!(
+        !globstar_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "globstar .gitignore pattern should protect nested .env.local"
+    );
+
+    let directory_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        directory_fixture.path().join("apps/web/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(directory_fixture.path().join(".gitignore"), "apps/\n");
+
+    let directory_project =
+        discover_project(directory_fixture.path()).expect("project should discover");
+    let directory_outcome = run_env_check(&directory_project).expect("check should run");
+
+    assert!(
+        !directory_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "directory-only .gitignore pattern should protect files under that directory"
+    );
+
+    let bare_directory_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        bare_directory_fixture.path().join("secrets/.env"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        bare_directory_fixture.path().join(".gitignore"),
+        "secrets\n",
+    );
+
+    let bare_directory_project =
+        discover_project(bare_directory_fixture.path()).expect("project should discover");
+    let bare_directory_outcome = run_env_check(&bare_directory_project).expect("check should run");
+
+    assert!(
+        !bare_directory_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "bare directory .gitignore pattern should protect files under that directory"
+    );
+
+    let tracked_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        tracked_fixture.path().join(".env"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(tracked_fixture.path().join(".gitignore"), ".env\n");
+    run_git(tracked_fixture.path(), &["init"]);
+    run_git(tracked_fixture.path(), &["add", "-f", ".env"]);
+
+    let tracked_project =
+        discover_project(tracked_fixture.path()).expect("project should discover");
+    let tracked_outcome = run_env_check(&tracked_project).expect("check should run");
+
+    assert!(
+        tracked_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "tracked concrete env files should not be treated as protected by .gitignore"
+    );
+
+    let nested_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        nested_fixture.path().join("apps/web/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        nested_fixture.path().join("apps/web/.gitignore"),
+        ".env.local\n",
+    );
+
+    let nested_project = discover_project(nested_fixture.path()).expect("project should discover");
+    let nested_outcome = run_env_check(&nested_project).expect("check should run");
+
+    assert!(
+        !nested_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "nested .gitignore should protect .env.local"
+    );
+
+    let ancestor_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        ancestor_fixture.path().join("apps/web/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        ancestor_fixture.path().join("apps/.gitignore"),
+        ".env.local\n",
+    );
+
+    let ancestor_project =
+        discover_project(ancestor_fixture.path()).expect("project should discover");
+    let ancestor_outcome = run_env_check(&ancestor_project).expect("check should run");
+
+    assert!(
+        !ancestor_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "ancestor .gitignore should protect nested .env.local"
+    );
+
+    let subdir_audit_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        subdir_audit_fixture.path().join(".git/HEAD"),
+        "ref: refs/heads/main\n",
+    );
+    write(
+        subdir_audit_fixture.path().join(".gitignore"),
+        "packages/app/.env.local\n",
+    );
+    write(
+        subdir_audit_fixture.path().join("packages/app/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+
+    let subdir_project = discover_project(subdir_audit_fixture.path().join("packages/app"))
+        .expect("project should discover");
+    let subdir_outcome = run_env_check(&subdir_project).expect("check should run");
+
+    assert!(
+        !subdir_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "repo root .gitignore should protect subdir audit targets"
+    );
+
+    let anchored_nested_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        anchored_nested_fixture.path().join("apps/web/.env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        anchored_nested_fixture.path().join(".gitignore"),
+        "/.env.local\n",
+    );
+
+    let anchored_nested_project =
+        discover_project(anchored_nested_fixture.path()).expect("project should discover");
+    let anchored_nested_outcome =
+        run_env_check(&anchored_nested_project).expect("check should run");
+
+    assert!(
+        anchored_nested_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "anchored root .gitignore pattern should not protect nested .env.local"
+    );
+
+    let anchored_root_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        anchored_root_fixture.path().join(".env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        anchored_root_fixture.path().join(".gitignore"),
+        "/.env.local\n",
+    );
+
+    let anchored_root_project =
+        discover_project(anchored_root_fixture.path()).expect("project should discover");
+    let anchored_root_outcome = run_env_check(&anchored_root_project).expect("check should run");
+
+    assert!(
+        !anchored_root_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "anchored root .gitignore pattern should protect root .env.local"
+    );
+
+    let directory_only_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        directory_only_fixture.path().join(".env.local"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        directory_only_fixture.path().join(".gitignore"),
+        ".env.local/\n",
+    );
+
+    let directory_only_project =
+        discover_project(directory_only_fixture.path()).expect("project should discover");
+    let directory_only_outcome = run_env_check(&directory_only_project).expect("check should run");
+
+    assert!(
+        directory_only_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "directory-only .gitignore pattern should not protect env files"
+    );
+}
+
+#[test]
 fn env_sync_planned_fix_uses_audited_snapshot_text() {
     let fixture = TempDir::new().expect("temp dir should exist");
     let example_path = fixture.path().join(".env.example");
@@ -161,7 +483,9 @@ fn env_sync_planned_fix_uses_audited_snapshot_text() {
     let planned = outcome
         .planned_fixes
         .iter()
-        .find(|fix| fix.public.id == format!("env-example:sync:{}", fixture.path().to_string_lossy()))
+        .find(|fix| {
+            fix.public.id == format!("env-example:sync:{}", fixture.path().to_string_lossy())
+        })
         .expect("planned sync fix should exist")
         .clone();
 
@@ -191,16 +515,12 @@ fn env_example_render_helpers_match_js_create_and_sync_semantics() {
         "ALPHA=\nZETA=\n"
     );
 
-    let synced = render_synced_env_example(
-        "PRIMARY=\n",
-        &["ZETA".to_string(), "ALPHA".to_string()],
-    );
+    let synced =
+        render_synced_env_example("PRIMARY=\n", &["ZETA".to_string(), "ALPHA".to_string()]);
     assert_eq!(synced, "PRIMARY=\nALPHA=\nZETA=\n");
 
-    let synced_without_trailing_newline = render_synced_env_example(
-        "PRIMARY=",
-        &["ZETA".to_string(), "ALPHA".to_string()],
-    );
+    let synced_without_trailing_newline =
+        render_synced_env_example("PRIMARY=", &["ZETA".to_string(), "ALPHA".to_string()]);
     assert_eq!(synced_without_trailing_newline, "PRIMARY=\nALPHA=\nZETA=\n");
 
     let synced_with_js_like_locale_order = render_synced_env_example(
@@ -291,20 +611,23 @@ fn env_contract_matrix_local_only_fixture_creates_example_contract() {
     let planned = outcome
         .planned_fixes
         .iter()
-        .find(|fix| fix.public.id == format!("env-example:create:{}", fixture.path().to_string_lossy()))
+        .find(|fix| {
+            fix.public.id == format!("env-example:create:{}", fixture.path().to_string_lossy())
+        })
         .expect("planned create fix should exist")
         .clone();
 
     apply_fix(&planned).expect("planned fix should apply");
 
-    let output = fs::read_to_string(fixture.path().join(".env.example"))
-        .expect("example file should exist");
+    let output =
+        fs::read_to_string(fixture.path().join(".env.example")).expect("example file should exist");
     assert_eq!(output, "API_URL=\nAUTH_TOKEN=\n");
 }
 
 #[test]
 fn env_template_order_preservation_fixtures_match_js_outputs() {
-    let create_fixture = copy_fixture_to_temp("env-template-order-preservation/create-from-concrete");
+    let create_fixture =
+        copy_fixture_to_temp("env-template-order-preservation/create-from-concrete");
     let create_project = discover_project(create_fixture.path()).expect("project should discover");
     let create_outcome = run_env_check(&create_project).expect("check should run");
     let create_fix = create_outcome
@@ -321,7 +644,8 @@ fn env_template_order_preservation_fixtures_match_js_outputs() {
         "API_URL=\nAPI-URL=\nAPI.URL=\nVAR_1=\nVAR_10=\nVAR_2=\n"
     );
 
-    let sync_fixture = copy_fixture_to_temp("env-template-order-preservation/sync-existing-template");
+    let sync_fixture =
+        copy_fixture_to_temp("env-template-order-preservation/sync-existing-template");
     let sync_project = discover_project(sync_fixture.path()).expect("project should discover");
     let sync_outcome = run_env_check(&sync_project).expect("check should run");
     let sync_fix = sync_outcome
@@ -346,6 +670,15 @@ fn write(path: impl AsRef<Path>, content: &str) {
     }
 
     fs::write(path, content).expect("fixture file should write");
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git command should run");
+    assert!(output.status.success(), "{output:?}");
 }
 
 fn fixture_root(relative_path: &str) -> PathBuf {

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -623,15 +623,13 @@ fn composite_project_reference_is_blocking_under_fail_on_error() {
         ),
         "error"
     );
-    assert!(
-        finding_field(
-            findings[0]
-                .as_object()
-                .expect("finding should be an object"),
-            "id"
-        )
-        .contains(":composite")
-    );
+    assert!(finding_field(
+        findings[0]
+            .as_object()
+            .expect("finding should be an object"),
+        "id"
+    )
+    .contains(":composite"));
 }
 
 #[cfg(unix)]
@@ -650,7 +648,10 @@ fn unreadable_project_reference_becomes_a_finding_instead_of_a_cli_error() {
         }
         "#,
     );
-    write(&target_path, r#"{ "compilerOptions": { "composite": true } }"#);
+    write(
+        &target_path,
+        r#"{ "compilerOptions": { "composite": true } }"#,
+    );
 
     let original_permissions = fs::metadata(&target_path)
         .expect("target metadata should exist")
@@ -686,15 +687,13 @@ fn unreadable_project_reference_becomes_a_finding_instead_of_a_cli_error() {
         .as_array()
         .expect("findings should be an array");
     assert_eq!(findings.len(), 1);
-    assert!(
-        finding_field(
-            findings[0]
-                .as_object()
-                .expect("finding should be an object"),
-            "id"
-        )
-        .contains(":unreadable")
-    );
+    assert!(finding_field(
+        findings[0]
+            .as_object()
+            .expect("finding should be an object"),
+        "id"
+    )
+    .contains(":unreadable"));
     assert_eq!(
         finding_field(
             findings[0]
@@ -768,6 +767,7 @@ fn write_env_fixture(root: &Path) {
     write(root.join(".env"), "SHARED=base\n");
     write(root.join(".env.local"), "SHARED=local\n");
     write(root.join(".env.example"), "SHARED=\n");
+    write(root.join(".gitignore"), ".env\n.env.local\n");
 }
 
 fn write_tsconfig_conflict_fixture(root: &Path) {

--- a/src/checks/env.js
+++ b/src/checks/env.js
@@ -1,9 +1,14 @@
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { promisify } from "node:util";
 
 import { getDirectories } from "../core/discover.js";
 import { makeFinding } from "../core/findings.js";
 import {
+  formatGitignoreProtectionHint,
   isConcreteEnvFileName,
+  isPathProtectedByExactGitignore,
   isTemplateEnvFileName,
   looksLikeSecret,
   parseEnv,
@@ -11,9 +16,12 @@ import {
 } from "../lib/env.js";
 import { readTextIfExists, writeText } from "../lib/fs.js";
 
+const execFileAsync = promisify(execFile);
+
 export async function runEnvCheck(project) {
   const findings = [];
   const fixes = [];
+  const gitignoreTraversalRoot = await findGitignoreTraversalRoot(project.rootDir);
 
   for (const directory of getDirectories(project)) {
     const envFiles = directory.filesByKind.get("env") ?? [];
@@ -75,6 +83,29 @@ export async function runEnvCheck(project) {
       for (const key of record.parsed.order) {
         contractKeys.add(key);
       }
+    }
+
+    const gitignoreSources = await readAncestorGitignoreSources(gitignoreTraversalRoot, directory.dir);
+
+    for (const record of concreteRecords) {
+      const isTracked = await isPathTrackedByGit(gitignoreTraversalRoot, record.file.path);
+      const isProtected = !isTracked && isPathProtectedByExactGitignore(record.file.path, gitignoreSources);
+
+      if (isProtected) {
+        continue;
+      }
+
+      findings.push(
+        makeFinding({
+          id: `env-gitignore:${record.file.path}`,
+          category: "env",
+          severity: "warn",
+          title: `Concrete env file "${record.file.name}" is not protected by .gitignore`,
+          file: record.file.path,
+          detail: formatGitignoreProtectionHint(project.rootDir, directory.dir, record.file.path),
+          hint: "Protect concrete env files with an exact .gitignore entry before committing secrets.",
+        }),
+      );
     }
 
     if (contractKeys.size > 0 && !exampleRecord) {
@@ -225,6 +256,66 @@ export async function runEnvCheck(project) {
   }
 
   return { findings, fixes };
+}
+
+async function isPathTrackedByGit(repoRoot, filePath) {
+  const relativePath = path.relative(repoRoot, filePath);
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return false;
+  }
+
+  try {
+    await execFileAsync("git", ["-C", repoRoot, "ls-files", "--error-unmatch", "--", relativePath]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitignoreTraversalRoot(rootDir) {
+  let currentDir = rootDir;
+
+  while (true) {
+    try {
+      await stat(path.join(currentDir, ".git"));
+      return currentDir;
+    } catch {
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        return rootDir;
+      }
+      currentDir = parentDir;
+    }
+  }
+}
+
+async function readAncestorGitignoreSources(rootDir, directoryDir) {
+  const sources = [];
+  let currentDir = rootDir;
+
+  while (true) {
+    const gitignoreText = await readTextIfExists(path.join(currentDir, ".gitignore"));
+    if (gitignoreText != null) {
+      sources.push([currentDir, gitignoreText]);
+    }
+
+    if (currentDir === directoryDir) {
+      break;
+    }
+
+    const relative = path.relative(currentDir, directoryDir);
+    if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+      break;
+    }
+
+    const [nextSegment] = relative.split(path.sep);
+    if (!nextSegment) {
+      break;
+    }
+    currentDir = path.join(currentDir, nextSegment);
+  }
+
+  return sources;
 }
 
 function compareContractRecords(left, right) {

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export function parseEnv(text, { label = ".env" } = {}) {
   const entries = [];
   const duplicates = [];
@@ -99,6 +101,48 @@ export function looksLikeSecret(value) {
   return false;
 }
 
+export function parseExactGitignorePatterns(text) {
+  return text
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map((line) => {
+      const negated = line.startsWith("!");
+      const pattern = normalizeGitignorePattern(negated ? line.slice(1) : line);
+      return pattern ? { ...pattern, negated } : null;
+    })
+    .filter(Boolean);
+}
+
+export function isPathProtectedByExactGitignore(targetPath, gitignoreSources) {
+  const fileName = path.basename(targetPath);
+  let protectedState = null;
+
+  for (const [ignoreRoot, gitignoreText] of gitignoreSources) {
+    const relativePath = normalizePath(path.relative(ignoreRoot, targetPath));
+    for (const pattern of parseExactGitignorePatterns(gitignoreText)) {
+      if (patternMatchesFile(pattern, relativePath, fileName)) {
+        protectedState = !pattern.negated;
+      }
+    }
+  }
+
+  return protectedState ?? false;
+}
+
+export function formatGitignoreProtectionHint(rootDir, directoryDir, filePath) {
+  const currentGitignorePath = path.join(directoryDir, ".gitignore");
+  const currentGitignoreDisplay = normalizePath(path.relative(rootDir, currentGitignorePath)) || ".gitignore";
+  const currentPattern = path.basename(filePath);
+  const rootPattern = normalizePath(path.relative(rootDir, filePath));
+
+  if (directoryDir === rootDir || rootPattern === currentPattern) {
+    return `Add "${currentPattern}" to ${currentGitignoreDisplay}.`;
+  }
+
+  return `Add "${currentPattern}" to ${currentGitignoreDisplay} or "${rootPattern}" to .gitignore.`;
+}
+
 function normalizeEnvValue(rawValue) {
   const trimmed = rawValue.trim();
 
@@ -110,4 +154,97 @@ function normalizeEnvValue(rawValue) {
   }
 
   return trimmed;
+}
+
+function normalizeGitignorePattern(pattern) {
+  const normalized = normalizePath(pattern).replace(/^\.\/+/u, "");
+  const anchored = normalized.startsWith("/");
+  const directoryOnly = normalized.endsWith("/");
+  const value = normalized.replace(/^\/+/u, "").replace(/\/+$/u, "");
+
+  return value.length > 0 ? { pattern: value, anchored, directoryOnly } : null;
+}
+
+function patternMatchesFile(pattern, relativePath, fileName) {
+  if (pattern.directoryOnly) {
+    return directoryPatternMatchesFile(pattern, relativePath);
+  }
+
+  return (
+    directoryPatternMatchesFile(pattern, relativePath) ||
+    gitignorePatternMatches(pattern.pattern, relativePath) ||
+    (!pattern.anchored && !pattern.pattern.includes("/") && gitignorePatternMatches(pattern.pattern, fileName))
+  );
+}
+
+function directoryPatternMatchesFile(pattern, relativePath) {
+  const directoryPath = relativePath.includes("/") ? relativePath.slice(0, relativePath.lastIndexOf("/")) : "";
+  if (!directoryPath) {
+    return false;
+  }
+
+  const directories = directoryAncestors(directoryPath);
+  if (!pattern.anchored && !pattern.pattern.includes("/")) {
+    return directories.some((directory) => gitignorePatternMatches(pattern.pattern, path.basename(directory)));
+  }
+
+  return directories.some((directory) => gitignorePatternMatches(pattern.pattern, directory));
+}
+
+function directoryAncestors(directoryPath) {
+  const parts = directoryPath.split("/");
+  const directories = [];
+  for (let index = 0; index < parts.length; index += 1) {
+    directories.push(parts.slice(0, index + 1).join("/"));
+  }
+  return directories;
+}
+
+function gitignorePatternMatches(pattern, value) {
+  const memo = new Map();
+
+  function matches(patternIndex, valueIndex) {
+    const memoKey = `${patternIndex}:${valueIndex}`;
+    if (memo.has(memoKey)) {
+      return memo.get(memoKey);
+    }
+
+    let result;
+    if (patternIndex >= pattern.length) {
+      result = valueIndex >= value.length;
+    } else if (pattern.startsWith("**", patternIndex)) {
+      const afterGlobstar = patternIndex + 2;
+      if (pattern[afterGlobstar] === "/") {
+        result = matches(afterGlobstar + 1, valueIndex);
+        for (let index = valueIndex; !result && index < value.length; index += 1) {
+          if (value[index] === "/") {
+            result = matches(afterGlobstar + 1, index + 1);
+          }
+        }
+      } else {
+        result = false;
+        for (let index = valueIndex; !result && index <= value.length; index += 1) {
+          result = matches(afterGlobstar, index);
+        }
+      }
+    } else if (pattern[patternIndex] === "*") {
+      result = matches(patternIndex + 1, valueIndex);
+      for (let index = valueIndex; !result && index < value.length && value[index] !== "/"; index += 1) {
+        result = matches(patternIndex + 1, index + 1);
+      }
+    } else if (pattern[patternIndex] === "?") {
+      result = valueIndex < value.length && value[valueIndex] !== "/" && matches(patternIndex + 1, valueIndex + 1);
+    } else {
+      result = valueIndex < value.length && pattern[patternIndex] === value[valueIndex] && matches(patternIndex + 1, valueIndex + 1);
+    }
+
+    memo.set(memoKey, result);
+    return result;
+  }
+
+  return matches(0, 0);
+}
+
+function normalizePath(value) {
+  return value.replaceAll("\\", "/");
 }

--- a/test/env-fix.test.js
+++ b/test/env-fix.test.js
@@ -1,15 +1,18 @@
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
-import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
 
 import { auditProject } from "../src/core/audit-project.js";
 import { applyFixes } from "../src/core/fixers.js";
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(testDir, "fixtures");
+const execFileAsync = promisify(execFile);
 
 test("maximus fix creates .env.example from concrete env files", async (t) => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-env-"));
@@ -111,6 +114,167 @@ test("template-like env files do not trigger .env.example creation", async (t) =
 
   assert.equal(audit.summary.fixesAvailable, 0);
   assert.ok(!audit.findings.some((finding) => finding.id.startsWith("env-example-missing:")));
+});
+
+test("env gitignore protection honors negation and ancestor gitignore files", async (t) => {
+  const negatedRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-negated-"));
+  const ancestorRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-ancestor-"));
+  const anchoredNestedRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-anchored-nested-"));
+  const anchoredRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-anchored-root-"));
+  const directoryOnlyRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-directory-only-"));
+  const subdirAuditRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-subdir-"));
+  const globRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-glob-"));
+  const globstarRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-globstar-"));
+  const leadingSpaceRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-leading-space-"));
+  const directoryRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-directory-"));
+  const bareDirectoryRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-bare-directory-"));
+  const trackedRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-tracked-"));
+
+  t.after(async () => {
+    await rm(negatedRoot, { recursive: true, force: true });
+    await rm(ancestorRoot, { recursive: true, force: true });
+    await rm(anchoredNestedRoot, { recursive: true, force: true });
+    await rm(anchoredRoot, { recursive: true, force: true });
+    await rm(directoryOnlyRoot, { recursive: true, force: true });
+    await rm(subdirAuditRoot, { recursive: true, force: true });
+    await rm(globRoot, { recursive: true, force: true });
+    await rm(globstarRoot, { recursive: true, force: true });
+    await rm(leadingSpaceRoot, { recursive: true, force: true });
+    await rm(directoryRoot, { recursive: true, force: true });
+    await rm(bareDirectoryRoot, { recursive: true, force: true });
+    await rm(trackedRoot, { recursive: true, force: true });
+  });
+
+  await writeFile(path.join(negatedRoot, ".env"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(negatedRoot, ".gitignore"), ".env\n!.env\n", "utf8");
+
+  const negatedAudit = await auditProject(negatedRoot);
+  assert.ok(
+    negatedAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "later negation should make .env unprotected",
+  );
+
+  await writeFile(path.join(leadingSpaceRoot, ".env"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(leadingSpaceRoot, ".gitignore"), " .env\n", "utf8");
+
+  const leadingSpaceAudit = await auditProject(leadingSpaceRoot);
+  assert.ok(
+    leadingSpaceAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "leading-space .gitignore pattern should not protect .env",
+  );
+
+  await writeFile(path.join(globRoot, ".env.local"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(globRoot, ".env.example"), "API_TOKEN=\n", "utf8");
+  await writeFile(path.join(globRoot, ".gitignore"), ".env*\n!.env.example\n", "utf8");
+
+  const globAudit = await auditProject(globRoot);
+  assert.ok(
+    !globAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "glob .gitignore pattern should protect .env.local",
+  );
+
+  await mkdir(path.join(globstarRoot, "apps/web"), { recursive: true });
+  await writeFile(path.join(globstarRoot, "apps/web/.env.local"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(globstarRoot, ".gitignore"), "**/.env.local\n", "utf8");
+
+  const globstarAudit = await auditProject(globstarRoot);
+  assert.ok(
+    !globstarAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "globstar .gitignore pattern should protect nested .env.local",
+  );
+
+  await mkdir(path.join(directoryRoot, "apps/web"), { recursive: true });
+  await writeFile(path.join(directoryRoot, "apps/web/.env.local"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(directoryRoot, ".gitignore"), "apps/\n", "utf8");
+
+  const directoryAudit = await auditProject(directoryRoot);
+  assert.ok(
+    !directoryAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "directory-only .gitignore pattern should protect files under that directory",
+  );
+
+  await mkdir(path.join(bareDirectoryRoot, "secrets"), { recursive: true });
+  await writeFile(path.join(bareDirectoryRoot, "secrets/.env"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(bareDirectoryRoot, ".gitignore"), "secrets\n", "utf8");
+
+  const bareDirectoryAudit = await auditProject(bareDirectoryRoot);
+  assert.ok(
+    !bareDirectoryAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "bare directory .gitignore pattern should protect files under that directory",
+  );
+
+  await writeFile(path.join(trackedRoot, ".env"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(trackedRoot, ".gitignore"), ".env\n", "utf8");
+  await execFileAsync("git", ["init"], { cwd: trackedRoot });
+  await execFileAsync("git", ["add", "-f", ".env"], { cwd: trackedRoot });
+
+  const trackedAudit = await auditProject(trackedRoot);
+  assert.ok(
+    trackedAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "tracked concrete env files should not be treated as protected by .gitignore",
+  );
+
+  await mkdir(path.join(ancestorRoot, "apps/web"), { recursive: true });
+  await writeFile(
+    path.join(ancestorRoot, "apps/web/.env.local"),
+    "API_TOKEN=abcdef1234567890\n",
+    "utf8",
+  );
+  await writeFile(path.join(ancestorRoot, "apps/.gitignore"), ".env.local\n", "utf8");
+
+  const ancestorAudit = await auditProject(ancestorRoot);
+  assert.ok(
+    !ancestorAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "ancestor .gitignore should protect nested .env.local",
+  );
+
+  await mkdir(path.join(subdirAuditRoot, ".git"), { recursive: true });
+  await mkdir(path.join(subdirAuditRoot, "packages/app"), { recursive: true });
+  await writeFile(path.join(subdirAuditRoot, ".git/HEAD"), "ref: refs/heads/main\n", "utf8");
+  await writeFile(path.join(subdirAuditRoot, ".gitignore"), "packages/app/.env.local\n", "utf8");
+  await writeFile(
+    path.join(subdirAuditRoot, "packages/app/.env.local"),
+    "API_TOKEN=abcdef1234567890\n",
+    "utf8",
+  );
+
+  const subdirAudit = await auditProject(path.join(subdirAuditRoot, "packages/app"));
+  assert.ok(
+    !subdirAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "repo root .gitignore should protect subdir audit targets",
+  );
+
+  await mkdir(path.join(anchoredNestedRoot, "apps/web"), { recursive: true });
+  await writeFile(
+    path.join(anchoredNestedRoot, "apps/web/.env.local"),
+    "API_TOKEN=abcdef1234567890\n",
+    "utf8",
+  );
+  await writeFile(path.join(anchoredNestedRoot, ".gitignore"), "/.env.local\n", "utf8");
+
+  const anchoredNestedAudit = await auditProject(anchoredNestedRoot);
+  assert.ok(
+    anchoredNestedAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "anchored root .gitignore pattern should not protect nested .env.local",
+  );
+
+  await writeFile(path.join(anchoredRoot, ".env.local"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(anchoredRoot, ".gitignore"), "/.env.local\n", "utf8");
+
+  const anchoredAudit = await auditProject(anchoredRoot);
+  assert.ok(
+    !anchoredAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "anchored root .gitignore pattern should protect root .env.local",
+  );
+
+  await writeFile(path.join(directoryOnlyRoot, ".env.local"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(directoryOnlyRoot, ".gitignore"), ".env.local/\n", "utf8");
+
+  const directoryOnlyAudit = await auditProject(directoryOnlyRoot);
+  assert.ok(
+    directoryOnlyAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "directory-only .gitignore pattern should not protect env files",
+  );
 });
 
 async function copyFixtureToTemp(relativeFixturePath) {

--- a/test/golden-rust/env-missing-example.audit.txt
+++ b/test/golden-rust/env-missing-example.audit.txt
@@ -2,12 +2,16 @@ Maximus audit
 Target: <TARGET>
 
 Status: attention needed
-Findings: 0 error, 1 warnings, 0 info
+Findings: 0 error, 2 warnings, 0 info
 Fixes available: 1
 
 Structure: single package, 0 package(s), 1 config file(s), 1 env folder(s)
 
 Findings
+- [warn] Concrete env file ".env" is not protected by .gitignore
+  file: .env
+  detail: Add ".env" to .gitignore.
+  hint: Protect concrete env files with an exact .gitignore entry before committing secrets.
 - [warn] Missing .env.example contract
   file: .env
   detail: Runtime env files exist, but .env.example is missing.

--- a/test/golden-rust/env-missing-example.doctor.txt
+++ b/test/golden-rust/env-missing-example.doctor.txt
@@ -6,14 +6,21 @@ Project shape: single package, 0 package(s), 1 config file(s), 1 env folder(s)
 
 Prescription
 - Run "maximus fix" to apply 1 safe fix(es).
-- No manual follow-up is required right now.
+- Review 1 manual issue(s) in priority order below.
 
 Top 3 priorities
-1. [warn] Missing .env.example contract
+1. [warn] Concrete env file ".env" is not protected by .gitignore
+   file: .env
+   next: Protect concrete env files with an exact .gitignore entry before committing secrets.
+2. [warn] Missing .env.example contract
    file: .env
    next: Run "maximus fix" to create a blank contract file.
 
 Findings
+- [warn] Concrete env file ".env" is not protected by .gitignore
+  file: .env
+  detail: Add ".env" to .gitignore.
+  hint: Protect concrete env files with an exact .gitignore entry before committing secrets.
 - [warn] Missing .env.example contract
   file: .env
   detail: Runtime env files exist, but .env.example is missing.

--- a/test/golden-rust/env-missing-example.fix-dry-run.txt
+++ b/test/golden-rust/env-missing-example.fix-dry-run.txt
@@ -3,9 +3,13 @@ Target: <TARGET>
 
 Dry run: 1 safe fix(es) available.
 
-Post-check: 0 error, 1 warnings, 0 info
+Post-check: 0 error, 2 warnings, 0 info
 
 Remaining findings
+- [warn] Concrete env file ".env" is not protected by .gitignore
+  file: .env
+  detail: Add ".env" to .gitignore.
+  hint: Protect concrete env files with an exact .gitignore entry before committing secrets.
 - [warn] Missing .env.example contract
   file: .env
   detail: Runtime env files exist, but .env.example is missing.

--- a/test/golden-rust/windows-crlf.doctor.txt
+++ b/test/golden-rust/windows-crlf.doctor.txt
@@ -6,13 +6,16 @@ Project shape: single package, 0 package(s), 2 config file(s), 1 env folder(s)
 
 Prescription
 - Run "maximus fix" to apply 1 safe fix(es).
-- Review 1 manual issue(s) in priority order below.
+- Review 2 manual issue(s) in priority order below.
 
 Top 3 priorities
 1. [error] Path alias target does not exist
    file: tsconfig.json
    next: Update or remove stale aliases before they break editor and build resolution.
-2. [warn] Missing .env.example contract
+2. [warn] Concrete env file ".env" is not protected by .gitignore
+   file: .env
+   next: Protect concrete env files with an exact .gitignore entry before committing secrets.
+3. [warn] Missing .env.example contract
    file: .env
    next: Run "maximus fix" to create a blank contract file.
 
@@ -21,6 +24,10 @@ Findings
   file: tsconfig.json
   detail: @app/* points to src/*, but the resolved path was not found.
   hint: Update or remove stale aliases before they break editor and build resolution.
+- [warn] Concrete env file ".env" is not protected by .gitignore
+  file: .env
+  detail: Add ".env" to .gitignore.
+  hint: Protect concrete env files with an exact .gitignore entry before committing secrets.
 - [warn] Missing .env.example contract
   file: .env
   detail: Runtime env files exist, but .env.example is missing.


### PR DESCRIPTION
## 요약
- `.gitignore` 보호 판단에서 루트/중간 ancestor `.gitignore`를 순서대로 반영합니다.
- `!` negation, anchored pattern, directory-only pattern을 Git 동작에 맞게 처리합니다.
- Rust/JS 양쪽 구현과 회귀 테스트를 함께 보강했습니다.

## 검증
- `cargo test -p maximus-checks --test env_checks`
- `node --test test/env-fix.test.js`
- `$devils-advocate-review-loop` 재리뷰: Critical/High 없음

Closes #70
