### PR TITLE
feat: ignore 소스 반영

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,10 +75,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
 
 [[package]]
 name = "getrandom"
@@ -67,7 +106,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -317,6 +356,7 @@ dependencies = [
  "icu_collator",
  "indexmap",
  "jsonc-parser",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",
@@ -328,6 +368,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -344,6 +393,15 @@ dependencies = [
  "serde_core",
  "writeable",
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -366,6 +424,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,9 +459,59 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -391,6 +524,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -492,7 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -508,6 +653,12 @@ dependencies = [
  "serde_core",
  "zerovec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -532,6 +683,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -746,6 +906,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -153,10 +153,11 @@ pub fn audit_project_with_config_root(
     config: &MaximusConfig,
     ignore_root: &Path,
 ) -> io::Result<AuditedProject> {
-    let project = if config.ignore.is_empty() {
+    let ignored_patterns = config.effective_ignore_patterns();
+    let project = if ignored_patterns.is_empty() {
         discover_project(root_dir)?
     } else {
-        discover_project_with_ignore_root(root_dir, &config.ignore, ignore_root)?
+        discover_project_with_ignore_root(root_dir, &ignored_patterns, ignore_root)?
     };
     let mut outcome = run_registered_checks_with_config_root(&project, config, ignore_root)?;
     apply_severity_overrides(&mut outcome.findings, &config.severity);
@@ -390,9 +391,19 @@ fn run_config_duplicate_check_registered(
 
 fn run_env_check_registered(
     project: &ProjectSnapshot,
-    _config: &MaximusConfig,
-    _ignore_root: &Path,
+    config: &MaximusConfig,
+    ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
+    if !config.gitignore_patterns.is_empty() {
+        let non_git_patterns = config.non_git_ignore_patterns();
+        let env_project = if non_git_patterns.is_empty() {
+            discover_project(&project.root_dir)?
+        } else {
+            discover_project_with_ignore_root(&project.root_dir, &non_git_patterns, ignore_root)?
+        };
+        return run_env_check(&env_project);
+    }
+
     run_env_check(project)
 }
 
@@ -441,7 +452,8 @@ fn run_lockfiles_check_registered(
     config: &MaximusConfig,
     ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
-    run_lockfiles_check_with_ignore_root(project, &config.ignore, ignore_root)
+    let ignored_patterns = config.effective_ignore_patterns();
+    run_lockfiles_check_with_ignore_root(project, &ignored_patterns, ignore_root)
 }
 
 fn run_package_entrypoints_check_registered(

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -16,8 +16,9 @@ use std::process;
 
 use maximus_checks::{audit_project_with_config_root, registered_check_ids};
 use maximus_core::{
-    apply_fixes, load_maximus_config, preview_fixes, select_fix_plans, select_planned_fixes,
-    AuditResult, FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
+    apply_fixes, find_ignore_root, load_ignore_file_pattern_sources, load_maximus_config,
+    preview_fixes, scope_ignore_patterns, select_fix_plans, select_planned_fixes, AuditResult,
+    FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
 };
 
 use crate::args::{parse_args, ArgsError, Flags, OutputFormat};
@@ -337,11 +338,27 @@ fn resolve_effective_config(
     flags: &Flags,
 ) -> Result<ResolvedConfig, CliError> {
     let loaded = load_maximus_config(target_dir)?;
-    let ignore_root = loaded
+    let config_root = loaded
         .as_ref()
-        .and_then(|loaded| loaded.path.parent().map(std::path::Path::to_path_buf))
-        .unwrap_or_else(|| target_dir.to_path_buf());
+        .and_then(|loaded| loaded.path.parent().map(std::path::Path::to_path_buf));
+    let ignore_root = find_ignore_root(
+        target_dir,
+        loaded.as_ref().map(|loaded| loaded.path.as_path()),
+    )?;
     let mut config = loaded.map(|loaded| loaded.config).unwrap_or_default();
+    if let Some(config_root) = config_root {
+        config.ignore = scope_ignore_patterns(&config.ignore, &config_root, &ignore_root)?;
+        config.ignore_patterns =
+            scope_ignore_patterns(&config.ignore_patterns, &config_root, &ignore_root)?;
+    }
+    let mut ignore_file_patterns = load_ignore_file_pattern_sources(&ignore_root, target_dir)?;
+    if !ignore_file_patterns.maximusignore.is_empty() {
+        ignore_file_patterns
+            .maximusignore
+            .extend(std::mem::take(&mut config.ignore));
+        config.ignore = ignore_file_patterns.maximusignore;
+    }
+    config.gitignore_patterns = ignore_file_patterns.gitignore;
 
     validate_check_ids("only", &config.checks.only)?;
     validate_check_ids("skip", &config.checks.skip)?;

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -459,6 +459,440 @@ fn config_glob_ignore_and_severity_overrides_are_applied() {
 }
 
 #[test]
+fn config_ignore_patterns_alias_applies_to_discovery() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(&fixture.path().join("generated"));
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignorePatterns": ["generated"], "checks": { "only": ["tsconfig"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignorePatterns should suppress generated findings: {findings:?}"
+    );
+}
+
+#[test]
+fn maximusignore_applies_to_discovery_without_config_file() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(&fixture.path().join("generated"));
+    write(fixture.path().join(".maximusignore"), "generated/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        ".maximusignore should suppress generated findings: {findings:?}"
+    );
+}
+
+#[test]
+fn ancestor_gitignore_applies_when_auditing_nested_target() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let repo = fixture.path().join("repo");
+    let target = repo.join("packages/web");
+    fs::create_dir_all(repo.join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(&target.join("generated"));
+    write(repo.join(".gitignore"), "packages/web/generated/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            target.to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ancestor .gitignore should suppress generated findings: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_root_and_nested_config_relative_patterns_are_combined() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let repo = fixture.path().join("repo");
+    let target = repo.join("packages/web");
+    fs::create_dir_all(repo.join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(&target.join("generated"));
+    write_tsconfig_conflict_fixture(&target.join("local/generated"));
+    write(repo.join(".gitignore"), "packages/web/generated/\n");
+    write(
+        target.join("maximus.config.json"),
+        r#"{ "ignorePatterns": ["local/generated"], "checks": { "only": ["tsconfig"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "root .gitignore and nested config ignorePatterns should both apply: {findings:?}"
+    );
+}
+
+#[test]
+fn nested_gitignore_bare_pattern_applies_when_auditing_inside_ignored_directory() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let repo = fixture.path().join("repo");
+    let target = repo.join("packages/web/generated/sub");
+    fs::create_dir_all(repo.join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(&target);
+    write(repo.join("packages/web/.gitignore"), "generated\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            target.to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "nested .gitignore bare pattern should suppress direct child audit target: {findings:?}"
+    );
+}
+
+#[test]
+fn nested_config_bare_ignore_applies_when_auditing_inside_ignored_directory() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let repo = fixture.path().join("repo");
+    let config_root = repo.join("packages/web");
+    let target = config_root.join("generated/sub");
+    write_tsconfig_conflict_fixture(&target);
+    write(
+        config_root.join("maximus.config.json"),
+        r#"{ "ignore": ["generated"], "checks": { "only": ["tsconfig"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", target.to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "nested config bare ignore should suppress direct child audit target: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_patterns_apply_to_lockfiles_check_traversal() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(fixture.path().join("ignored/package-lock.json"), "{}\n");
+    write(
+        fixture.path().join("ignored/yarn.lock"),
+        "# yarn lockfile v1\n",
+    );
+    write(fixture.path().join(".gitignore"), "ignored/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "lockfiles",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        ".gitignore should suppress ignored lockfile findings: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_patterns_do_not_hide_env_check_inputs() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(fixture.path().join(".env.local"), "SECRET=local\n");
+    write(fixture.path().join(".gitignore"), ".env.local\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("env-example-missing:"))
+        }),
+        ".gitignore should not remove env files from env contract checks: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_patterns_do_not_hide_tracked_env_check_inputs() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(fixture.path().join(".env"), "SECRET=tracked\n");
+    write(fixture.path().join(".gitignore"), ".env\n");
+    run_git(fixture.path(), &["init"]);
+    run_git(fixture.path(), &["add", "-f", ".env"]);
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("env-gitignore:"))
+        }),
+        "tracked env files ignored by .gitignore should still reach the tracked-file guard: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_escaped_leading_bang_matches_literal_path() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(&fixture.path().join("!generated"));
+    write_tsconfig_conflict_fixture(&fixture.path().join("generated"));
+    write(fixture.path().join(".gitignore"), "\\!generated/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    let finding = findings[0]
+        .as_object()
+        .expect("finding should be an object");
+    assert!(
+        finding_field(finding, "file").contains("generated/tsconfig.json"),
+        "escaped bang should suppress literal !generated only: {findings:?}"
+    );
+    assert!(
+        !finding_field(finding, "file").contains("!generated/tsconfig.json"),
+        "escaped bang should not scan literal !generated: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_anchored_root_pattern_does_not_suppress_nested_target() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let repo = fixture.path().join("repo");
+    let target = repo.join("packages/web");
+    fs::create_dir_all(repo.join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(&target.join("generated"));
+    write(repo.join(".gitignore"), "/generated/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            target.to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "id"
+        )
+        .starts_with("tsconfig-import-conflict:"),
+        "anchored root .gitignore should not suppress nested generated findings: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_directory_only_file_pattern_does_not_suppress_matching_file() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+    write(fixture.path().join(".gitignore"), "tsconfig.json/\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "id"
+        )
+        .starts_with("tsconfig-import-conflict:"),
+        "directory-only .gitignore file pattern should not suppress a file: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_leading_space_pattern_does_not_suppress_matching_file() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+    write(fixture.path().join(".gitignore"), " tsconfig.json\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "tsconfig",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_eq!(findings.len(), 1);
+    assert!(
+        finding_field(
+            findings[0]
+                .as_object()
+                .expect("finding should be an object"),
+            "id"
+        )
+        .starts_with("tsconfig-import-conflict:"),
+        "leading-space .gitignore pattern should not suppress tsconfig.json: {findings:?}"
+    );
+}
+
+#[test]
 fn config_ignore_applies_to_lockfiles_check_traversal() {
     let fixture = TempDir::new().expect("temp dir should exist");
     write(fixture.path().join("ignored/package-lock.json"), "{}\n");
@@ -799,6 +1233,16 @@ fn write(path: impl AsRef<Path>, content: &str) {
     }
 
     fs::write(path, content).expect("fixture file should write");
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git should run");
+    assert!(output.status.success(), "{output:?}");
 }
 
 fn parse_json(output: &Output) -> Value {

--- a/crates/maximus-core/src/config.rs
+++ b/crates/maximus-core/src/config.rs
@@ -1,12 +1,35 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
 
 use crate::{parse_jsonc, read_text_if_exists, ParseJsoncError};
 
 const CONFIG_FILE_NAMES: [&str; 2] = ["maximus.config.json", ".maximusrc.json"];
+const GIT_IGNORE_FILE_NAME: &str = ".gitignore";
+const MAXIMUS_IGNORE_FILE_NAME: &str = ".maximusignore";
+const DEFAULT_IGNORE_PATTERN_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".idea",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".pnpm-store",
+    ".svelte-kit",
+    ".turbo",
+    ".vercel",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+    "tmp",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -15,10 +38,40 @@ pub struct MaximusConfig {
     pub checks: CheckFilterConfig,
     #[serde(default)]
     pub ignore: Vec<String>,
+    #[serde(default, rename = "ignorePatterns")]
+    pub ignore_patterns: Vec<String>,
+    #[serde(skip)]
+    pub gitignore_patterns: Vec<String>,
     #[serde(default)]
     pub severity: BTreeMap<String, ConfigSeverity>,
     #[serde(default)]
     pub report: ReportConfig,
+}
+
+impl MaximusConfig {
+    pub fn effective_ignore_patterns(&self) -> Vec<String> {
+        let mut patterns = self.gitignore_patterns.clone();
+        patterns.extend(self.non_git_ignore_patterns());
+        patterns
+    }
+
+    pub fn non_git_ignore_patterns(&self) -> Vec<String> {
+        let mut patterns = self.ignore.clone();
+        patterns.extend(self.ignore_patterns.clone());
+        patterns
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IgnoreFilePatternSources {
+    pub maximusignore: Vec<String>,
+    pub gitignore: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IgnoreFileKind {
+    Maximus,
+    Git,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -134,4 +187,276 @@ pub fn find_maximus_config_path(start_dir: &Path) -> io::Result<Option<PathBuf>>
     }
 
     Ok(None)
+}
+
+pub fn find_ignore_root(start_dir: &Path, config_path: Option<&Path>) -> io::Result<PathBuf> {
+    let start_dir = std::path::absolute(start_dir)?;
+    let mut start_dirs = Vec::new();
+    if let Ok(canonical_start_dir) = std::fs::canonicalize(&start_dir) {
+        start_dirs.push(canonical_start_dir);
+    }
+    start_dirs.push(start_dir.clone());
+    let mut searched_directories = BTreeSet::new();
+
+    for start_dir in start_dirs {
+        for directory in start_dir.ancestors() {
+            if !searched_directories.insert(directory.to_path_buf()) {
+                continue;
+            }
+            if directory.join(".git").exists() {
+                return Ok(directory.to_path_buf());
+            }
+        }
+    }
+
+    if let Some(config_path) = config_path {
+        if let Some(parent) = config_path.parent() {
+            return Ok(parent.to_path_buf());
+        }
+    }
+
+    Ok(start_dir)
+}
+
+pub fn scope_ignore_patterns(
+    patterns: &[String],
+    base_dir: &Path,
+    ignore_root: &Path,
+) -> io::Result<Vec<String>> {
+    let base_dir = canonical_or_absolute(base_dir)?;
+    let ignore_root = canonical_or_absolute(ignore_root)?;
+    let base_prefix = base_dir
+        .strip_prefix(ignore_root)
+        .ok()
+        .map(relative_path_string)
+        .filter(|value| value != ".")
+        .unwrap_or_default();
+
+    Ok(patterns
+        .iter()
+        .filter_map(|pattern| normalize_ignore_file_line(pattern, &base_prefix))
+        .collect())
+}
+
+pub fn load_ignore_file_patterns(ignore_root: &Path, target_dir: &Path) -> io::Result<Vec<String>> {
+    let sources = load_ignore_file_pattern_sources(ignore_root, target_dir)?;
+    let mut patterns = sources.gitignore;
+    patterns.extend(sources.maximusignore);
+
+    Ok(patterns)
+}
+
+pub fn load_ignore_file_pattern_sources(
+    ignore_root: &Path,
+    target_dir: &Path,
+) -> io::Result<IgnoreFilePatternSources> {
+    let ignore_root = canonical_or_absolute(ignore_root)?;
+    let target_dir = canonical_or_absolute(target_dir)?;
+    let include_gitignore = ignore_root.join(".git").exists();
+    let mut ignore_files = BTreeMap::new();
+
+    for directory in ignore_directories_from_root_to_target(&ignore_root, &target_dir) {
+        insert_ignore_files(&mut ignore_files, &directory, include_gitignore);
+    }
+
+    if target_dir.starts_with(&ignore_root) {
+        for entry in WalkDir::new(&target_dir)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(|entry| should_visit_for_ignore_files(entry))
+        {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if should_skip_walk_error(&error) => continue,
+                Err(error) => return Err(error.into()),
+            };
+
+            if entry.depth() == 0 || !entry.file_type().is_file() {
+                continue;
+            }
+            if let Some(kind) = ignore_file_kind(entry.file_name(), include_gitignore) {
+                ignore_files.insert(entry.path().to_path_buf(), kind);
+            }
+        }
+    }
+
+    let mut sources = IgnoreFilePatternSources::default();
+    for (ignore_file, kind) in ignore_files {
+        let Some(text) = read_text_if_exists(&ignore_file)? else {
+            continue;
+        };
+        let base_dir = ignore_file.parent().unwrap_or(ignore_root.as_path());
+        let patterns = parse_ignore_file_patterns(&text, base_dir, &ignore_root);
+        match kind {
+            IgnoreFileKind::Maximus => sources.maximusignore.extend(patterns),
+            IgnoreFileKind::Git => sources.gitignore.extend(patterns),
+        }
+    }
+
+    Ok(sources)
+}
+
+fn canonical_or_absolute(path: &Path) -> io::Result<PathBuf> {
+    std::fs::canonicalize(path).or_else(|_| std::path::absolute(path))
+}
+
+fn ignore_directories_from_root_to_target(ignore_root: &Path, target_dir: &Path) -> Vec<PathBuf> {
+    if !target_dir.starts_with(ignore_root) {
+        return vec![ignore_root.to_path_buf()];
+    }
+
+    let mut directories = Vec::new();
+    let mut current = Some(target_dir);
+    while let Some(directory) = current {
+        directories.push(directory.to_path_buf());
+        if directory == ignore_root {
+            break;
+        }
+        current = directory.parent();
+    }
+    directories.reverse();
+    directories
+}
+
+fn insert_ignore_files(
+    ignore_files: &mut BTreeMap<PathBuf, IgnoreFileKind>,
+    directory: &Path,
+    include_gitignore: bool,
+) {
+    let maximusignore = directory.join(MAXIMUS_IGNORE_FILE_NAME);
+    if maximusignore.is_file() {
+        ignore_files.insert(maximusignore, IgnoreFileKind::Maximus);
+    }
+
+    if include_gitignore {
+        let gitignore = directory.join(GIT_IGNORE_FILE_NAME);
+        if gitignore.is_file() {
+            ignore_files.insert(gitignore, IgnoreFileKind::Git);
+        }
+    }
+}
+
+fn ignore_file_kind(file_name: &OsStr, include_gitignore: bool) -> Option<IgnoreFileKind> {
+    if file_name == MAXIMUS_IGNORE_FILE_NAME {
+        return Some(IgnoreFileKind::Maximus);
+    }
+    if include_gitignore && file_name == GIT_IGNORE_FILE_NAME {
+        return Some(IgnoreFileKind::Git);
+    }
+
+    None
+}
+
+fn parse_ignore_file_patterns(text: &str, base_dir: &Path, ignore_root: &Path) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| normalize_ignore_file_line_with_paths(line, base_dir, ignore_root))
+        .collect()
+}
+
+fn normalize_ignore_file_line_with_paths(
+    line: &str,
+    base_dir: &Path,
+    ignore_root: &Path,
+) -> Option<String> {
+    let base_prefix = base_dir
+        .strip_prefix(ignore_root)
+        .ok()
+        .map(relative_path_string)
+        .filter(|value| value != ".")
+        .unwrap_or_default();
+
+    normalize_ignore_file_line(line, &base_prefix)
+}
+
+fn normalize_ignore_file_line(line: &str, base_prefix: &str) -> Option<String> {
+    let mut value = line.trim_end();
+    if value.is_empty() || value.starts_with('#') {
+        return None;
+    }
+
+    let mut negated = false;
+    let mut literal_prefix = None;
+    if let Some(remainder) = value.strip_prefix('!') {
+        negated = true;
+        value = remainder;
+    } else if let Some(remainder) = value.strip_prefix("\\!") {
+        literal_prefix = Some('!');
+        value = remainder;
+    } else if let Some(remainder) = value.strip_prefix("\\#") {
+        literal_prefix = Some('#');
+        value = remainder;
+    }
+
+    if value.is_empty() && literal_prefix.is_none() {
+        return None;
+    }
+
+    let directory_only = value.ends_with('/');
+    let anchored = literal_prefix.is_none() && value.starts_with('/');
+    let mut normalized = value
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string();
+    if let Some(prefix) = literal_prefix {
+        normalized = format!("{prefix}{normalized}");
+    }
+
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let scoped = if base_prefix.is_empty() {
+        if anchored {
+            format!("/{normalized}")
+        } else {
+            normalized
+        }
+    } else if anchored || normalized.contains('/') {
+        format!("{base_prefix}/{normalized}")
+    } else {
+        format!("{base_prefix}/**/{normalized}")
+    };
+    let scoped = if directory_only {
+        format!("{scoped}/")
+    } else {
+        scoped
+    };
+
+    Some(if negated {
+        format!("!{scoped}")
+    } else if scoped.starts_with('!') {
+        format!("\\{scoped}")
+    } else {
+        scoped
+    })
+}
+
+fn should_visit_for_ignore_files(entry: &walkdir::DirEntry) -> bool {
+    if entry.depth() == 0 || !entry.file_type().is_dir() {
+        return true;
+    }
+
+    let file_name = entry.file_name().to_string_lossy();
+    !DEFAULT_IGNORE_PATTERN_DIRS.contains(&file_name.as_ref())
+}
+
+fn should_skip_walk_error(error: &walkdir::Error) -> bool {
+    error.depth() > 0
+        && error.io_error().is_some_and(|io_error| {
+            matches!(
+                io_error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+            )
+        })
+}
+
+fn relative_path_string(path: &Path) -> String {
+    let value = path.to_string_lossy().replace('\\', "/");
+    if value.is_empty() {
+        ".".to_string()
+    } else {
+        value
+    }
 }

--- a/crates/maximus-core/src/discover.rs
+++ b/crates/maximus-core/src/discover.rs
@@ -30,9 +30,25 @@ const IGNORED_DIRECTORIES: &[&str] = &[
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum IgnorePattern {
-    Component(String),
-    Glob(Vec<String>),
+struct IgnorePattern {
+    negated: bool,
+    matcher: IgnoreMatcher,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IgnoreMatcher {
+    Component {
+        value: String,
+        directory_only: bool,
+    },
+    BasenameGlob {
+        pattern: String,
+        directory_only: bool,
+    },
+    Glob {
+        segments: Vec<String>,
+        directory_only: bool,
+    },
 }
 
 pub fn discover_project(root_dir: impl AsRef<Path>) -> io::Result<ProjectSnapshot> {
@@ -60,7 +76,7 @@ pub fn discover_project_with_ignore_root(
         .filter_map(|pattern| normalize_ignore_pattern(pattern))
         .collect::<Vec<_>>();
 
-    if is_ignored_path_from_root(&ignore_root, &root_dir, &ignored_patterns) {
+    if is_ignored_path_from_root(&ignore_root, &root_dir, &ignored_patterns, true) {
         return Ok(ProjectSnapshot {
             root_dir,
             files: Vec::new(),
@@ -97,7 +113,7 @@ pub fn discover_project_with_ignore_root(
             .map(Path::to_path_buf)
             .unwrap_or_else(|| root_dir.clone());
         let relative_path = relative_string(&root_dir, &path);
-        if is_ignored_path_from_root(&ignore_root, &path, &ignored_patterns) {
+        if is_ignored_path_from_root(&ignore_root, &path, &ignored_patterns, false) {
             continue;
         }
 
@@ -182,7 +198,12 @@ pub fn is_ignored_project_path_from_root(
         .filter_map(|pattern| normalize_ignore_pattern(pattern))
         .collect::<Vec<_>>();
 
-    is_ignored_path_from_root(ignore_root.as_ref(), target.as_ref(), &ignored_patterns)
+    is_ignored_path_from_root(
+        ignore_root.as_ref(),
+        target.as_ref(),
+        &ignored_patterns,
+        target.as_ref().is_dir(),
+    )
 }
 
 pub fn get_files(project: &ProjectSnapshot, kind: FileKind) -> &[ProjectFile] {
@@ -219,7 +240,7 @@ fn should_visit(ignore_root: &Path, entry: &DirEntry, ignored_patterns: &[Ignore
         return false;
     }
 
-    !is_ignored_path_from_root(ignore_root, entry.path(), ignored_patterns)
+    !is_ignored_path_from_root(ignore_root, entry.path(), ignored_patterns, true)
 }
 
 fn should_skip_walk_error(error: &walkdir::Error) -> bool {
@@ -233,31 +254,81 @@ fn should_skip_walk_error(error: &walkdir::Error) -> bool {
 }
 
 fn normalize_ignore_pattern(pattern: &str) -> Option<IgnorePattern> {
-    let trimmed = pattern.trim().replace('\\', "/");
+    let trimmed = pattern.trim_end();
+    let (negated, trimmed) = if let Some(remainder) = trimmed.strip_prefix('!') {
+        (true, remainder.to_string())
+    } else if let Some(remainder) = trimmed.strip_prefix("\\!") {
+        (false, format!("!{remainder}"))
+    } else if let Some(remainder) = trimmed.strip_prefix("\\#") {
+        (false, format!("#{remainder}"))
+    } else {
+        (false, trimmed.to_string())
+    };
+    let trimmed = trimmed.replace('\\', "/");
+    let anchored = trimmed.starts_with('/');
+    let directory_only = trimmed.ends_with('/');
     let trimmed = trimmed.trim_start_matches("./").trim_matches('/');
 
     if trimmed.is_empty() {
         return None;
     }
 
-    if !trimmed.contains('/') && !contains_glob_meta(trimmed) {
-        return Some(IgnorePattern::Component(trimmed.to_string()));
+    if anchored {
+        return Some(IgnorePattern {
+            negated,
+            matcher: IgnoreMatcher::Glob {
+                segments: trimmed
+                    .split('/')
+                    .filter(|segment| !segment.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect(),
+                directory_only,
+            },
+        });
     }
 
-    Some(IgnorePattern::Glob(
-        trimmed
-            .split('/')
-            .filter(|segment| !segment.is_empty())
-            .map(ToOwned::to_owned)
-            .collect(),
-    ))
+    if !trimmed.contains('/') && !contains_glob_meta(trimmed) {
+        return Some(IgnorePattern {
+            negated,
+            matcher: IgnoreMatcher::Component {
+                value: trimmed.to_string(),
+                directory_only,
+            },
+        });
+    }
+
+    if !trimmed.contains('/') {
+        return Some(IgnorePattern {
+            negated,
+            matcher: IgnoreMatcher::BasenameGlob {
+                pattern: trimmed.to_string(),
+                directory_only,
+            },
+        });
+    }
+
+    Some(IgnorePattern {
+        negated,
+        matcher: IgnoreMatcher::Glob {
+            segments: trimmed
+                .split('/')
+                .filter(|segment| !segment.is_empty())
+                .map(ToOwned::to_owned)
+                .collect(),
+            directory_only,
+        },
+    })
 }
 
 fn contains_glob_meta(pattern: &str) -> bool {
     pattern.contains('*') || pattern.contains('?')
 }
 
-fn is_ignored_relative_path(relative_path: &str, ignored_patterns: &[IgnorePattern]) -> bool {
+fn is_ignored_relative_path(
+    relative_path: &str,
+    ignored_patterns: &[IgnorePattern],
+    is_directory: bool,
+) -> bool {
     if ignored_patterns.is_empty() {
         return false;
     }
@@ -268,25 +339,69 @@ fn is_ignored_relative_path(relative_path: &str, ignored_patterns: &[IgnorePatte
         .filter(|segment| !segment.is_empty() && *segment != ".")
         .collect::<Vec<_>>();
 
-    ignored_patterns.iter().any(|pattern| match pattern {
-        IgnorePattern::Component(component) => path_segments
-            .iter()
-            .any(|segment| *segment == component.as_str()),
-        IgnorePattern::Glob(pattern_segments) => {
-            glob_path_matches(pattern_segments, &path_segments)
+    let mut ignored = false;
+    for pattern in ignored_patterns {
+        if ignore_pattern_matches(pattern, &path_segments, is_directory) {
+            ignored = !pattern.negated;
         }
-    })
+    }
+
+    ignored
+}
+
+fn ignore_pattern_matches(
+    pattern: &IgnorePattern,
+    path_segments: &[&str],
+    is_directory: bool,
+) -> bool {
+    match &pattern.matcher {
+        IgnoreMatcher::Component {
+            value,
+            directory_only,
+        } => {
+            let segments = if *directory_only {
+                directory_path_segments(path_segments, is_directory)
+            } else {
+                path_segments
+            };
+            segments.iter().any(|segment| *segment == value.as_str())
+        }
+        IgnoreMatcher::BasenameGlob {
+            pattern,
+            directory_only,
+        } => {
+            let segments = if *directory_only {
+                directory_path_segments(path_segments, is_directory)
+            } else {
+                path_segments
+            };
+            segments
+                .iter()
+                .any(|segment| glob_segment_matches(pattern, segment))
+        }
+        IgnoreMatcher::Glob {
+            segments,
+            directory_only,
+        } => {
+            if *directory_only {
+                glob_directory_path_matches(segments, path_segments, is_directory)
+            } else {
+                glob_path_or_parent_directory_matches(segments, path_segments, is_directory)
+            }
+        }
+    }
 }
 
 fn is_ignored_path_from_root(
     ignore_root: &Path,
     target: &Path,
     ignored_patterns: &[IgnorePattern],
+    is_directory: bool,
 ) -> bool {
     if ignored_patterns.is_empty() {
         return false;
     }
-    if relative_matches(ignore_root, target, ignored_patterns) {
+    if relative_matches(ignore_root, target, ignored_patterns, is_directory) {
         return true;
     }
 
@@ -297,17 +412,58 @@ fn is_ignored_path_from_root(
         return false;
     };
 
-    relative_matches(&canonical_ignore_root, &canonical_target, ignored_patterns)
+    relative_matches(
+        &canonical_ignore_root,
+        &canonical_target,
+        ignored_patterns,
+        is_directory,
+    )
 }
 
-fn relative_matches(ignore_root: &Path, target: &Path, ignored_patterns: &[IgnorePattern]) -> bool {
+fn relative_matches(
+    ignore_root: &Path,
+    target: &Path,
+    ignored_patterns: &[IgnorePattern],
+    is_directory: bool,
+) -> bool {
     let relative_path = relative_string(ignore_root, target);
-    is_ignored_relative_path(&relative_path, ignored_patterns)
+    is_ignored_relative_path(&relative_path, ignored_patterns, is_directory)
 }
 
 fn glob_path_matches(pattern_segments: &[String], path_segments: &[&str]) -> bool {
     let mut memo = vec![vec![None; path_segments.len() + 1]; pattern_segments.len() + 1];
     glob_path_matches_from(pattern_segments, path_segments, 0, 0, &mut memo)
+}
+
+fn glob_path_or_parent_directory_matches(
+    pattern_segments: &[String],
+    path_segments: &[&str],
+    is_directory: bool,
+) -> bool {
+    glob_path_matches(pattern_segments, path_segments)
+        || glob_directory_path_matches(pattern_segments, path_segments, is_directory)
+}
+
+fn glob_directory_path_matches(
+    pattern_segments: &[String],
+    path_segments: &[&str],
+    is_directory: bool,
+) -> bool {
+    let max_end = if is_directory {
+        path_segments.len()
+    } else {
+        path_segments.len().saturating_sub(1)
+    };
+
+    (0..=max_end).any(|end| glob_path_matches(pattern_segments, &path_segments[..end]))
+}
+
+fn directory_path_segments<'a>(path_segments: &'a [&'a str], is_directory: bool) -> &'a [&'a str] {
+    if is_directory {
+        path_segments
+    } else {
+        &path_segments[..path_segments.len().saturating_sub(1)]
+    }
 }
 
 fn glob_path_matches_from(

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -12,8 +12,10 @@ pub mod models;
 mod text_order;
 
 pub use config::{
-    find_maximus_config_path, load_maximus_config, CheckFilterConfig, ConfigSeverity, FailOnLevel,
-    LoadConfigError, LoadedConfig, MaximusConfig, ReportConfig,
+    find_ignore_root, find_maximus_config_path, load_ignore_file_pattern_sources,
+    load_ignore_file_patterns, load_maximus_config, scope_ignore_patterns, CheckFilterConfig,
+    ConfigSeverity, FailOnLevel, IgnoreFilePatternSources, LoadConfigError, LoadedConfig,
+    MaximusConfig, ReportConfig,
 };
 pub use discover::{
     discover_project, discover_project_with_ignore, discover_project_with_ignore_root,

--- a/crates/maximus-core/tests/config_loader.rs
+++ b/crates/maximus-core/tests/config_loader.rs
@@ -1,6 +1,9 @@
 use std::fs;
 
-use maximus_core::{find_maximus_config_path, load_maximus_config, ConfigSeverity, FailOnLevel};
+use maximus_core::{
+    find_ignore_root, find_maximus_config_path, load_ignore_file_patterns, load_maximus_config,
+    ConfigSeverity, FailOnLevel,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -116,6 +119,7 @@ fn parses_jsonc_shape_for_checks_severity_and_report() {
             "skip": ["duplicates"]
           },
           "ignore": ["dist", "coverage"],
+          "ignorePatterns": ["**/*.generated.json"],
           "severity": {
             "env-mismatch": "info"
           },
@@ -134,6 +138,11 @@ fn parses_jsonc_shape_for_checks_severity_and_report() {
     assert_eq!(loaded.config.checks.only, vec!["env", "tsconfig"]);
     assert_eq!(loaded.config.checks.skip, vec!["duplicates"]);
     assert_eq!(loaded.config.ignore, vec!["dist", "coverage"]);
+    assert_eq!(loaded.config.ignore_patterns, vec!["**/*.generated.json"]);
+    assert_eq!(
+        loaded.config.effective_ignore_patterns(),
+        vec!["dist", "coverage", "**/*.generated.json"]
+    );
     assert_eq!(
         loaded.config.severity.get("env-mismatch"),
         Some(&ConfigSeverity::Info)
@@ -188,4 +197,45 @@ fn parse_errors_when_unknown_config_keys_are_present() {
 
     assert!(rendered.contains(&config_path.to_string_lossy().to_string()));
     assert!(rendered.contains("skp"));
+}
+
+#[test]
+fn loads_ancestor_gitignore_and_nested_maximusignore_patterns_from_ignore_root() {
+    let temp = tempdir().expect("temp dir should exist");
+    let repo = temp.path().join("repo");
+    let nested = repo.join("packages/web");
+    fs::create_dir_all(nested.join("feature")).expect("nested dir should exist");
+    fs::create_dir_all(repo.join(".git")).expect("git dir should exist");
+    fs::write(
+        repo.join(".gitignore"),
+        "\n# generated artifacts\n*.env\n!.env.example\n",
+    )
+    .expect("gitignore should write");
+    fs::write(nested.join(".maximusignore"), "generated/\n").expect("maximusignore should write");
+
+    let ignore_root = find_ignore_root(&nested, None).expect("ignore root should resolve");
+    let patterns =
+        load_ignore_file_patterns(&ignore_root, &nested).expect("ignore patterns should load");
+
+    assert_eq!(
+        ignore_root,
+        fs::canonicalize(&repo).expect("repo should canonicalize")
+    );
+    assert_eq!(
+        patterns,
+        vec!["*.env", "!.env.example", "packages/web/**/generated/",]
+    );
+}
+
+#[test]
+fn loads_maximusignore_but_not_gitignore_without_git_root() {
+    let temp = tempdir().expect("temp dir should exist");
+    fs::write(temp.path().join(".gitignore"), "*.env\n").expect("gitignore should write");
+    fs::write(temp.path().join(".maximusignore"), "generated/\n")
+        .expect("maximusignore should write");
+
+    let patterns =
+        load_ignore_file_patterns(temp.path(), temp.path()).expect("ignore patterns should load");
+
+    assert_eq!(patterns, vec!["generated/"]);
 }

--- a/crates/maximus-core/tests/core_models.rs
+++ b/crates/maximus-core/tests/core_models.rs
@@ -243,6 +243,55 @@ fn discovery_applies_glob_ignore_patterns_to_matching_files() {
 }
 
 #[test]
+fn discovery_applies_gitignore_style_negated_patterns_in_order() {
+    let fixture = temp_fixture();
+    std::fs::write(fixture.path().join(".env"), "API_TOKEN=secret\n").unwrap();
+    std::fs::write(fixture.path().join(".env.example"), "API_TOKEN=\n").unwrap();
+
+    let snapshot = discover_project_with_ignore(
+        fixture.path(),
+        &["*.env".to_string(), "!.env.example".to_string()],
+    )
+    .unwrap();
+    let relative_paths = snapshot
+        .files
+        .iter()
+        .map(|file| file.relative_path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!relative_paths.contains(&".env"));
+    assert!(relative_paths.contains(&".env.example"));
+}
+
+#[test]
+fn discovery_keeps_gitignore_anchored_patterns_root_relative() {
+    let fixture = temp_fixture();
+    std::fs::create_dir_all(fixture.path().join("generated")).unwrap();
+    std::fs::write(
+        fixture.path().join("generated/tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":"."}}"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(fixture.path().join("packages/app/generated")).unwrap();
+    std::fs::write(
+        fixture.path().join("packages/app/generated/tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":"."}}"#,
+    )
+    .unwrap();
+
+    let snapshot = discover_project_with_ignore(fixture.path(), &["/generated/".to_string()])
+        .expect("project should discover");
+    let relative_paths = snapshot
+        .files
+        .iter()
+        .map(|file| file.relative_path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!relative_paths.contains(&"generated/tsconfig.json"));
+    assert!(relative_paths.contains(&"packages/app/generated/tsconfig.json"));
+}
+
+#[test]
 fn discovery_skips_directly_ignored_target_directory() {
     let fixture = temp_fixture();
     let target = fixture.path().join("packages/app/generated");


### PR DESCRIPTION
## 배경

`.gitignore`, `.maximusignore`, `maximus.config.json`의 `ignorePatterns`가 Rust canonical runtime의 discovery와 lockfiles traversal에 함께 반영되지 않아, 생성물이나 예외 처리된 파일이 검사 대상으로 남을 수 있었습니다.

추가 리뷰에서 `.gitignore`를 전역 discovery에 그대로 적용하면 env check가 의도적으로 추적해야 하는 `.env.local` 입력까지 숨길 수 있는 회귀가 확인되어, `.gitignore` source와 `.maximusignore` / config ignore source를 분리했습니다.

## 변경 사항

- `MaximusConfig`에 runtime-only `gitignore_patterns`를 추가하고, 기존 `ignore` / config `ignorePatterns`와 함께 effective ignore pattern을 구성합니다.
- CLI config resolution에서 `.gitignore`와 `.maximusignore`를 별도 source로 읽어 `.gitignore`는 일반 source discovery에는 반영하되 env 입력 discovery에는 적용하지 않습니다.
- `.maximusignore`와 config ignore pattern은 env 입력 재탐색에도 유지해 명시적 사용자 제외 의도를 보존합니다.
- discovery ignore matcher에 gitignore-style negation, basename glob, directory-only prefix matching을 추가했습니다.
- lockfiles check도 같은 effective ignore pattern을 사용하게 맞췄습니다.
- ancestor `.gitignore`, `.maximusignore`, nested config-relative `ignorePatterns`, negation 동작, `.gitignore`가 env 입력을 숨기지 않는 회귀를 테스트로 고정했습니다.

## 검증

- `env CARGO_NET_OFFLINE=true cargo test -p maximus-cli --test config_and_filtering`
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-core`
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-checks lockfiles`
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-cli`
- `rustfmt --check --edition 2021 crates/maximus-core/src/config.rs crates/maximus-checks/src/registry.rs crates/maximus-cli/tests/config_and_filtering.rs`
- `git diff --check`

## Review Gate

- `$devils-advocate-review-loop`: CHANGE_REQUEST 1건 수용 후 수정
- `$independent-pr-review-comment`: APPROVE
- Severity: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- Base: `master`
- Branch: `codex/ignore-pattern-sources`
- Worktree: `/private/tmp/maximus-ignore-pattern-sources`
- Source root worktree `/Users/pjw/workspace/maximus`에는 기존 `workspace_config` / `vite_tsconfig_alias` 계열 dirty 변경이 있어, 별도 clean worktree에서 이번 ignore 변경만 분리해 패키징했습니다.

## 이슈 연결

- 별도 이슈 번호 없음.
