### PR TITLE
fix: env negated directory 보호 판정 보정

### DIFF
--- a/crates/maximus-checks/src/env.rs
+++ b/crates/maximus-checks/src/env.rs
@@ -592,7 +592,7 @@ fn pattern_matches_file(
     file_name: &str,
 ) -> bool {
     if pattern.directory_only {
-        return directory_pattern_matches_file(pattern, relative_path);
+        return !pattern.negated && directory_pattern_matches_file(pattern, relative_path);
     }
 
     directory_pattern_matches_file(pattern, relative_path)

--- a/crates/maximus-checks/tests/env_checks.rs
+++ b/crates/maximus-checks/tests/env_checks.rs
@@ -312,6 +312,29 @@ fn env_check_reports_unprotected_concrete_env_files_and_respects_root_and_nested
         "bare directory .gitignore pattern should protect files under that directory"
     );
 
+    let negated_directory_fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        negated_directory_fixture.path().join("secrets/.env"),
+        "API_TOKEN=abcdef1234567890\n",
+    );
+    write(
+        negated_directory_fixture.path().join(".gitignore"),
+        "*.env\n!secrets/\n",
+    );
+
+    let negated_directory_project =
+        discover_project(negated_directory_fixture.path()).expect("project should discover");
+    let negated_directory_outcome =
+        run_env_check(&negated_directory_project).expect("check should run");
+
+    assert!(
+        !negated_directory_outcome
+            .findings
+            .iter()
+            .any(|finding| finding.id.starts_with("env-gitignore:")),
+        "negated directory pattern should not unprotect ignored env files inside that directory"
+    );
+
     let tracked_fixture = TempDir::new().expect("temp dir should exist");
     write(
         tracked_fixture.path().join(".env"),

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -167,7 +167,7 @@ function normalizeGitignorePattern(pattern) {
 
 function patternMatchesFile(pattern, relativePath, fileName) {
   if (pattern.directoryOnly) {
-    return directoryPatternMatchesFile(pattern, relativePath);
+    return !pattern.negated && directoryPatternMatchesFile(pattern, relativePath);
   }
 
   return (

--- a/test/env-fix.test.js
+++ b/test/env-fix.test.js
@@ -128,6 +128,7 @@ test("env gitignore protection honors negation and ancestor gitignore files", as
   const leadingSpaceRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-leading-space-"));
   const directoryRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-directory-"));
   const bareDirectoryRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-bare-directory-"));
+  const negatedDirectoryRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-negated-directory-"));
   const trackedRoot = await mkdtemp(path.join(os.tmpdir(), "maximus-env-gitignore-tracked-"));
 
   t.after(async () => {
@@ -142,6 +143,7 @@ test("env gitignore protection honors negation and ancestor gitignore files", as
     await rm(leadingSpaceRoot, { recursive: true, force: true });
     await rm(directoryRoot, { recursive: true, force: true });
     await rm(bareDirectoryRoot, { recursive: true, force: true });
+    await rm(negatedDirectoryRoot, { recursive: true, force: true });
     await rm(trackedRoot, { recursive: true, force: true });
   });
 
@@ -201,6 +203,16 @@ test("env gitignore protection honors negation and ancestor gitignore files", as
   assert.ok(
     !bareDirectoryAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
     "bare directory .gitignore pattern should protect files under that directory",
+  );
+
+  await mkdir(path.join(negatedDirectoryRoot, "secrets"), { recursive: true });
+  await writeFile(path.join(negatedDirectoryRoot, "secrets/.env"), "API_TOKEN=abcdef1234567890\n", "utf8");
+  await writeFile(path.join(negatedDirectoryRoot, ".gitignore"), "*.env\n!secrets/\n", "utf8");
+
+  const negatedDirectoryAudit = await auditProject(negatedDirectoryRoot);
+  assert.ok(
+    !negatedDirectoryAudit.findings.some((finding) => finding.id.startsWith("env-gitignore:")),
+    "negated directory pattern should not unprotect ignored env files inside that directory",
   );
 
   await writeFile(path.join(trackedRoot, ".env"), "API_TOKEN=abcdef1234567890\n", "utf8");


### PR DESCRIPTION
## 배경

PR #74 병합 직후 fresh review에서 `.gitignore`의 negated directory 패턴을 파일 보호 상태에 그대로 적용해 Git의 실제 ignore 판정과 어긋나는 케이스가 확인됐습니다. 기존 PR은 이미 병합되어 원격 head가 삭제됐기 때문에, 최신 `master` 기준의 독립 후속 PR로 분리했습니다.

## 변경 사항

- JS/Rust env gitignore 판정에서 directory-only negation이 descendant env file을 unprotect하지 않도록 보정했습니다.
- `*.env`와 `!secrets/` 조합에서 `secrets/.env`가 여전히 보호된 상태로 남는 회귀 테스트를 JS/Rust 양쪽에 추가했습니다.
- JS/Rust parity를 유지하도록 동일한 조건 분기를 반영했습니다.

## 검증

- `env CARGO_NET_OFFLINE=true node --test test/env-fix.test.js`
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-checks --test env_checks`
- `rustfmt --check crates/maximus-checks/src/env.rs crates/maximus-checks/tests/env_checks.rs`
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-cli`
- `env CARGO_NET_OFFLINE=true npm test` 최종 재실행 124 pass / 0 fail / 0 skipped
- `git diff --check`

## Review Gate

- `$devils-advocate-review-loop`: APPROVE
- Severity: Critical 0 / High 0 / Medium 1 / Low 0
- Medium: `secrets/` 뒤 `!secrets/.env`만 있는 기존 Git parity gap은 남아 있지만, 이번 PR의 타깃인 `*.env` + `!secrets/` 회귀는 해결됐고 merge blocker는 아닙니다.

## 브랜치 / 워크트리

- Base: `master`
- Branch: `codex/fix-env-negated-directory`
- Worktree: `/private/tmp/maximus-followup/env-negated-directory`
