### PR TITLE
fix: Vite 함수형 config alias 파싱 보정

### DIFF
--- a/crates/maximus-checks/src/vite_tsconfig_alias.rs
+++ b/crates/maximus-checks/src/vite_tsconfig_alias.rs
@@ -170,13 +170,115 @@ fn find_vite_config_object_start(text: &str) -> Option<usize> {
         let Some('(') = text[cursor..].chars().next() else {
             return None;
         };
+        let call_end = find_matching_delimiter(text, cursor, '(', ')')?;
         cursor = skip_ws_and_comments(text, cursor + 1);
+        if let Some(object_start) = find_arrow_returned_config_object_start(text, cursor, call_end)
+        {
+            return Some(object_start);
+        }
     }
 
     match text[cursor..].chars().next()? {
         '{' => Some(cursor),
         _ => None,
     }
+}
+
+fn find_arrow_returned_config_object_start(
+    text: &str,
+    cursor: usize,
+    call_end: usize,
+) -> Option<usize> {
+    let arrow = find_top_level_arrow(text, cursor, call_end)?;
+    let body = skip_ws_and_comments(text, arrow + 2);
+    match text[body..].chars().next()? {
+        '(' => {
+            let inner = skip_ws_and_comments(text, body + 1);
+            if text[inner..].starts_with('{') {
+                Some(inner)
+            } else {
+                None
+            }
+        }
+        '{' => find_block_returned_config_object_start(text, body),
+        _ => None,
+    }
+}
+
+fn find_block_returned_config_object_start(text: &str, block_start: usize) -> Option<usize> {
+    let block_end = find_matching_delimiter(text, block_start, '{', '}')?;
+    let mut cursor = block_start + 1;
+
+    while cursor < block_end {
+        cursor = skip_ws_and_comments(text, cursor);
+        if cursor >= block_end {
+            break;
+        }
+        if starts_with_keyword(text, cursor, "return") {
+            let value_start = skip_ws_and_comments(text, cursor + "return".len());
+            return match text[value_start..].chars().next()? {
+                '{' => Some(value_start),
+                '(' => {
+                    let inner = skip_ws_and_comments(text, value_start + 1);
+                    if text[inner..].starts_with('{') {
+                        Some(inner)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+        }
+
+        let ch = text[cursor..].chars().next()?;
+        cursor = match ch {
+            '\'' | '"' => parse_string_literal(text, cursor)?.1,
+            '`' => skip_template_literal(text, cursor)?,
+            '(' => find_matching_delimiter(text, cursor, '(', ')')? + 1,
+            '[' => find_matching_delimiter(text, cursor, '[', ']')? + 1,
+            '{' => find_matching_delimiter(text, cursor, '{', '}')? + 1,
+            _ => cursor + ch.len_utf8(),
+        };
+    }
+
+    None
+}
+
+fn find_top_level_arrow(text: &str, mut cursor: usize, limit: usize) -> Option<usize> {
+    while cursor < limit {
+        cursor = skip_ws_and_comments(text, cursor);
+        if cursor >= limit {
+            break;
+        }
+        if text[cursor..].starts_with("=>") {
+            return Some(cursor);
+        }
+
+        let ch = text[cursor..].chars().next()?;
+        match ch {
+            '\'' | '"' => {
+                let (_, next_cursor) = parse_string_literal(text, cursor)?;
+                cursor = next_cursor;
+            }
+            '`' => {
+                cursor = skip_template_literal(text, cursor)?;
+            }
+            '(' => {
+                cursor = find_matching_delimiter(text, cursor, '(', ')')? + 1;
+            }
+            '[' => {
+                cursor = find_matching_delimiter(text, cursor, '[', ']')? + 1;
+            }
+            '{' => {
+                cursor = find_matching_delimiter(text, cursor, '{', '}')? + 1;
+            }
+            _ => {
+                cursor += ch.len_utf8();
+            }
+        }
+    }
+
+    None
 }
 
 fn find_export_default_value_start(text: &str) -> Option<usize> {

--- a/crates/maximus-checks/tests/vite_tsconfig_alias_registry.rs
+++ b/crates/maximus-checks/tests/vite_tsconfig_alias_registry.rs
@@ -192,6 +192,48 @@ fn vite_tsconfig_alias_check_reports_path_resolve_object_mismatches() {
 }
 
 #[test]
+fn vite_tsconfig_alias_check_reports_function_form_config_mismatches() {
+    let fixture = fixture("function-form-mismatch");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_vite_tsconfig_alias_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "vite-alias-sync:{}:@app",
+            fixture.join("vite.config.ts").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Vite alias \"@app\" differs from tsconfig paths",
+        "Vite resolves \"@app\" to",
+        "Align both alias surfaces so editor and bundler resolution stay in sync.",
+        Some(fixture.join("vite.config.ts")),
+    );
+}
+
+#[test]
+fn vite_tsconfig_alias_check_reports_function_form_block_return_mismatches() {
+    let fixture = fixture("function-form-block-mismatch");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_vite_tsconfig_alias_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "vite-alias-sync:{}:@app",
+            fixture.join("vite.config.ts").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Vite alias \"@app\" differs from tsconfig paths",
+        "Vite resolves \"@app\" to",
+        "Align both alias surfaces so editor and bundler resolution stay in sync.",
+        Some(fixture.join("vite.config.ts")),
+    );
+}
+
+#[test]
 fn vite_tsconfig_alias_check_ignores_alias_tokens_inside_comments() {
     let fixture = fixture("comment-prefix-mismatch");
 

--- a/test/fixtures/vite-tsconfig-alias-sync/function-form-block-mismatch/tsconfig.json
+++ b/test/fixtures/vite-tsconfig-alias-sync/function-form-block-mismatch/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./src/server/*"]
+    }
+  }
+}

--- a/test/fixtures/vite-tsconfig-alias-sync/function-form-block-mismatch/vite.config.ts
+++ b/test/fixtures/vite-tsconfig-alias-sync/function-form-block-mismatch/vite.config.ts
@@ -1,0 +1,13 @@
+function defineConfig(value: unknown) {
+  return value;
+}
+
+export default defineConfig(() => {
+  return {
+    resolve: {
+      alias: {
+        "@app": "./src/client",
+      },
+    },
+  };
+});

--- a/test/fixtures/vite-tsconfig-alias-sync/function-form-mismatch/tsconfig.json
+++ b/test/fixtures/vite-tsconfig-alias-sync/function-form-mismatch/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./src/server/*"]
+    }
+  }
+}

--- a/test/fixtures/vite-tsconfig-alias-sync/function-form-mismatch/vite.config.ts
+++ b/test/fixtures/vite-tsconfig-alias-sync/function-form-mismatch/vite.config.ts
@@ -1,0 +1,11 @@
+function defineConfig(value: unknown) {
+  return value;
+}
+
+export default defineConfig(() => ({
+  resolve: {
+    alias: {
+      "@app": "./src/client",
+    },
+  },
+}));


### PR DESCRIPTION
## 배경

PR #72 병합 직후 fresh review에서 Vite `defineConfig(() => ({ ... }))` 형태의 함수형 config가 alias 검사에서 통째로 skip되는 문제가 확인됐습니다. 기존 PR은 이미 병합되어 원격 head가 삭제됐기 때문에, 최신 `master` 기준의 독립 후속 PR로 분리했습니다.

추가 독립 리뷰에서 `defineConfig(() => { return { ... }; })` 블록 반환형도 skip되는 High finding이 확인되어, 같은 PR 안에서 accepted fix로 반영했습니다.

## 변경 사항

- `defineConfig` 호출의 첫 번째 인자가 arrow function일 때, 괄호로 감싼 객체 반환식 `() => ({ ... })`을 Vite config object로 인식합니다.
- block-body arrow function의 top-level `return { ... }` / `return ({ ... })`도 Vite config object로 인식합니다.
- function-form mismatch와 block-return mismatch fixture를 추가해 `tsconfig` paths와 Vite alias 불일치가 실제 finding으로 보고되는지 고정했습니다.
- Rust registry 테스트에 함수형 config mismatch 케이스를 추가했습니다.

## 검증

- `env CARGO_NET_OFFLINE=true cargo test -p maximus-checks --test vite_tsconfig_alias_registry`
- `env CARGO_NET_OFFLINE=true node --test test/fixtures/vite-tsconfig-alias-sync/function-form-mismatch/vite.config.ts`
- `env CARGO_NET_OFFLINE=true node --test test/fixtures/vite-tsconfig-alias-sync/function-form-block-mismatch/vite.config.ts`
- `rustfmt --check crates/maximus-checks/src/vite_tsconfig_alias.rs crates/maximus-checks/tests/vite_tsconfig_alias_registry.rs`
- `env CARGO_NET_OFFLINE=true npm test` 최종 재실행 126 pass / 0 fail / 0 skipped
- `env CARGO_NET_OFFLINE=true cargo test -p maximus-cli`
- `git diff --check`

## Review Gate

- `$devils-advocate-review-loop`: CHANGE_REQUEST 1건 수용 후 수정
- `$independent-pr-review-comment`: APPROVE
- Severity: Critical 0 / High 0 / Medium 1 / Low 0
- Medium: 조건부/다중 `return`이 있는 동적 block-body config에서 첫 return을 config로 채택할 수 있습니다. 이번 PR의 타깃인 단일 객체 반환 회귀에서는 merge blocker가 아니며, 동적 config 정책은 별도 follow-up으로 분리하는 것이 안전합니다.

## 브랜치 / 워크트리

- Base: `master`
- Branch: `codex/fix-vite-function-config`
- Worktree: `/private/tmp/maximus-followup/vite-function-config`
