### PR TITLE
feat: test runner와 editorconfig 충돌 검사 추가

### DIFF
--- a/crates/maximus-checks/src/editorconfig_prettier.rs
+++ b/crates/maximus-checks/src/editorconfig_prettier.rs
@@ -1,0 +1,351 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use maximus_core::{
+    make_finding, parse_jsonc, read_text_if_exists, FileKind, FindingInput, ProjectFile,
+    ProjectSnapshot, Severity,
+};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{package_file_for_directory, read_package_json};
+
+#[derive(Debug)]
+struct EditorConfigDocument {
+    path: PathBuf,
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct PrettierDocument {
+    path: PathBuf,
+    values: BTreeMap<String, String>,
+}
+
+pub fn run_editorconfig_prettier_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let editorconfigs = find_editorconfig_documents(&project.root_dir)?;
+    if editorconfigs.is_empty() {
+        return Ok(CheckOutcome {
+            findings: Vec::new(),
+            fixes: Vec::new(),
+            planned_fixes: Vec::new(),
+        });
+    }
+
+    let prettier_documents = find_prettier_documents(project)?;
+    let editorconfig = &editorconfigs[0];
+    let mut findings = Vec::new();
+    let mut reported_directories = BTreeSet::new();
+
+    for prettier in prettier_documents {
+        let conflicts = find_conflicts(&editorconfig.values, &prettier.values);
+        if conflicts.is_empty() {
+            continue;
+        }
+
+        let directory = prettier
+            .path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| project.root_dir.clone());
+        if !reported_directories.insert(directory.clone()) {
+            continue;
+        }
+
+        let editor_detail = conflicts
+            .iter()
+            .map(|conflict| {
+                format!(
+                    "{}={}",
+                    conflict.editorconfig_key, conflict.editorconfig_value
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let prettier_detail = conflicts
+            .iter()
+            .map(|conflict| format!("{}={}", conflict.prettier_key, conflict.prettier_value))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        findings.push(make_finding(FindingInput {
+            id: format!(
+                "editorconfig-prettier-conflict:{}",
+                directory.to_string_lossy()
+            ),
+            title: "EditorConfig and Prettier disagree".to_string(),
+            category: Some("editorconfig-prettier".to_string()),
+            detail: Some(format!(
+                "EditorConfig sets {editor_detail}, but Prettier sets {prettier_detail}."
+            )),
+            file: Some(editorconfig.path.clone()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Align EditorConfig and Prettier so editor saves do not fight formatter output."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+#[derive(Debug)]
+struct Conflict {
+    editorconfig_key: &'static str,
+    editorconfig_value: String,
+    prettier_key: &'static str,
+    prettier_value: String,
+}
+
+fn find_conflicts(
+    editorconfig: &BTreeMap<String, String>,
+    prettier: &BTreeMap<String, String>,
+) -> Vec<Conflict> {
+    let mut conflicts = Vec::new();
+
+    if let (Some(indent_style), Some(use_tabs)) =
+        (editorconfig.get("indent_style"), prettier.get("useTabs"))
+    {
+        let expected_use_tabs = match indent_style.as_str() {
+            "tab" => Some("true"),
+            "space" => Some("false"),
+            _ => None,
+        };
+        if expected_use_tabs.is_some_and(|expected| expected != use_tabs) {
+            conflicts.push(Conflict {
+                editorconfig_key: "indent_style",
+                editorconfig_value: indent_style.clone(),
+                prettier_key: "useTabs",
+                prettier_value: use_tabs.clone(),
+            });
+        }
+    }
+
+    if let (Some(indent_size), Some(tab_width)) =
+        (editorconfig.get("indent_size"), prettier.get("tabWidth"))
+    {
+        if indent_size != "tab"
+            && parse_positive_number(indent_size) != parse_positive_number(tab_width)
+        {
+            conflicts.push(Conflict {
+                editorconfig_key: "indent_size",
+                editorconfig_value: indent_size.clone(),
+                prettier_key: "tabWidth",
+                prettier_value: tab_width.clone(),
+            });
+        }
+    }
+
+    if let (Some(end_of_line), Some(prettier_end_of_line)) =
+        (editorconfig.get("end_of_line"), prettier.get("endOfLine"))
+    {
+        if prettier_end_of_line != "auto" && end_of_line != prettier_end_of_line {
+            conflicts.push(Conflict {
+                editorconfig_key: "end_of_line",
+                editorconfig_value: end_of_line.clone(),
+                prettier_key: "endOfLine",
+                prettier_value: prettier_end_of_line.clone(),
+            });
+        }
+    }
+
+    if let (Some(max_line_length), Some(print_width)) = (
+        editorconfig.get("max_line_length"),
+        prettier.get("printWidth"),
+    ) {
+        if max_line_length != "off"
+            && parse_positive_number(max_line_length) != parse_positive_number(print_width)
+        {
+            conflicts.push(Conflict {
+                editorconfig_key: "max_line_length",
+                editorconfig_value: max_line_length.clone(),
+                prettier_key: "printWidth",
+                prettier_value: print_width.clone(),
+            });
+        }
+    }
+
+    conflicts
+}
+
+fn find_editorconfig_documents(root_dir: &Path) -> io::Result<Vec<EditorConfigDocument>> {
+    let path = root_dir.join(".editorconfig");
+    let Some(text) = read_text_if_exists(&path)? else {
+        return Ok(Vec::new());
+    };
+
+    let values = parse_editorconfig_values(&text);
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![EditorConfigDocument { path, values }])
+}
+
+fn find_prettier_documents(project: &ProjectSnapshot) -> io::Result<Vec<PrettierDocument>> {
+    let mut documents = Vec::new();
+
+    for directory in &project.directories {
+        if let Some(package_file) = package_file_for_directory(directory) {
+            if let Some(prettier) = read_package_prettier(package_file) {
+                documents.push(prettier);
+            }
+        }
+
+        if let Some(prettier_files) = directory.files_by_kind.get(&FileKind::Prettier) {
+            for file in prettier_files {
+                if let Some(prettier) = read_prettier_file(file)? {
+                    documents.push(prettier);
+                }
+            }
+        }
+    }
+
+    Ok(documents)
+}
+
+fn read_package_prettier(package_file: &ProjectFile) -> Option<PrettierDocument> {
+    let package_json = read_package_json(&package_file.path)?;
+    let prettier = package_json.get("prettier")?;
+    let values = prettier_values_from_json(prettier);
+    if values.is_empty() {
+        return None;
+    }
+
+    Some(PrettierDocument {
+        path: package_file.path.clone(),
+        values,
+    })
+}
+
+fn read_prettier_file(file: &ProjectFile) -> io::Result<Option<PrettierDocument>> {
+    let Some(text) = read_text_if_exists(&file.path)? else {
+        return Ok(None);
+    };
+
+    let values = parse_jsonc::<Value>(&text, &file.path.to_string_lossy())
+        .ok()
+        .map(|value| prettier_values_from_json(&value))
+        .unwrap_or_else(|| prettier_values_from_text(&text));
+
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(PrettierDocument {
+        path: file.path.clone(),
+        values,
+    }))
+}
+
+fn prettier_values_from_json(value: &Value) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    let Some(object) = value.as_object() else {
+        return values;
+    };
+
+    for key in ["useTabs", "tabWidth", "endOfLine", "printWidth"] {
+        if let Some(value) = object.get(key).and_then(normalize_prettier_value) {
+            values.insert(key.to_string(), value);
+        }
+    }
+
+    values
+}
+
+fn prettier_values_from_text(text: &str) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    for key in ["useTabs", "tabWidth", "endOfLine", "printWidth"] {
+        if let Some(value) = find_js_property_value(text, key) {
+            values.insert(key.to_string(), value);
+        }
+    }
+    values
+}
+
+fn normalize_prettier_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::String(value) => Some(value.to_ascii_lowercase()),
+        _ => None,
+    }
+}
+
+fn parse_editorconfig_values(text: &str) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+
+    for line in text.lines() {
+        let line = strip_editorconfig_comment(line).trim();
+        if line.is_empty() || line.starts_with('[') {
+            if line.starts_with('[') {
+                break;
+            }
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        values.insert(
+            key.trim().to_ascii_lowercase(),
+            value.trim().to_ascii_lowercase(),
+        );
+    }
+
+    values
+}
+
+fn strip_editorconfig_comment(line: &str) -> &str {
+    line.split(['#', ';']).next().unwrap_or(line)
+}
+
+fn parse_positive_number(value: &str) -> Option<u64> {
+    value.parse::<u64>().ok()
+}
+
+fn find_js_property_value(text: &str, property: &str) -> Option<String> {
+    for quote in ['"', '\''] {
+        let needle = format!("{quote}{property}{quote}");
+        if let Some(value) = find_js_property_value_after(text, &needle) {
+            return Some(value);
+        }
+    }
+
+    find_js_property_value_after(text, property)
+}
+
+fn find_js_property_value_after(text: &str, needle: &str) -> Option<String> {
+    let index = text.find(needle)?;
+    let after_key = &text[index + needle.len()..];
+    let colon = after_key.find(':')?;
+    let after_colon = after_key[colon + 1..].trim_start();
+    parse_simple_js_value(after_colon)
+}
+
+fn parse_simple_js_value(text: &str) -> Option<String> {
+    let first = text.chars().next()?;
+    if first == '"' || first == '\'' {
+        let rest = &text[first.len_utf8()..];
+        let end = rest.find(first)?;
+        return Some(rest[..end].to_ascii_lowercase());
+    }
+
+    let value = text
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod check_outcome;
 mod config_duplicates;
+mod editorconfig_prettier;
 mod env;
 mod eslint_prettier;
 mod jsx_config;
@@ -11,12 +12,14 @@ mod monorepo_tsconfig;
 pub mod package_entrypoints;
 pub mod registry;
 pub mod structure;
+mod test_runner_config;
 mod tsconfig;
 mod vite_tsconfig_alias;
 mod workspace_config;
 
 pub use check_outcome::CheckOutcome;
 pub use config_duplicates::run_config_duplicate_check;
+pub use editorconfig_prettier::run_editorconfig_prettier_check;
 pub use env::{render_created_env_example, render_synced_env_example, run_env_check};
 pub use eslint_prettier::run_eslint_prettier_check;
 pub use jsx_config::run_jsx_config_check;
@@ -28,6 +31,7 @@ pub use registry::{
     run_registered_checks_with_config_root, run_registered_checks_with_filters, AuditedProject,
 };
 pub use structure::build_structure_report;
+pub use test_runner_config::run_test_runner_config_check;
 pub use tsconfig::run_tsconfig_check;
 pub use vite_tsconfig_alias::run_vite_tsconfig_alias_check;
 pub use workspace_config::run_workspace_config_check;

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -17,11 +17,12 @@ use crate::lockfiles::run_lockfiles_check_with_ignore_root;
 use crate::module_system::run_module_system_check;
 use crate::monorepo_tsconfig::run_monorepo_tsconfig_check;
 use crate::package_entrypoints::run_package_entrypoints_check;
+use crate::test_runner_config::run_test_runner_config_check;
 use crate::vite_tsconfig_alias::run_vite_tsconfig_alias_check;
 use crate::workspace_config::run_workspace_config_check;
 use crate::{
-    build_structure_report, run_config_duplicate_check, run_env_check, run_eslint_prettier_check,
-    run_tsconfig_check,
+    build_structure_report, run_config_duplicate_check, run_editorconfig_prettier_check,
+    run_env_check, run_eslint_prettier_check, run_tsconfig_check,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,6 +84,14 @@ const REGISTERED_CHECKS: &[RegisteredCheck] = &[
         id: "workspace-config",
         run: run_workspace_config_check_registered,
     },
+    RegisteredCheck {
+        id: "test-runner-config",
+        run: run_test_runner_config_check_registered,
+    },
+    RegisteredCheck {
+        id: "editorconfig-prettier",
+        run: run_editorconfig_prettier_check_registered,
+    },
 ];
 
 pub fn registered_check_ids() -> &'static [&'static str] {
@@ -98,6 +107,8 @@ pub fn registered_check_ids() -> &'static [&'static str] {
         "package-entrypoints",
         "vite-tsconfig-alias",
         "workspace-config",
+        "test-runner-config",
+        "editorconfig-prettier",
     ]
 }
 
@@ -478,6 +489,22 @@ fn run_workspace_config_check_registered(
     _ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
     run_workspace_config_check(project)
+}
+
+fn run_test_runner_config_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_test_runner_config_check(project)
+}
+
+fn run_editorconfig_prettier_check_registered(
+    project: &ProjectSnapshot,
+    _config: &MaximusConfig,
+    _ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    run_editorconfig_prettier_check(project)
 }
 
 fn apply_severity_overrides(

--- a/crates/maximus-checks/src/test_runner_config.rs
+++ b/crates/maximus-checks/src/test_runner_config.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use maximus_core::{make_finding, FileKind, FindingInput, ProjectFile, ProjectSnapshot, Severity};
+
+use crate::check_outcome::CheckOutcome;
+use crate::registry::{package_file_for_directory, read_package_json};
+
+#[derive(Default)]
+struct TestRunnerSources {
+    jest_file: Option<PathBuf>,
+    vitest_file: Option<PathBuf>,
+    package_file: Option<PathBuf>,
+    has_package_jest: bool,
+    has_package_vitest: bool,
+}
+
+pub fn run_test_runner_config_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    let mut sources_by_dir = BTreeMap::<PathBuf, TestRunnerSources>::new();
+
+    for directory in &project.directories {
+        let sources = sources_by_dir.entry(directory.dir.clone()).or_default();
+
+        if let Some(jest_file) = directory
+            .files_by_kind
+            .get(&FileKind::Jest)
+            .and_then(|files| files.first())
+        {
+            sources.jest_file = Some(jest_file.path.clone());
+        }
+
+        if let Some(package_file) = package_file_for_directory(directory) {
+            sources.package_file = Some(package_file.path.clone());
+            sources.has_package_jest = package_has_jest_config(package_file);
+            sources.has_package_vitest = package_has_vitest_config(package_file);
+        }
+    }
+
+    for vitest_file in find_vitest_config_files(&project.root_dir)? {
+        let directory = vitest_file
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| project.root_dir.clone());
+        sources_by_dir.entry(directory).or_default().vitest_file = Some(vitest_file);
+    }
+
+    let mut findings = Vec::new();
+    for (directory, sources) in sources_by_dir {
+        let has_jest = sources.jest_file.is_some() || sources.has_package_jest;
+        let has_vitest = sources.vitest_file.is_some() || sources.has_package_vitest;
+
+        if !has_jest || !has_vitest {
+            continue;
+        }
+
+        let file = sources.jest_file.or(sources.package_file);
+        findings.push(make_finding(FindingInput {
+            id: format!("test-runner-dual-config:{}", directory.to_string_lossy()),
+            title: "Jest and Vitest configs coexist".to_string(),
+            category: Some("test-runner-config".to_string()),
+            detail: Some(
+                "This directory declares both Jest and Vitest configuration, so tests can run under different environments depending on the command."
+                    .to_string(),
+            ),
+            file,
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Pick one runner for this package, or document the split with separate config ownership and scripts."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn package_has_jest_config(package_file: &ProjectFile) -> bool {
+    package_has_config_field(package_file, "jest")
+}
+
+fn package_has_vitest_config(package_file: &ProjectFile) -> bool {
+    package_has_config_field(package_file, "vitest")
+}
+
+fn package_has_config_field(package_file: &ProjectFile, field: &str) -> bool {
+    read_package_json(&package_file.path)
+        .map(|package_json| {
+            package_json
+                .as_object()
+                .map(|object| object.contains_key(field))
+                .unwrap_or(false)
+        })
+        .unwrap_or(false)
+}
+
+fn find_vitest_config_files(root_dir: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_vitest_config_files(root_dir, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_vitest_config_files(directory: &Path, files: &mut Vec<PathBuf>) -> io::Result<()> {
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+
+        if file_type.is_dir() {
+            if should_skip_directory(&name) {
+                continue;
+            }
+            collect_vitest_config_files(&path, files)?;
+        } else if file_type.is_file() && is_vitest_config_name(&name) {
+            files.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_vitest_config_name(name: &str) -> bool {
+    matches!(
+        name,
+        "vitest.config.js"
+            | "vitest.config.cjs"
+            | "vitest.config.mjs"
+            | "vitest.config.ts"
+            | "vitest.config.cts"
+            | "vitest.config.mts"
+    )
+}
+
+fn should_skip_directory(name: &str) -> bool {
+    matches!(
+        name,
+        ".git" | "node_modules" | "dist" | "build" | "coverage" | "target"
+    )
+}

--- a/crates/maximus-checks/tests/editorconfig_prettier_registry.rs
+++ b/crates/maximus-checks/tests/editorconfig_prettier_registry.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+
+use maximus_checks::{run_editorconfig_prettier_check, run_registered_checks};
+use maximus_core::{discover_project, Severity};
+
+#[test]
+fn editorconfig_prettier_check_reports_conflicts_and_registry_wiring() {
+    let fixture = fixture("conflict");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_editorconfig_prettier_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("editorconfig-prettier-conflict:{}", fixture.to_string_lossy()),
+        Severity::Warn,
+        "EditorConfig and Prettier disagree",
+        "EditorConfig sets indent_style=tab, indent_size=4, end_of_line=crlf, but Prettier sets useTabs=false, tabWidth=2, endOfLine=lf.",
+        "Align EditorConfig and Prettier so editor saves do not fight formatter output.",
+        Some(fixture.join(".editorconfig")),
+    );
+
+    let registered = run_registered_checks(&project).expect("registry should run");
+    assert!(
+        registered.findings.iter().any(|finding| {
+            finding.id
+                == format!(
+                    "editorconfig-prettier-conflict:{}",
+                    fixture.to_string_lossy()
+                )
+        }),
+        "registry should include the EditorConfig/Prettier check"
+    );
+}
+
+#[test]
+fn editorconfig_prettier_check_accepts_aligned_configs() {
+    let fixture = fixture("clean");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_editorconfig_prettier_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "aligned EditorConfig and Prettier values should not produce findings"
+    );
+}
+
+#[test]
+fn editorconfig_prettier_check_ignores_section_specific_values() {
+    let fixture = fixture("section-override");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_editorconfig_prettier_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "section-specific EditorConfig overrides should not count as root defaults"
+    );
+}
+
+#[test]
+fn editorconfig_prettier_check_ignores_nested_editorconfig_files() {
+    let fixture = fixture("nested-override");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_editorconfig_prettier_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "nested EditorConfig files should not override the repository root default block"
+    );
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test/fixtures/editorconfig-prettier")
+        .join(name)
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    detail: &str,
+    hint: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.detail, detail);
+    assert_eq!(finding.hint, hint);
+    assert_eq!(finding.file, file);
+    assert!(!finding.fixable);
+    assert!(finding.fix_ids.is_empty());
+}

--- a/crates/maximus-checks/tests/test_runner_config_registry.rs
+++ b/crates/maximus-checks/tests/test_runner_config_registry.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+
+use maximus_checks::{run_registered_checks, run_test_runner_config_check};
+use maximus_core::{discover_project, Severity};
+
+#[test]
+fn test_runner_config_check_reports_jest_vitest_dual_config_and_registry_wiring() {
+    let fixture = fixture("dual-config");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_test_runner_config_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("test-runner-dual-config:{}", fixture.to_string_lossy()),
+        Severity::Warn,
+        "Jest and Vitest configs coexist",
+        "This directory declares both Jest and Vitest configuration, so tests can run under different environments depending on the command.",
+        "Pick one runner for this package, or document the split with separate config ownership and scripts.",
+        Some(fixture.join("jest.config.js")),
+    );
+
+    let registered = run_registered_checks(&project).expect("registry should run");
+    assert!(
+        registered.findings.iter().any(|finding| {
+            finding.id == format!("test-runner-dual-config:{}", fixture.to_string_lossy())
+        }),
+        "registry should include the test runner config check"
+    );
+}
+
+#[test]
+fn test_runner_config_check_accepts_single_runner_projects() {
+    let fixture = fixture("vitest-only");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_test_runner_config_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "single-runner projects should not produce findings"
+    );
+}
+
+#[test]
+fn test_runner_config_check_detects_vitest_package_field_with_jest_file() {
+    let fixture = fixture("package-field");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_test_runner_config_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("test-runner-dual-config:{}", fixture.to_string_lossy()),
+        Severity::Warn,
+        "Jest and Vitest configs coexist",
+        "This directory declares both Jest and Vitest configuration, so tests can run under different environments depending on the command.",
+        "Pick one runner for this package, or document the split with separate config ownership and scripts.",
+        Some(fixture.join("jest.config.js")),
+    );
+}
+
+#[test]
+fn test_runner_config_check_detects_package_json_dual_fields_without_config_files() {
+    let fixture = fixture("package-only");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_test_runner_config_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("test-runner-dual-config:{}", fixture.to_string_lossy()),
+        Severity::Warn,
+        "Jest and Vitest configs coexist",
+        "This directory declares both Jest and Vitest configuration, so tests can run under different environments depending on the command.",
+        "Pick one runner for this package, or document the split with separate config ownership and scripts.",
+        Some(fixture.join("package.json")),
+    );
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test/fixtures/test-runners")
+        .join(name)
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    detail: &str,
+    hint: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.detail, detail);
+    assert_eq!(finding.hint, hint);
+    assert_eq!(finding.file, file);
+    assert!(!finding.fixable);
+    assert!(finding.fix_ids.is_empty());
+}

--- a/test/fixtures/editorconfig-prettier/clean/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/clean/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf

--- a/test/fixtures/editorconfig-prettier/clean/package.json
+++ b/test/fixtures/editorconfig-prettier/clean/package.json
@@ -1,0 +1,7 @@
+{
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2,
+    "endOfLine": "lf"
+  }
+}

--- a/test/fixtures/editorconfig-prettier/conflict/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/conflict/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+indent_style = tab
+indent_size = 4
+end_of_line = crlf

--- a/test/fixtures/editorconfig-prettier/conflict/package.json
+++ b/test/fixtures/editorconfig-prettier/conflict/package.json
@@ -1,0 +1,7 @@
+{
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2,
+    "endOfLine": "lf"
+  }
+}

--- a/test/fixtures/editorconfig-prettier/nested-override/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/nested-override/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+indent_style = space
+indent_size = 2
+end_of_line = lf

--- a/test/fixtures/editorconfig-prettier/nested-override/packages/app/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/nested-override/packages/app/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+indent_style = tab
+indent_size = 4
+end_of_line = crlf

--- a/test/fixtures/editorconfig-prettier/nested-override/packages/app/package.json
+++ b/test/fixtures/editorconfig-prettier/nested-override/packages/app/package.json
@@ -1,0 +1,7 @@
+{
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2,
+    "endOfLine": "lf"
+  }
+}

--- a/test/fixtures/editorconfig-prettier/section-override/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/section-override/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+indent_style = space
+indent_size = 2
+end_of_line = lf
+
+[*]
+indent_style = tab

--- a/test/fixtures/editorconfig-prettier/section-override/package.json
+++ b/test/fixtures/editorconfig-prettier/section-override/package.json
@@ -1,0 +1,7 @@
+{
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2,
+    "endOfLine": "lf"
+  }
+}

--- a/test/fixtures/test-runners/dual-config/jest.config.js
+++ b/test/fixtures/test-runners/dual-config/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: "node"
+};

--- a/test/fixtures/test-runners/dual-config/package.json
+++ b/test/fixtures/test-runners/dual-config/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "test": "jest",
+    "test:unit": "vitest"
+  }
+}

--- a/test/fixtures/test-runners/dual-config/vitest.config.ts
+++ b/test/fixtures/test-runners/dual-config/vitest.config.ts
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    environment: "jsdom"
+  }
+};

--- a/test/fixtures/test-runners/package-field/jest.config.js
+++ b/test/fixtures/test-runners/package-field/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/test-runners/package-field/package.json
+++ b/test/fixtures/test-runners/package-field/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-field",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "vitest": {
+    "globals": true
+  }
+}

--- a/test/fixtures/test-runners/package-only/package.json
+++ b/test/fixtures/test-runners/package-only/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-only",
+  "private": true,
+  "jest": {
+    "testEnvironment": "node"
+  },
+  "vitest": {
+    "globals": true
+  }
+}

--- a/test/fixtures/test-runners/vitest-only/package.json
+++ b/test/fixtures/test-runners/vitest-only/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "test": "vitest"
+  }
+}

--- a/test/fixtures/test-runners/vitest-only/vitest.config.ts
+++ b/test/fixtures/test-runners/vitest-only/vitest.config.ts
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    environment: "node"
+  }
+};


### PR DESCRIPTION
배경
- `#82 REG-3`로 Jest/Vitest dual config와 EditorConfig/Prettier 충돌 검사를 추가했다.

변경 사항
- `test-runner-config`와 `editorconfig-prettier` registered check를 추가했다.
- registry wiring과 fixtures/tests를 추가했다.
- root `.editorconfig` default만 보도록 스코프를 제한했다.
- `package.json`의 `jest` / `vitest` top-level field 조합도 감지한다.

검증
- `cargo test -p maximus-checks --test test_runner_config_registry --test editorconfig_prettier_registry`
- `cargo test -p maximus-checks`
- `git diff --check`

브랜치 / 워크트리
- branch: `codex/wave-a-reg-3`
- worktree: `/tmp/maximus-waveA/reg-3`

이슈 연결
- Closes #82
