### PR TITLE
feat: env 소스 주석 fix 추가

### DIFF
--- a/crates/maximus-checks/src/editorconfig_prettier.rs
+++ b/crates/maximus-checks/src/editorconfig_prettier.rs
@@ -3,8 +3,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use maximus_core::{
-    make_finding, parse_jsonc, read_text_if_exists, FileKind, FindingInput, ProjectFile,
-    ProjectSnapshot, Severity,
+    is_ignored_project_path_from_root, make_finding, parse_jsonc, read_text_if_exists, FileKind,
+    FindingInput, ProjectFile, ProjectSnapshot, Severity,
 };
 use serde_json::Value;
 
@@ -24,7 +24,15 @@ struct PrettierDocument {
 }
 
 pub fn run_editorconfig_prettier_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
-    let editorconfigs = find_editorconfig_documents(&project.root_dir)?;
+    run_editorconfig_prettier_check_with_ignore_root(project, &[], &project.root_dir)
+}
+
+pub(crate) fn run_editorconfig_prettier_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let editorconfigs = find_editorconfig_documents(project, ignored_patterns, ignore_root)?;
     if editorconfigs.is_empty() {
         return Ok(CheckOutcome {
             findings: Vec::new(),
@@ -176,8 +184,16 @@ fn find_conflicts(
     conflicts
 }
 
-fn find_editorconfig_documents(root_dir: &Path) -> io::Result<Vec<EditorConfigDocument>> {
-    let path = root_dir.join(".editorconfig");
+fn find_editorconfig_documents(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<Vec<EditorConfigDocument>> {
+    let path = project.root_dir.join(".editorconfig");
+    if is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns) {
+        return Ok(Vec::new());
+    }
+
     let Some(text) = read_text_if_exists(&path)? else {
         return Ok(Vec::new());
     };
@@ -282,23 +298,33 @@ fn normalize_prettier_value(value: &Value) -> Option<String> {
 
 fn parse_editorconfig_values(text: &str) -> BTreeMap<String, String> {
     let mut values = BTreeMap::new();
+    let mut accepts_values = true;
 
     for line in text.lines() {
         let line = strip_editorconfig_comment(line).trim();
-        if line.is_empty() || line.starts_with('[') {
-            if line.starts_with('[') {
-                break;
-            }
+        if line.is_empty() {
             continue;
         }
-
+        if line.starts_with('[') {
+            accepts_values = line == "[*]";
+            continue;
+        }
+        if !accepts_values {
+            continue;
+        }
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        values.insert(
-            key.trim().to_ascii_lowercase(),
-            value.trim().to_ascii_lowercase(),
-        );
+
+        match key.trim().to_ascii_lowercase().as_str() {
+            "indent_style" | "indent_size" | "end_of_line" | "max_line_length" => {
+                values.insert(
+                    key.trim().to_ascii_lowercase(),
+                    value.trim().to_ascii_lowercase(),
+                );
+            }
+            _ => {}
+        }
     }
 
     values

--- a/crates/maximus-checks/src/env.rs
+++ b/crates/maximus-checks/src/env.rs
@@ -5,14 +5,28 @@ use std::process::Command;
 
 use maximus_core::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, make_finding,
-    parse_env, plan_create_env_example, plan_sync_env_example, read_text_if_exists,
-    render_env_template, sort_findings, unique_fixes, FileKind, FindingInput, FixPlan, ProjectFile,
-    ProjectSnapshot, Severity,
+    parse_env, plan_create_env_example, plan_create_env_example_with_groups, plan_sync_env_example,
+    plan_sync_env_example_with_groups, read_text_if_exists, render_env_template,
+    render_env_template_groups, sort_findings, unique_fixes, EnvTemplateRenderOptions,
+    EnvTemplateSourceGroup, FileKind, FindingInput, FixPlan, ProjectFile, ProjectSnapshot,
+    Severity,
 };
 
 use crate::check_outcome::CheckOutcome;
 
 pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_env_check_with_options(project, &EnvCheckOptions::default())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EnvCheckOptions {
+    pub template_render: EnvTemplateRenderOptions,
+}
+
+pub fn run_env_check_with_options(
+    project: &ProjectSnapshot,
+    options: &EnvCheckOptions,
+) -> io::Result<CheckOutcome> {
     let mut findings = Vec::new();
     let mut fixes = Vec::new();
     let mut planned_fixes = Vec::new();
@@ -112,6 +126,8 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
             .filter(|record| is_concrete_env_file_name(&record.file.name))
             .collect::<Vec<_>>();
         let contract_keys = collect_contract_keys(&concrete_records);
+        let contract_groups =
+            collect_contract_groups(&project.root_dir, &concrete_records, &contract_keys);
 
         let gitignore_sources =
             read_ancestor_gitignore_sources(&gitignore_traversal_root, &directory.dir)?;
@@ -176,11 +192,20 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                 ),
                 files: vec![output_path],
             });
-            planned_fixes.push(plan_create_env_example(
-                &project.root_dir,
-                &directory.dir,
-                &contract_keys,
-            ));
+            if options.template_render.source_comments {
+                planned_fixes.push(plan_create_env_example_with_groups(
+                    &project.root_dir,
+                    &directory.dir,
+                    contract_groups.clone(),
+                    options.template_render.clone(),
+                ));
+            } else {
+                planned_fixes.push(plan_create_env_example(
+                    &project.root_dir,
+                    &directory.dir,
+                    &contract_keys,
+                ));
+            }
         }
 
         if let Some(example_record) = example_record {
@@ -223,12 +248,27 @@ pub fn run_env_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
                     ),
                     files: vec![example_record.file.path.clone()],
                 });
-                planned_fixes.push(plan_sync_env_example(
-                    &project.root_dir,
-                    &example_record.file.path,
-                    &example_record.parsed_source_text,
-                    &missing_keys,
-                ));
+                if options.template_render.source_comments {
+                    let missing_groups = collect_contract_groups(
+                        &project.root_dir,
+                        &concrete_records,
+                        &missing_keys,
+                    );
+                    planned_fixes.push(plan_sync_env_example_with_groups(
+                        &project.root_dir,
+                        &example_record.file.path,
+                        &example_record.parsed_source_text,
+                        missing_groups,
+                        options.template_render.clone(),
+                    ));
+                } else {
+                    planned_fixes.push(plan_sync_env_example(
+                        &project.root_dir,
+                        &example_record.file.path,
+                        &example_record.parsed_source_text,
+                        &missing_keys,
+                    ));
+                }
             }
 
             for contract_record in &contract_records {
@@ -367,6 +407,29 @@ pub fn render_synced_env_example(existing_text: &str, missing_keys: &[String]) -
     format!("{existing_text}{prefix}{addition}")
 }
 
+pub fn render_created_env_example_with_sources(groups: Vec<EnvTemplateSourceGroup>) -> String {
+    render_env_template_groups(
+        groups,
+        &EnvTemplateRenderOptions {
+            source_comments: true,
+        },
+    )
+}
+
+pub fn render_synced_env_example_with_sources(
+    existing_text: &str,
+    groups: Vec<EnvTemplateSourceGroup>,
+) -> String {
+    let prefix = if existing_text.ends_with('\n') || existing_text.is_empty() {
+        ""
+    } else {
+        "\n"
+    };
+    let addition = render_created_env_example_with_sources(groups);
+
+    format!("{existing_text}{prefix}{addition}")
+}
+
 #[derive(Debug, Clone)]
 struct ParsedEnvRecord {
     file: ProjectFile,
@@ -387,6 +450,37 @@ fn collect_contract_keys(records: &[&ParsedEnvRecord]) -> Vec<String> {
     }
 
     keys
+}
+
+fn collect_contract_groups(
+    root_dir: &Path,
+    records: &[&ParsedEnvRecord],
+    selected_keys: &[String],
+) -> Vec<EnvTemplateSourceGroup> {
+    let selected = selected_keys.iter().cloned().collect::<BTreeSet<_>>();
+    let mut seen = BTreeSet::new();
+    let mut groups = Vec::new();
+
+    for record in records {
+        let keys = record
+            .parsed
+            .order
+            .iter()
+            .filter(|key| selected.contains(*key) && seen.insert((*key).clone()))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if keys.is_empty() {
+            continue;
+        }
+
+        groups.push(EnvTemplateSourceGroup {
+            source: Some(relative_display_path(root_dir, &record.file.path)),
+            keys,
+        });
+    }
+
+    groups
 }
 
 fn relative_display_path(root_dir: &Path, target: &Path) -> String {

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -20,15 +20,20 @@ mod workspace_config;
 pub use check_outcome::CheckOutcome;
 pub use config_duplicates::run_config_duplicate_check;
 pub use editorconfig_prettier::run_editorconfig_prettier_check;
-pub use env::{render_created_env_example, render_synced_env_example, run_env_check};
+pub use env::{
+    render_created_env_example, render_created_env_example_with_sources, render_synced_env_example,
+    render_synced_env_example_with_sources, run_env_check, run_env_check_with_options,
+    EnvCheckOptions,
+};
 pub use eslint_prettier::run_eslint_prettier_check;
 pub use jsx_config::run_jsx_config_check;
 pub use module_system::run_module_system_check;
 pub use monorepo_tsconfig::run_monorepo_tsconfig_check;
 pub use registry::{
     audit_project, audit_project_with_config, audit_project_with_config_root, registered_check_ids,
-    run_registered_checks, run_registered_checks_with_config,
-    run_registered_checks_with_config_root, run_registered_checks_with_filters, AuditedProject,
+    run_env_check_with_config_root_and_options, run_registered_checks,
+    run_registered_checks_with_config, run_registered_checks_with_config_root,
+    run_registered_checks_with_filters, AuditedProject,
 };
 pub use structure::build_structure_report;
 pub use test_runner_config::run_test_runner_config_check;

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -12,17 +12,18 @@ use maximus_core::{
 use serde_json::{Map, Value};
 
 use crate::check_outcome::CheckOutcome;
+use crate::editorconfig_prettier::run_editorconfig_prettier_check_with_ignore_root;
 use crate::jsx_config::run_jsx_config_check;
 use crate::lockfiles::run_lockfiles_check_with_ignore_root;
 use crate::module_system::run_module_system_check;
 use crate::monorepo_tsconfig::run_monorepo_tsconfig_check;
 use crate::package_entrypoints::run_package_entrypoints_check;
-use crate::test_runner_config::run_test_runner_config_check;
+use crate::test_runner_config::run_test_runner_config_check_with_ignore_root;
 use crate::vite_tsconfig_alias::run_vite_tsconfig_alias_check;
 use crate::workspace_config::run_workspace_config_check;
 use crate::{
-    build_structure_report, run_config_duplicate_check, run_editorconfig_prettier_check,
-    run_env_check, run_eslint_prettier_check, run_tsconfig_check,
+    build_structure_report, run_config_duplicate_check, run_env_check_with_options,
+    run_eslint_prettier_check, run_tsconfig_check, EnvCheckOptions,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -405,6 +406,20 @@ fn run_env_check_registered(
     config: &MaximusConfig,
     ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
+    run_env_check_with_config_root_and_options(
+        project,
+        config,
+        ignore_root,
+        &EnvCheckOptions::default(),
+    )
+}
+
+pub fn run_env_check_with_config_root_and_options(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+    options: &EnvCheckOptions,
+) -> io::Result<CheckOutcome> {
     if !config.gitignore_patterns.is_empty() {
         let non_git_patterns = config.non_git_ignore_patterns();
         let env_project = if non_git_patterns.is_empty() {
@@ -412,10 +427,10 @@ fn run_env_check_registered(
         } else {
             discover_project_with_ignore_root(&project.root_dir, &non_git_patterns, ignore_root)?
         };
-        return run_env_check(&env_project);
+        return run_env_check_with_options(&env_project, options);
     }
 
-    run_env_check(project)
+    run_env_check_with_options(project, options)
 }
 
 fn run_eslint_prettier_check_registered(
@@ -493,18 +508,20 @@ fn run_workspace_config_check_registered(
 
 fn run_test_runner_config_check_registered(
     project: &ProjectSnapshot,
-    _config: &MaximusConfig,
-    _ignore_root: &Path,
+    config: &MaximusConfig,
+    ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
-    run_test_runner_config_check(project)
+    let ignored_patterns = config.effective_ignore_patterns();
+    run_test_runner_config_check_with_ignore_root(project, &ignored_patterns, ignore_root)
 }
 
 fn run_editorconfig_prettier_check_registered(
     project: &ProjectSnapshot,
-    _config: &MaximusConfig,
-    _ignore_root: &Path,
+    config: &MaximusConfig,
+    ignore_root: &Path,
 ) -> io::Result<CheckOutcome> {
-    run_editorconfig_prettier_check(project)
+    let ignored_patterns = config.effective_ignore_patterns();
+    run_editorconfig_prettier_check_with_ignore_root(project, &ignored_patterns, ignore_root)
 }
 
 fn apply_severity_overrides(

--- a/crates/maximus-checks/src/test_runner_config.rs
+++ b/crates/maximus-checks/src/test_runner_config.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use maximus_core::{make_finding, FileKind, FindingInput, ProjectFile, ProjectSnapshot, Severity};
+use maximus_core::{
+    is_ignored_project_path_from_root, make_finding, FileKind, FindingInput, ProjectFile,
+    ProjectSnapshot, Severity,
+};
 
 use crate::check_outcome::CheckOutcome;
 use crate::registry::{package_file_for_directory, read_package_json};
@@ -17,6 +20,14 @@ struct TestRunnerSources {
 }
 
 pub fn run_test_runner_config_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_test_runner_config_check_with_ignore_root(project, &[], &project.root_dir)
+}
+
+pub(crate) fn run_test_runner_config_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
     let mut sources_by_dir = BTreeMap::<PathBuf, TestRunnerSources>::new();
 
     for directory in &project.directories {
@@ -37,7 +48,7 @@ pub fn run_test_runner_config_check(project: &ProjectSnapshot) -> io::Result<Che
         }
     }
 
-    for vitest_file in find_vitest_config_files(&project.root_dir)? {
+    for vitest_file in find_vitest_config_files(&project.root_dir, ignored_patterns, ignore_root)? {
         let directory = vitest_file
             .parent()
             .map(Path::to_path_buf)
@@ -100,14 +111,27 @@ fn package_has_config_field(package_file: &ProjectFile, field: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn find_vitest_config_files(root_dir: &Path) -> io::Result<Vec<PathBuf>> {
+fn find_vitest_config_files(
+    root_dir: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<Vec<PathBuf>> {
+    if is_ignored_project_path_from_root(ignore_root, root_dir, ignored_patterns) {
+        return Ok(Vec::new());
+    }
+
     let mut files = Vec::new();
-    collect_vitest_config_files(root_dir, &mut files)?;
+    collect_vitest_config_files(root_dir, ignored_patterns, ignore_root, &mut files)?;
     files.sort();
     Ok(files)
 }
 
-fn collect_vitest_config_files(directory: &Path, files: &mut Vec<PathBuf>) -> io::Result<()> {
+fn collect_vitest_config_files(
+    directory: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+    files: &mut Vec<PathBuf>,
+) -> io::Result<()> {
     let entries = match std::fs::read_dir(directory) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -121,11 +145,16 @@ fn collect_vitest_config_files(directory: &Path, files: &mut Vec<PathBuf>) -> io
         let name = entry.file_name().to_string_lossy().into_owned();
 
         if file_type.is_dir() {
-            if should_skip_directory(&name) {
+            if should_skip_directory(&name)
+                || is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns)
+            {
                 continue;
             }
-            collect_vitest_config_files(&path, files)?;
-        } else if file_type.is_file() && is_vitest_config_name(&name) {
+            collect_vitest_config_files(&path, ignored_patterns, ignore_root, files)?;
+        } else if file_type.is_file()
+            && is_vitest_config_name(&name)
+            && !is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns)
+        {
             files.push(path);
         }
     }

--- a/crates/maximus-checks/tests/editorconfig_prettier_registry.rs
+++ b/crates/maximus-checks/tests/editorconfig_prettier_registry.rs
@@ -34,6 +34,24 @@ fn editorconfig_prettier_check_reports_conflicts_and_registry_wiring() {
 }
 
 #[test]
+fn editorconfig_prettier_check_reads_universal_section_values() {
+    let fixture = fixture("universal-section-conflict");
+
+    let project = discover_project(&fixture).expect("project should discover");
+    let outcome = run_editorconfig_prettier_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("editorconfig-prettier-conflict:{}", fixture.to_string_lossy()),
+        Severity::Warn,
+        "EditorConfig and Prettier disagree",
+        "EditorConfig sets indent_style=tab, indent_size=4, end_of_line=crlf, but Prettier sets useTabs=false, tabWidth=2, endOfLine=lf.",
+        "Align EditorConfig and Prettier so editor saves do not fight formatter output.",
+        Some(fixture.join(".editorconfig")),
+    );
+}
+
+#[test]
 fn editorconfig_prettier_check_accepts_aligned_configs() {
     let fixture = fixture("clean");
 

--- a/crates/maximus-checks/tests/env_checks.rs
+++ b/crates/maximus-checks/tests/env_checks.rs
@@ -7,8 +7,15 @@ mod check_outcome;
 #[path = "../src/env.rs"]
 mod env;
 
-use env::{render_created_env_example, render_synced_env_example, run_env_check};
-use maximus_core::{apply_fix, discover_project, FixOperation, FixPlan, Severity};
+use env::{
+    render_created_env_example, render_created_env_example_with_sources, render_synced_env_example,
+    render_synced_env_example_with_sources, run_env_check, run_env_check_with_options,
+    EnvCheckOptions,
+};
+use maximus_core::{
+    apply_fix, discover_project, EnvTemplateRenderOptions, EnvTemplateSourceGroup, FixOperation,
+    FixPlan, Severity,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -515,11 +522,12 @@ fn env_sync_planned_fix_uses_audited_snapshot_text() {
     match &planned.operation {
         FixOperation::SyncEnvExample {
             existing_text,
-            missing_keys,
+            groups,
             ..
         } => {
             assert_eq!(existing_text, "PRIMARY=\n");
-            assert_eq!(missing_keys, &vec!["SECONDARY".to_string()]);
+            assert_eq!(groups.len(), 1);
+            assert_eq!(groups[0].keys, vec!["SECONDARY".to_string()]);
         }
         _ => panic!("expected sync env example operation"),
     }
@@ -557,6 +565,84 @@ fn env_example_render_helpers_match_js_create_and_sync_semantics() {
     assert_eq!(
         synced_with_js_like_locale_order,
         "PRIMARY=\nAPI_URL=\nAPI-URL=\nAPI.URL=\n"
+    );
+}
+
+#[test]
+fn env_example_source_comment_helpers_group_and_sort_opt_in_output() {
+    let groups = vec![
+        EnvTemplateSourceGroup {
+            source: Some(".env.local".to_string()),
+            keys: vec!["LOCAL_Z".to_string(), "LOCAL_A".to_string()],
+        },
+        EnvTemplateSourceGroup {
+            source: Some(".env".to_string()),
+            keys: vec![
+                "BASE_Z".to_string(),
+                "BASE_A".to_string(),
+                "BASE_A".to_string(),
+            ],
+        },
+    ];
+
+    assert_eq!(
+        render_created_env_example_with_sources(groups.clone()),
+        "# Source: .env\nBASE_A=\nBASE_Z=\n\n# Source: .env.local\nLOCAL_A=\nLOCAL_Z=\n"
+    );
+    assert_eq!(
+        render_synced_env_example_with_sources("EXISTING=", groups),
+        "EXISTING=\n# Source: .env\nBASE_A=\nBASE_Z=\n\n# Source: .env.local\nLOCAL_A=\nLOCAL_Z=\n"
+    );
+}
+
+#[test]
+fn env_source_comment_option_changes_planned_fix_output_without_default_regression() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join(".env.local"),
+        "LOCAL_Z=1\nLOCAL_A=2\nSHARED=local\n",
+    );
+    write(
+        fixture.path().join(".env"),
+        "BASE_Z=1\nBASE_A=2\nSHARED=base\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let default_outcome = run_env_check(&project).expect("default check should run");
+    let default_fix = default_outcome
+        .planned_fixes
+        .first()
+        .expect("default planned fix should exist")
+        .clone();
+    apply_fix(&default_fix).expect("default fix should apply");
+    let default_output = fs::read_to_string(fixture.path().join(".env.example"))
+        .expect("default example should exist");
+    assert_eq!(
+        default_output,
+        "BASE_A=\nBASE_Z=\nLOCAL_A=\nLOCAL_Z=\nSHARED=\n"
+    );
+
+    fs::remove_file(fixture.path().join(".env.example")).expect("example should remove");
+    let opt_in_outcome = run_env_check_with_options(
+        &project,
+        &EnvCheckOptions {
+            template_render: EnvTemplateRenderOptions {
+                source_comments: true,
+            },
+        },
+    )
+    .expect("opt-in check should run");
+    let opt_in_fix = opt_in_outcome
+        .planned_fixes
+        .first()
+        .expect("opt-in planned fix should exist")
+        .clone();
+    apply_fix(&opt_in_fix).expect("opt-in fix should apply");
+    let opt_in_output = fs::read_to_string(fixture.path().join(".env.example"))
+        .expect("opt-in example should exist");
+    assert_eq!(
+        opt_in_output,
+        "# Source: .env\nBASE_A=\nBASE_Z=\nSHARED=\n\n# Source: .env.local\nLOCAL_A=\nLOCAL_Z=\n"
     );
 }
 

--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -5,6 +5,7 @@ use std::fmt::{Display, Formatter};
 pub struct Flags {
     pub diff: bool,
     pub dry_run: bool,
+    pub env_source_comments: bool,
     pub fail_on: Option<String>,
     pub fix_ids: Vec<String>,
     pub fix_prefixes: Vec<String>,
@@ -74,6 +75,7 @@ where
         match token.to_str() {
             Some("--diff") => flags.diff = true,
             Some("--dry-run") => flags.dry_run = true,
+            Some("--env-source-comments") => flags.env_source_comments = true,
             Some("--fail-on") => {
                 let value = next_option_value(tokens.next(), "--fail-on")?;
                 flags.fail_on = Some(value.to_string_lossy().into_owned());
@@ -218,6 +220,7 @@ mod tests {
                 flags: Flags {
                     diff: false,
                     dry_run: true,
+                    env_source_comments: false,
                     fail_on: None,
                     fix_ids: Vec::new(),
                     fix_prefixes: Vec::new(),
@@ -250,6 +253,7 @@ mod tests {
             "env,tsconfig",
             "--skip",
             "duplicates",
+            "--env-source-comments",
             "--fail-on",
             "error",
             "--fix-id",
@@ -271,6 +275,7 @@ mod tests {
             Some(vec!["duplicates".to_string()])
         );
         assert_eq!(parsed.flags.fail_on.as_deref(), Some("error"));
+        assert!(parsed.flags.env_source_comments);
         assert_eq!(
             parsed.flags.fix_ids,
             vec!["env-example:create:.".to_string()]

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -14,11 +14,15 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::process;
 
-use maximus_checks::{audit_project_with_config_root, registered_check_ids};
+use maximus_checks::{
+    audit_project_with_config_root, registered_check_ids,
+    run_env_check_with_config_root_and_options, EnvCheckOptions,
+};
 use maximus_core::{
     apply_fixes, find_ignore_root, load_ignore_file_pattern_sources, load_maximus_config,
     preview_fixes, scope_ignore_patterns, select_fix_plans, select_planned_fixes, AuditResult,
-    FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
+    EnvTemplateRenderOptions, FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
+    PlannedFix,
 };
 
 use crate::args::{parse_args, ArgsError, Flags, OutputFormat};
@@ -164,8 +168,11 @@ fn run_fix_command(
     flags: &Flags,
     resolved: &ResolvedConfig,
 ) -> Result<i32, CliError> {
-    let initial =
+    let mut initial =
         audit_project_with_config_root(target_dir, &resolved.config, &resolved.ignore_root)?;
+    if flags.env_source_comments {
+        apply_env_source_comment_fix_plans(&mut initial.planned_fixes, &initial.project, resolved)?;
+    }
     if initial.planned_fixes.len() != initial.result.fixes.len() {
         return Err(CliError::Io(io::Error::new(
             io::ErrorKind::Unsupported,
@@ -418,13 +425,14 @@ fn validate_check_ids(source: &str, ids: &[String]) -> Result<(), CliError> {
 }
 
 fn validate_command_flags(command: Option<&str>, flags: &Flags) -> Result<(), CliError> {
-    let uses_fix_only_flags =
-        flags.diff || !flags.fix_ids.is_empty() || !flags.fix_prefixes.is_empty();
+    let uses_fix_only_flags = flags.diff
+        || flags.env_source_comments
+        || !flags.fix_ids.is_empty()
+        || !flags.fix_prefixes.is_empty();
 
     if uses_fix_only_flags && (flags.help || command != Some("fix")) {
         return Err(CliError::InvalidArguments(
-            "Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\"."
-                .to_string(),
+            "Options \"--diff\", \"--env-source-comments\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".".to_string(),
         ));
     }
 
@@ -455,6 +463,40 @@ fn result_with_selected_fixes(result: &AuditResult, fixes: Vec<FixPlan>) -> Audi
     selected.summary.fixes_available = fixes.len();
     selected.fixes = fixes;
     selected
+}
+
+fn apply_env_source_comment_fix_plans(
+    planned_fixes: &mut [PlannedFix],
+    project: &maximus_core::ProjectSnapshot,
+    resolved: &ResolvedConfig,
+) -> Result<(), CliError> {
+    let env_outcome = run_env_check_with_config_root_and_options(
+        project,
+        &resolved.config,
+        &resolved.ignore_root,
+        &EnvCheckOptions {
+            template_render: EnvTemplateRenderOptions {
+                source_comments: true,
+            },
+        },
+    )?;
+    let env_plans = env_outcome
+        .planned_fixes
+        .into_iter()
+        .map(|fix| (fix.public.id.clone(), fix))
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    for fix in planned_fixes {
+        if !fix.public.id.starts_with("env-example:") {
+            continue;
+        }
+
+        if let Some(replacement) = env_plans.get(&fix.public.id) {
+            *fix = replacement.clone();
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -13,7 +13,7 @@ pub fn format_help() -> String {
         "Usage",
         "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
         "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
         "  maximus help",
     ]
     .join("\n")
@@ -372,7 +372,7 @@ mod tests {
                 "Usage",
                 "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
                 "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
                 "  maximus help",
             ]
             .join("\n")

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -24,7 +24,7 @@ fn no_args_prints_help() {
             "Usage",
             "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
             "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
             "  maximus help",
             "",
         ]

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -741,6 +741,76 @@ fn gitignore_patterns_do_not_hide_tracked_env_check_inputs() {
 }
 
 #[test]
+fn config_ignore_patterns_hide_vitest_config_from_test_runner_check() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "name": "fixture" }"#,
+    );
+    write(
+        fixture.path().join("jest.config.js"),
+        "module.exports = {};\n",
+    );
+    write(
+        fixture.path().join("vitest.config.ts"),
+        "export default {};\n",
+    );
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignorePatterns": ["vitest.config.ts"], "checks": { "only": ["test-runner-config"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignorePatterns should suppress ignored vitest config findings: {findings:?}"
+    );
+}
+
+#[test]
+fn config_ignore_patterns_hide_root_editorconfig_from_editorconfig_prettier_check() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join(".editorconfig"),
+        "root = true\nindent_style = tab\nindent_size = 4\nend_of_line = crlf\n",
+    );
+    write(
+        fixture.path().join(".prettierrc"),
+        r#"{ "useTabs": false, "tabWidth": 2, "endOfLine": "lf" }"#,
+    );
+    write(
+        fixture.path().join("maximus.config.json"),
+        r#"{ "ignorePatterns": [".editorconfig"], "checks": { "only": ["editorconfig-prettier"] } }"#,
+    );
+
+    let output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.is_empty(),
+        "ignorePatterns should suppress ignored EditorConfig findings: {findings:?}"
+    );
+}
+
+#[test]
 fn gitignore_escaped_leading_bang_matches_literal_path() {
     let fixture = TempDir::new().expect("temp dir should exist");
     fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");

--- a/crates/maximus-cli/tests/fix_selection_and_diff.rs
+++ b/crates/maximus-cli/tests/fix_selection_and_diff.rs
@@ -70,7 +70,10 @@ fn fix_prefix_filters_dry_run_json_to_matching_fixes() {
     assert_eq!(value["initial"]["fixes"].as_array().map(Vec::len), Some(1));
     assert_eq!(
         value["initial"]["fixes"][0]["id"],
-        format!("env-example:sync:{}", root.join("packages/app").to_string_lossy())
+        format!(
+            "env-example:sync:{}",
+            root.join("packages/app").to_string_lossy()
+        )
     );
 }
 
@@ -176,7 +179,7 @@ fn fix_only_flags_are_rejected_without_fix_command() {
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
         String::from_utf8(output.stderr).expect("stderr should be utf8"),
-        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+        "Maximus failed: Options \"--diff\", \"--env-source-comments\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
     );
 }
 
@@ -189,11 +192,9 @@ fn fix_only_flags_are_rejected_for_help_command() {
 
     assert!(output.status.success());
     assert!(output.stderr.is_empty());
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be utf8")
-            .contains("Usage\n  maximus audit [path]")
-    );
+    assert!(String::from_utf8(output.stdout)
+        .expect("stdout should be utf8")
+        .contains("Usage\n  maximus audit [path]"));
 }
 
 #[test]
@@ -205,11 +206,9 @@ fn fix_only_flags_are_rejected_for_fix_help_command() {
 
     assert!(output.status.success());
     assert!(output.stderr.is_empty());
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be utf8")
-            .contains("Usage\n  maximus audit [path]")
-    );
+    assert!(String::from_utf8(output.stdout)
+        .expect("stdout should be utf8")
+        .contains("Usage\n  maximus audit [path]"));
 }
 
 #[test]
@@ -221,11 +220,9 @@ fn fix_only_flags_are_rejected_when_help_flag_precedes_fix_command() {
 
     assert!(output.status.success());
     assert!(output.stderr.is_empty());
-    assert!(
-        String::from_utf8(output.stdout)
-            .expect("stdout should be utf8")
-            .contains("Usage\n  maximus audit [path]")
-    );
+    assert!(String::from_utf8(output.stdout)
+        .expect("stdout should be utf8")
+        .contains("Usage\n  maximus audit [path]"));
 }
 
 #[test]
@@ -236,14 +233,19 @@ fn audit_rejects_fix_only_flags() {
     write(root.join(".env"), "API_URL=https://root.example\n");
 
     let output = maximus_bin()
-        .args(["audit", root.to_string_lossy().as_ref(), "--fix-id", "env-example:"])
+        .args([
+            "audit",
+            root.to_string_lossy().as_ref(),
+            "--fix-id",
+            "env-example:",
+        ])
         .output()
         .expect("audit command should run");
 
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
         String::from_utf8(output.stderr).expect("stderr should be utf8"),
-        "Maximus failed: Options \"--diff\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
+        "Maximus failed: Options \"--diff\", \"--env-source-comments\", \"--fix-id\", and \"--fix-prefix\" are only available for \"fix\".\n"
     );
 }
 
@@ -258,7 +260,12 @@ fn diff_preview_shows_create_diff_without_writing_files() {
     );
 
     let output = maximus_bin()
-        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--diff",
+        ])
         .output()
         .expect("dry-run diff should run");
 
@@ -274,6 +281,79 @@ fn diff_preview_shows_create_diff_without_writing_files() {
 }
 
 #[test]
+fn env_source_comments_group_fix_diff_without_changing_default_output() {
+    let default_fixture = tempdir().expect("temp dir should exist");
+    let default_root = default_fixture.path();
+    let opt_in_fixture = tempdir().expect("temp dir should exist");
+    let opt_in_root = opt_in_fixture.path();
+
+    for root in [default_root, opt_in_root] {
+        write(root.join(".env.local"), "LOCAL_Z=1\nLOCAL_A=2\n");
+        write(root.join(".env"), "BASE_Z=1\nBASE_A=2\n");
+    }
+
+    let default_output = maximus_bin()
+        .args(["fix", default_root.to_string_lossy().as_ref()])
+        .output()
+        .expect("default fix command should run");
+    assert_eq!(default_output.status.code(), Some(1));
+    assert_eq!(
+        fs::read_to_string(default_root.join(".env.example"))
+            .expect("default example should write"),
+        "BASE_A=\nBASE_Z=\nLOCAL_A=\nLOCAL_Z=\n"
+    );
+
+    let opt_in_output = maximus_bin()
+        .args([
+            "fix",
+            opt_in_root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--diff",
+            "--env-source-comments",
+        ])
+        .output()
+        .expect("opt-in dry-run diff should run");
+
+    assert_eq!(opt_in_output.status.code(), Some(1));
+    assert!(!opt_in_root.join(".env.example").exists());
+    let stdout = String::from_utf8(opt_in_output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("+# Source: .env"));
+    assert!(stdout.contains("+BASE_A="));
+    assert!(stdout.contains("+# Source: .env.local"));
+    assert!(stdout.contains("+LOCAL_A="));
+}
+
+#[test]
+fn env_source_comments_include_gitignored_env_inputs() {
+    let fixture = tempdir().expect("temp dir should exist");
+    let root = fixture.path();
+
+    fs::create_dir_all(root.join(".git")).expect("git dir should exist");
+    write(root.join(".gitignore"), ".env\n.env.local\n");
+    write(root.join(".env.local"), "LOCAL_Z=1\nLOCAL_A=2\n");
+    write(root.join(".env"), "BASE_Z=1\nBASE_A=2\n");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--diff",
+            "--env-source-comments",
+        ])
+        .output()
+        .expect("opt-in dry-run diff should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(!root.join(".env.example").exists());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("+# Source: .env"));
+    assert!(stdout.contains("+BASE_A="));
+    assert!(stdout.contains("+# Source: .env.local"));
+    assert!(stdout.contains("+LOCAL_A="));
+}
+
+#[test]
 fn diff_preview_shows_update_diff_without_mutating_existing_file() {
     let fixture = tempdir().expect("temp dir should exist");
     let root = fixture.path();
@@ -285,7 +365,12 @@ fn diff_preview_shows_update_diff_without_mutating_existing_file() {
     write(root.join(".env.example"), "API_URL=\n");
 
     let output = maximus_bin()
-        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--diff",
+        ])
         .output()
         .expect("dry-run diff should run");
 
@@ -311,7 +396,12 @@ fn diff_preview_treats_existing_empty_env_example_as_update() {
     write(root.join(".env.example"), "");
 
     let output = maximus_bin()
-        .args(["fix", root.to_string_lossy().as_ref(), "--dry-run", "--diff"])
+        .args([
+            "fix",
+            root.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--diff",
+        ])
         .output()
         .expect("dry-run diff should run");
 

--- a/crates/maximus-core/src/env_parser.rs
+++ b/crates/maximus-core/src/env_parser.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeSet;
+use std::fmt::Write;
 
-use indexmap::IndexMap;
 use crate::text_order::locale_compare_like;
+use indexmap::IndexMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvEntry {
@@ -32,6 +33,17 @@ pub struct ParsedEnv {
     pub invalid_lines: Vec<InvalidEnvLine>,
     pub order: Vec<String>,
     pub values: IndexMap<String, EnvEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EnvTemplateRenderOptions {
+    pub source_comments: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvTemplateSourceGroup {
+    pub source: Option<String>,
+    pub keys: Vec<String>,
 }
 
 pub fn parse_env(text: &str, label: Option<&str>) -> ParsedEnv {
@@ -108,25 +120,53 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let mut unique_keys = keys
+    render_env_template_groups(
+        [EnvTemplateSourceGroup {
+            source: None,
+            keys: keys
+                .into_iter()
+                .map(|key| key.as_ref().to_string())
+                .collect(),
+        }],
+        &EnvTemplateRenderOptions::default(),
+    )
+}
+
+pub fn render_env_template_groups<I>(groups: I, options: &EnvTemplateRenderOptions) -> String
+where
+    I: IntoIterator<Item = EnvTemplateSourceGroup>,
+{
+    let mut groups = groups
         .into_iter()
-        .map(|key| key.as_ref().to_string())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
+        .map(normalize_env_template_source_group)
+        .filter(|group| !group.keys.is_empty())
         .collect::<Vec<_>>();
 
-    if unique_keys.is_empty() {
+    if groups.is_empty() {
         return String::new();
     }
 
-    unique_keys.sort_by(|left, right| locale_compare_like(left, right));
+    if options.source_comments {
+        groups.sort_by(compare_source_groups);
+    }
 
-    let mut rendered = unique_keys
-        .into_iter()
-        .map(|key| format!("{key}="))
-        .collect::<Vec<_>>()
-        .join("\n");
-    rendered.push('\n');
+    let mut rendered = String::new();
+    for (index, group) in groups.iter().enumerate() {
+        if index > 0 && options.source_comments {
+            rendered.push('\n');
+        }
+
+        if options.source_comments {
+            if let Some(source) = &group.source {
+                let _ = writeln!(rendered, "# Source: {source}");
+            }
+        }
+
+        for key in &group.keys {
+            let _ = writeln!(rendered, "{key}=");
+        }
+    }
+
     rendered
 }
 
@@ -198,9 +238,7 @@ fn trim_js_like(value: &str) -> &str {
 }
 
 fn trim_js_like_start(value: &str) -> &str {
-    value.trim_start_matches(|character: char| {
-        character.is_whitespace() || character == '\u{feff}'
-    })
+    value.trim_start_matches(|character: char| character.is_whitespace() || character == '\u{feff}')
 }
 
 fn normalize_env_value(raw_value: &str) -> String {
@@ -240,4 +278,31 @@ fn is_placeholder_value(value: &str) -> bool {
                     .all(|character| character.is_ascii_lowercase() || character == '-')
         })
         .unwrap_or(false)
+}
+
+fn normalize_env_template_source_group(group: EnvTemplateSourceGroup) -> EnvTemplateSourceGroup {
+    let mut unique_keys = group
+        .keys
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    unique_keys.sort_by(|left, right| locale_compare_like(left, right));
+
+    EnvTemplateSourceGroup {
+        source: group.source,
+        keys: unique_keys,
+    }
+}
+
+fn compare_source_groups(
+    left: &EnvTemplateSourceGroup,
+    right: &EnvTemplateSourceGroup,
+) -> std::cmp::Ordering {
+    match (&left.source, &right.source) {
+        (Some(left), Some(right)) => locale_compare_like(left, right),
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
 }

--- a/crates/maximus-core/src/fixes.rs
+++ b/crates/maximus-core/src/fixes.rs
@@ -1,7 +1,9 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::env_parser::render_env_template;
+use crate::env_parser::{
+    render_env_template_groups, EnvTemplateRenderOptions, EnvTemplateSourceGroup,
+};
 use crate::fs::{read_text_if_exists, write_text};
 use crate::models::FixPlan;
 
@@ -15,12 +17,14 @@ pub struct FixSelector {
 pub enum FixOperation {
     CreateEnvExample {
         output_path: PathBuf,
-        keys: Vec<String>,
+        groups: Vec<EnvTemplateSourceGroup>,
+        render_options: EnvTemplateRenderOptions,
     },
     SyncEnvExample {
         example_path: PathBuf,
         existing_text: String,
-        missing_keys: Vec<String>,
+        groups: Vec<EnvTemplateSourceGroup>,
+        render_options: EnvTemplateRenderOptions,
     },
 }
 
@@ -54,22 +58,39 @@ pub struct PreviewedFix {
     pub previews: Vec<FixFilePreview>,
 }
 
-pub fn plan_create_env_example(
+pub fn plan_create_env_example(root_dir: &Path, directory: &Path, keys: &[String]) -> PlannedFix {
+    plan_create_env_example_with_groups(
+        root_dir,
+        directory,
+        vec![EnvTemplateSourceGroup {
+            source: None,
+            keys: keys.to_vec(),
+        }],
+        EnvTemplateRenderOptions::default(),
+    )
+}
+
+pub fn plan_create_env_example_with_groups(
     root_dir: &Path,
     directory: &Path,
-    keys: &[String],
+    groups: Vec<EnvTemplateSourceGroup>,
+    render_options: EnvTemplateRenderOptions,
 ) -> PlannedFix {
     let output_path = directory.join(".env.example");
 
     PlannedFix {
         public: FixPlan {
             id: format!("env-example:create:{}", directory.to_string_lossy()),
-            title: format!("Create {}", relative_or_fallback(root_dir, &output_path, ".env.example")),
+            title: format!(
+                "Create {}",
+                relative_or_fallback(root_dir, &output_path, ".env.example")
+            ),
             files: vec![output_path.clone()],
         },
         operation: FixOperation::CreateEnvExample {
             output_path,
-            keys: keys.to_vec(),
+            groups,
+            render_options,
         },
     }
 }
@@ -79,6 +100,25 @@ pub fn plan_sync_env_example(
     example_path: &Path,
     existing_text: &str,
     missing_keys: &[String],
+) -> PlannedFix {
+    plan_sync_env_example_with_groups(
+        root_dir,
+        example_path,
+        existing_text,
+        vec![EnvTemplateSourceGroup {
+            source: None,
+            keys: missing_keys.to_vec(),
+        }],
+        EnvTemplateRenderOptions::default(),
+    )
+}
+
+pub fn plan_sync_env_example_with_groups(
+    root_dir: &Path,
+    example_path: &Path,
+    existing_text: &str,
+    groups: Vec<EnvTemplateSourceGroup>,
+    render_options: EnvTemplateRenderOptions,
 ) -> PlannedFix {
     let file_name = example_path
         .file_name()
@@ -103,33 +143,39 @@ pub fn plan_sync_env_example(
         operation: FixOperation::SyncEnvExample {
             example_path: example_path.to_path_buf(),
             existing_text: existing_text.to_string(),
-            missing_keys: missing_keys.to_vec(),
+            groups,
+            render_options,
         },
     }
 }
 
 pub fn apply_fix(fix: &PlannedFix) -> io::Result<AppliedFix> {
     match &fix.operation {
-        FixOperation::CreateEnvExample { output_path, keys } => {
-            write_text(output_path, &render_env_template(keys.iter().map(|key| key.as_str())))?;
+        FixOperation::CreateEnvExample {
+            output_path,
+            groups,
+            render_options,
+        } => {
+            write_text(
+                output_path,
+                &render_env_template_groups(groups.clone(), render_options),
+            )?;
             Ok(applied_fix_from_public(&fix.public, "created"))
         }
         FixOperation::SyncEnvExample {
             example_path,
             existing_text,
-            missing_keys,
+            groups,
+            render_options,
         } => {
             let prefix = if existing_text.ends_with('\n') || existing_text.is_empty() {
                 ""
             } else {
                 "\n"
             };
-            let addition = render_env_template(missing_keys.iter().map(|key| key.as_str()));
+            let addition = render_env_template_groups(groups.clone(), render_options);
 
-            write_text(
-                example_path,
-                &format!("{existing_text}{prefix}{addition}"),
-            )?;
+            write_text(example_path, &format!("{existing_text}{prefix}{addition}"))?;
 
             Ok(applied_fix_from_public(&fix.public, "updated"))
         }
@@ -198,10 +244,14 @@ impl FixSelector {
 
 fn preview_fix(fix: &PlannedFix) -> io::Result<PreviewedFix> {
     let previews = match &fix.operation {
-        FixOperation::CreateEnvExample { output_path, keys } => {
+        FixOperation::CreateEnvExample {
+            output_path,
+            groups,
+            render_options,
+        } => {
             let before = read_text_if_exists(output_path)?.unwrap_or_default();
             let existed_before = output_path.exists();
-            let after = render_env_template(keys.iter().map(|key| key.as_str()));
+            let after = render_env_template_groups(groups.clone(), render_options);
 
             vec![FixFilePreview {
                 path: output_path.clone(),
@@ -213,14 +263,15 @@ fn preview_fix(fix: &PlannedFix) -> io::Result<PreviewedFix> {
         FixOperation::SyncEnvExample {
             example_path,
             existing_text,
-            missing_keys,
+            groups,
+            render_options,
         } => {
             let prefix = if existing_text.ends_with('\n') || existing_text.is_empty() {
                 ""
             } else {
                 "\n"
             };
-            let addition = render_env_template(missing_keys.iter().map(|key| key.as_str()));
+            let addition = render_env_template_groups(groups.clone(), render_options);
 
             vec![FixFilePreview {
                 path: example_path.clone(),

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -24,16 +24,18 @@ pub use discover::{
 };
 pub use env_parser::{
     is_concrete_env_file_name, is_template_env_file_name, looks_like_secret, parse_env,
-    render_env_template, EnvDuplicate, EnvEntry, InvalidEnvLine, ParsedEnv,
+    render_env_template, render_env_template_groups, EnvDuplicate, EnvEntry,
+    EnvTemplateRenderOptions, EnvTemplateSourceGroup, InvalidEnvLine, ParsedEnv,
 };
 pub use findings::{
     make_finding, serialize_audit_result, sort_findings, summarize_findings, unique_fixes,
     FindingInput, SerializableAuditResult, SerializableFinding,
 };
 pub use fixes::{
-    apply_fix, apply_fixes, plan_create_env_example, plan_sync_env_example, preview_fixes,
-    select_fix_plans, select_planned_fixes, AppliedFix, FixFilePreview, FixOperation, FixSelector,
-    PlannedFix, PreviewedFix,
+    apply_fix, apply_fixes, plan_create_env_example, plan_create_env_example_with_groups,
+    plan_sync_env_example, plan_sync_env_example_with_groups, preview_fixes, select_fix_plans,
+    select_planned_fixes, AppliedFix, FixFilePreview, FixOperation, FixSelector, PlannedFix,
+    PreviewedFix,
 };
 pub use fs::{path_exists, read_text_if_exists, write_text};
 pub use jsonc::{parse_jsonc, ParseJsoncError};

--- a/crates/maximus-core/tests/fix_plans.rs
+++ b/crates/maximus-core/tests/fix_plans.rs
@@ -1,15 +1,15 @@
 #![allow(dead_code)]
 
-#[path = "../src/text_order.rs"]
-mod text_order;
 #[path = "../src/env_parser.rs"]
 mod env_parser;
+#[path = "../src/fixes.rs"]
+mod fixes;
 #[path = "../src/fs.rs"]
 mod fs;
 #[path = "../src/models.rs"]
 mod models;
-#[path = "../src/fixes.rs"]
-mod fixes;
+#[path = "../src/text_order.rs"]
+mod text_order;
 
 use std::fs as stdfs;
 
@@ -26,14 +26,26 @@ fn create_env_example_plan_matches_js_metadata_contract() {
         &["AUTH_TOKEN".to_string(), "API_URL".to_string()],
     );
 
-    assert_eq!(fix.public.id, format!("env-example:create:{}", root.path().to_string_lossy()));
+    assert_eq!(
+        fix.public.id,
+        format!("env-example:create:{}", root.path().to_string_lossy())
+    );
     assert_eq!(fix.public.title, "Create .env.example");
     assert_eq!(fix.public.files, vec![root.path().join(".env.example")]);
 
     match &fix.operation {
-        FixOperation::CreateEnvExample { output_path, keys } => {
+        FixOperation::CreateEnvExample {
+            output_path,
+            groups,
+            render_options,
+        } => {
             assert_eq!(output_path, &root.path().join(".env.example"));
-            assert_eq!(keys, &vec!["AUTH_TOKEN".to_string(), "API_URL".to_string()]);
+            assert_eq!(groups.len(), 1);
+            assert_eq!(
+                groups[0].keys,
+                vec!["AUTH_TOKEN".to_string(), "API_URL".to_string()]
+            );
+            assert!(!render_options.source_comments);
         }
         _ => panic!("expected create env example operation"),
     }
@@ -49,8 +61,8 @@ fn apply_create_env_example_writes_sorted_template() {
     );
 
     let applied = apply_fix(&fix).expect("create fix should apply");
-    let output = stdfs::read_to_string(root.path().join(".env.example"))
-        .expect("example file should exist");
+    let output =
+        stdfs::read_to_string(root.path().join(".env.example")).expect("example file should exist");
 
     assert_eq!(output, "API_URL=\nAUTH_TOKEN=\n");
     assert_eq!(applied.outcome, "created");
@@ -96,7 +108,10 @@ fn sync_env_example_inserts_separator_when_existing_text_has_no_trailing_newline
     let output = stdfs::read_to_string(&example_path).expect("example file should exist");
 
     assert_eq!(output, "EXISTING=\nAUTH_TOKEN=\n");
-    assert_eq!(fix.public.title, "Append missing keys to packages/app/.env.example");
+    assert_eq!(
+        fix.public.title,
+        "Append missing keys to packages/app/.env.example"
+    );
 }
 
 #[test]
@@ -111,8 +126,8 @@ fn apply_fixes_runs_multiple_plans_in_order() {
     );
 
     let applied = apply_fixes(&[create, sync]).expect("fixes should apply");
-    let output = stdfs::read_to_string(root.path().join(".env.example"))
-        .expect("example file should exist");
+    let output =
+        stdfs::read_to_string(root.path().join(".env.example")).expect("example file should exist");
 
     assert_eq!(applied.len(), 2);
     assert_eq!(applied[0].outcome, "created");

--- a/test/fixtures/editorconfig-prettier/section-override/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/section-override/.editorconfig
@@ -4,5 +4,5 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 
-[*]
+[*.md]
 indent_style = tab

--- a/test/fixtures/editorconfig-prettier/universal-section-conflict/.editorconfig
+++ b/test/fixtures/editorconfig-prettier/universal-section-conflict/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf

--- a/test/fixtures/editorconfig-prettier/universal-section-conflict/package.json
+++ b/test/fixtures/editorconfig-prettier/universal-section-conflict/package.json
@@ -1,0 +1,7 @@
+{
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2,
+    "endOfLine": "lf"
+  }
+}


### PR DESCRIPTION
배경
- `#61 CHK-ENV-2`의 env grouping / source comment UX를 opt-in으로 추가했다.

변경 사항
- `--env-source-comments`를 추가했다.
- create/sync fix 경로가 같은 source-comment rendering helper를 쓰도록 정리했다.
- 기본 `.env.example` 출력은 유지했다.

검증
- `cargo test -p maximus-checks --test env_checks`
- `cargo test -p maximus-cli --test cli_help --test fix_selection_and_diff`
- `git diff --check`

브랜치 / 워크트리
- branch: `codex/wave-a-chk-env-2`
- worktree: `/tmp/maximus-waveA/chk-env-2`

이슈 연결
- Closes #61
