### PR TITLE
test(tsconfig): 패턴 severity 계약 고정

### DIFF
--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use maximus_core::{discover_project, Severity};
+use maximus_core::{discover_project, summarize_findings, Severity, StructureReport};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
@@ -847,6 +847,111 @@ fn tsconfig_check_reports_empty_include_and_useless_exclude_patterns() {
         }),
         "useful include/exclude patterns should not report tsconfig-pattern findings"
     );
+}
+
+#[test]
+fn tsconfig_pattern_severity_contract_keeps_noop_excludes_non_blocking() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+
+    write(
+        fixture.path().join("empty-include/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/missing/**/*.mts"]
+        }
+        "#,
+    );
+    write(
+        fixture.path().join("empty-include/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    write(
+        fixture.path().join("noop-node-modules-exclude/tsconfig.json"),
+        r#"
+        {
+          "include": ["src/**/*.ts"],
+          "exclude": ["node_modules"]
+        }
+        "#,
+    );
+    write(
+        fixture
+            .path()
+            .join("noop-node-modules-exclude/src/index.ts"),
+        "export const ok = true;\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:src/missing/**/*.mts",
+            fixture
+                .path()
+                .join("empty-include/tsconfig.json")
+                .to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"src/missing/**/*.mts\" matched 0 files under base dir {}.",
+            fixture.path().join("empty-include").to_string_lossy()
+        ),
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+        Some(fixture.path().join("empty-include/tsconfig.json")),
+    );
+
+    let noop_exclude_id = format!(
+        "tsconfig-patterns:{}:exclude:node_modules",
+        fixture
+            .path()
+            .join("noop-node-modules-exclude/tsconfig.json")
+            .to_string_lossy()
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &noop_exclude_id,
+        Severity::Info,
+        "Exclude pattern does not filter any included files",
+        &format!(
+            "exclude pattern \"node_modules\" removed 0 files from 1 included file(s) under base dir {}.",
+            fixture
+                .path()
+                .join("noop-node-modules-exclude")
+                .to_string_lossy()
+        ),
+        "Remove or tighten exclude entries that do not change the effective TypeScript input set.",
+        Some(
+            fixture
+                .path()
+                .join("noop-node-modules-exclude/tsconfig.json"),
+        ),
+    );
+
+    let noop_exclude_finding = outcome
+        .findings
+        .iter()
+        .find(|finding| finding.id == noop_exclude_id)
+        .expect("no-op node_modules exclude finding should exist");
+    let summary = summarize_findings(
+        std::slice::from_ref(noop_exclude_finding),
+        &outcome.fixes,
+        &StructureReport {
+            is_monorepo: false,
+            package_count: 0,
+            env_directories: 0,
+            config_files: 1,
+            recommendations: Vec::new(),
+        },
+    );
+
+    assert_eq!(summary.status, "clean");
+    assert_eq!(summary.blocking_findings, 0);
+    assert_eq!(summary.warning_findings, 0);
+    assert_eq!(summary.info_findings, 1);
 }
 
 #[test]


### PR DESCRIPTION
## 배경

tsconfig 패턴 audit에서 empty include와 no-op exclude의 severity 계약이 회귀하지 않도록 테스트로 고정합니다.

## 변경 사항

- empty include pattern은 `warn`으로 유지되는지 검증했습니다.
- no-op `exclude: node_modules` 계열 finding은 `info`로 유지되는지 검증했습니다.
- info-only no-op exclude가 blocking status를 만들지 않는지 summary 계약을 추가로 검증했습니다.

## 검증

- `cargo test -p maximus-checks --test tsconfig_checks`
- `git diff --check origin/master..HEAD`
- 사전 `$devils-advocate-review-loop`: Critical/High 없음

## 브랜치 / 워크트리

- Branch: `codex/test-89-tsconfig-patterns`
- Worktree: `/tmp/maximus-noise-wave1/issue-89-tsconfig-patterns`
- Base: `master`

## 이슈 연결

Closes #89
