### PR TITLE
fix(env): worktree env 감사 제외

### DIFF
--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -10,6 +10,7 @@ use maximus_core::{
     sort_findings, unique_fixes, AuditResult, CheckFilterConfig, ConfigSeverity, MaximusConfig,
     PlannedFix, ProjectDirectory, ProjectFile, ProjectSnapshot, Severity,
 };
+use maximus_core::{is_concrete_env_file_name, is_template_env_file_name};
 use serde_json::{Map, Value};
 
 use crate::check_outcome::CheckOutcome;
@@ -433,16 +434,140 @@ pub fn run_env_check_with_config_root_and_options(
     options: &EnvCheckOptions,
 ) -> io::Result<CheckOutcome> {
     if !config.gitignore_patterns.is_empty() {
-        let non_git_patterns = config.non_git_ignore_patterns();
-        let env_project = if non_git_patterns.is_empty() {
+        let ignored_patterns = env_rediscovery_ignore_patterns(config);
+        let env_project = if ignored_patterns.is_empty() {
             discover_project(&project.root_dir)?
         } else {
-            discover_project_with_ignore_root(&project.root_dir, &non_git_patterns, ignore_root)?
+            discover_project_with_ignore_root(&project.root_dir, &ignored_patterns, ignore_root)?
         };
         return run_env_check_with_options(&env_project, options);
     }
 
     run_env_check_with_options(project, options)
+}
+
+fn env_rediscovery_ignore_patterns(config: &MaximusConfig) -> Vec<String> {
+    let mut patterns = config
+        .gitignore_patterns
+        .iter()
+        .filter_map(|pattern| env_rediscovery_gitignore_pattern(pattern))
+        .collect::<Vec<_>>();
+    patterns.extend(config.non_git_ignore_patterns());
+    patterns
+}
+
+fn env_rediscovery_gitignore_pattern(pattern: &str) -> Option<String> {
+    if is_env_file_name_ignore_pattern(pattern) {
+        Some(format!("{}/", pattern.trim_end().trim_end_matches('/')))
+    } else {
+        Some(pattern.to_string())
+    }
+}
+
+fn is_env_file_name_ignore_pattern(pattern: &str) -> bool {
+    let pattern = pattern.trim_end();
+    if pattern.starts_with('!') {
+        return false;
+    }
+    if pattern.ends_with('/') {
+        return false;
+    }
+
+    let pattern = pattern.trim_start_matches('/');
+    let file_pattern = pattern.rsplit('/').next().unwrap_or(pattern);
+    if file_pattern.contains('*') || file_pattern.contains('?') {
+        return is_env_specific_glob_pattern(file_pattern)
+            && glob_pattern_can_match_env_file_name(file_pattern);
+    }
+
+    is_concrete_env_file_name(file_pattern) || is_template_env_file_name(file_pattern)
+}
+
+fn is_env_specific_glob_pattern(pattern: &str) -> bool {
+    pattern.starts_with(".env") || pattern.starts_with("*.env")
+}
+
+fn glob_pattern_can_match_env_file_name(pattern: &str) -> bool {
+    let pattern = pattern.chars().collect::<Vec<_>>();
+    let mut memo = vec![vec![None; 7]; pattern.len() + 1];
+    env_name_glob_intersects(&pattern, 0, 0, &mut memo)
+}
+
+fn env_name_glob_intersects(
+    pattern: &[char],
+    pattern_index: usize,
+    env_state: usize,
+    memo: &mut [Vec<Option<bool>>],
+) -> bool {
+    if pattern_index == pattern.len() {
+        return env_name_state_accepts(env_state);
+    }
+    if let Some(result) = memo[pattern_index][env_state] {
+        return result;
+    }
+
+    let result = match pattern[pattern_index] {
+        '*' => env_name_wildcard_closure(env_state)
+            .iter()
+            .enumerate()
+            .filter(|(_, reachable)| **reachable)
+            .any(|(state, _)| env_name_glob_intersects(pattern, pattern_index + 1, state, memo)),
+        '?' => env_name_wildcard_next_states(env_state)
+            .iter()
+            .any(|state| env_name_glob_intersects(pattern, pattern_index + 1, *state, memo)),
+        character => env_name_next_state(env_state, character)
+            .is_some_and(|state| env_name_glob_intersects(pattern, pattern_index + 1, state, memo)),
+    };
+    memo[pattern_index][env_state] = Some(result);
+    result
+}
+
+fn env_name_next_state(state: usize, character: char) -> Option<usize> {
+    match (state, character) {
+        (0, '.') => Some(1),
+        (1, 'e') => Some(2),
+        (2, 'n') => Some(3),
+        (3, 'v') => Some(4),
+        (4, '.') => Some(5),
+        (5, '/') | (6, '/') => None,
+        (5, _) => Some(6),
+        (6, _) => Some(6),
+        _ => None,
+    }
+}
+
+fn env_name_wildcard_next_states(state: usize) -> &'static [usize] {
+    match state {
+        0 => &[1],
+        1 => &[2],
+        2 => &[3],
+        3 => &[4],
+        4 => &[5],
+        5 => &[6],
+        6 => &[6],
+        _ => &[],
+    }
+}
+
+fn env_name_wildcard_closure(state: usize) -> [bool; 7] {
+    let mut reachable = [false; 7];
+    let mut stack = vec![state];
+    reachable[state] = true;
+
+    while let Some(state) = stack.pop() {
+        for next_state in env_name_wildcard_next_states(state) {
+            if !reachable[*next_state] {
+                reachable[*next_state] = true;
+                stack.push(*next_state);
+            }
+        }
+    }
+
+    reachable
+}
+
+fn env_name_state_accepts(state: usize) -> bool {
+    matches!(state, 4 | 6)
 }
 
 fn run_eslint_prettier_check_registered(

--- a/crates/maximus-cli/tests/config_and_filtering.rs
+++ b/crates/maximus-cli/tests/config_and_filtering.rs
@@ -1006,6 +1006,255 @@ fn gitignore_patterns_do_not_hide_tracked_env_check_inputs() {
 }
 
 #[test]
+fn gitignore_suffix_env_globs_do_not_hide_env_check_inputs() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(fixture.path().join(".env"), "SECRET=one\nSECRET=two\n");
+    write(
+        fixture.path().join("archive.env/.env"),
+        "ARCHIVE_SECRET=one\nARCHIVE_SECRET=two\n",
+    );
+    write(fixture.path().join(".gitignore"), "*.env\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let root_env = fixture.path().join(".env").to_string_lossy().into_owned();
+    let archive_env = fixture
+        .path()
+        .join("archive.env/.env")
+        .to_string_lossy()
+        .into_owned();
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with(&format!("env-duplicate:{root_env}:SECRET:")))
+        }),
+        "suffix-style gitignore globs should not remove env files from env checks: {findings:?}"
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|finding| !finding.to_string().contains(&archive_env)),
+        "suffix-style gitignore globs should still hide matching directories: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_env_globs_with_variable_suffixes_do_not_hide_env_check_inputs() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(
+        fixture.path().join(".env.production"),
+        "PRODUCTION_SECRET=one\nPRODUCTION_SECRET=two\n",
+    );
+    write(
+        fixture.path().join(".env.production.local"),
+        "LOCAL_SECRET=one\nLOCAL_SECRET=two\n",
+    );
+    write(
+        fixture.path().join(".gitignore"),
+        ".env.prod*\n.env.*.local\n",
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let production_env = fixture
+        .path()
+        .join(".env.production")
+        .to_string_lossy()
+        .into_owned();
+    let local_env = fixture
+        .path()
+        .join(".env.production.local")
+        .to_string_lossy()
+        .into_owned();
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"].as_str().is_some_and(|id| {
+                id.starts_with(&format!(
+                    "env-duplicate:{production_env}:PRODUCTION_SECRET:"
+                ))
+            })
+        }),
+        "env glob patterns should not remove .env.production from env checks: {findings:?}"
+    );
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"].as_str().is_some_and(|id| {
+                id.starts_with(&format!("env-duplicate:{local_env}:LOCAL_SECRET:"))
+            })
+        }),
+        "env glob patterns should not remove .env.production.local from env checks: {findings:?}"
+    );
+}
+
+#[test]
+fn broad_env_globs_still_hide_matching_directories() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(
+        fixture.path().join("old-env-copy/.env"),
+        "LANE_SECRET=one\nLANE_SECRET=two\n",
+    );
+    write(fixture.path().join(".gitignore"), "*env*\n");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let ignored_env = fixture
+        .path()
+        .join("old-env-copy/.env")
+        .to_string_lossy()
+        .into_owned();
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings
+            .iter()
+            .all(|finding| !finding.to_string().contains(&ignored_env)),
+        "broad env globs should still hide matching directories: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_negated_env_patterns_are_kept_for_env_check_rediscovery() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(fixture.path().join(".env"), "SECRET=one\n");
+    write(fixture.path().join(".env.example"), "SECRET=\n");
+    write(
+        fixture.path().join(".gitignore"),
+        ".env\n*.example\n!.env.example\n",
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().all(|finding| {
+            finding["id"].as_str().is_none_or(|id| {
+                !id.starts_with(&format!(
+                    "env-example-missing:{}",
+                    fixture.path().to_string_lossy()
+                ))
+            })
+        }),
+        "negated env patterns should keep whitelisted env templates visible: {findings:?}"
+    );
+}
+
+#[test]
+fn gitignore_env_patterns_do_not_reinclude_worktree_env_files() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    fs::create_dir_all(fixture.path().join(".git")).expect("git dir should exist");
+    write(fixture.path().join(".env"), "SECRET=one\nSECRET=two\n");
+    write(fixture.path().join(".env.local.example"), "SECRET=\n");
+    write(
+        fixture.path().join(".worktrees/lane/.env"),
+        "LANE_SECRET=one\nLANE_SECRET=two\n",
+    );
+    write(
+        fixture.path().join(".gitignore"),
+        ".env*\n!.env.local.example\n.worktrees/\n",
+    );
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--only",
+            "env",
+            "--json",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let root_env = fixture.path().join(".env").to_string_lossy().into_owned();
+    let worktree_env = fixture
+        .path()
+        .join(".worktrees/lane/.env")
+        .to_string_lossy()
+        .into_owned();
+    let value = parse_json(&output);
+    let findings = value["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with(&format!("env-duplicate:{root_env}:SECRET:")))
+        }),
+        "root .env duplicate should remain visible to env checks: {findings:?}"
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|finding| !finding.to_string().contains(&worktree_env)),
+        ".worktrees env copies should stay excluded from env checks: {findings:?}"
+    );
+}
+
+#[test]
 fn config_ignore_patterns_hide_vitest_config_from_test_runner_check() {
     let fixture = TempDir::new().expect("temp dir should exist");
     write(

--- a/crates/maximus-core/src/discover.rs
+++ b/crates/maximus-core/src/discover.rs
@@ -20,6 +20,7 @@ const IGNORED_DIRECTORIES: &[&str] = &[
     ".svelte-kit",
     ".turbo",
     ".vercel",
+    ".worktrees",
     "build",
     "coverage",
     "dist",


### PR DESCRIPTION
## 배경

env check가 루트의 gitignored `.env`는 계속 감사해야 하지만, 병렬 worktree 복제본 안의 env 파일까지 audit 결과에 섞이면 노이즈가 커집니다.

## 변경 사항

- env rediscovery에서 env 파일명 ignore 패턴은 파일 visibility만 우회하고, matching directory ignore는 유지되도록 조정했습니다.
- 기본 discovery ignored directory 목록에 `.worktrees`를 추가했습니다.
- `.env*`, `*.env`, negated env template, broad env glob, `.worktrees/` 조합 회귀 테스트를 추가했습니다.

## 검증

- `cargo test -p maximus-cli --test config_and_filtering`
- `cargo test -p maximus-core discovery_ignores_common_build_directories`
- `git diff --check origin/master..HEAD`
- `rustfmt --check crates/maximus-checks/src/registry.rs crates/maximus-cli/tests/config_and_filtering.rs crates/maximus-core/src/discover.rs`
- 사전 `$devils-advocate-review-loop`: Critical/High 없음

## 브랜치 / 워크트리

- Branch: `codex/fix-90-worktrees-env`
- Worktree: `/tmp/maximus-noise-wave1/issue-90-worktrees-env`
- Base: `master`

## 이슈 연결

Closes #90
