### PR TITLE
fix(env): 플랫폼 주입 env sync 제외

### DIFF
--- a/crates/maximus-checks/src/env.rs
+++ b/crates/maximus-checks/src/env.rs
@@ -125,9 +125,9 @@ pub fn run_env_check_with_options(
             .iter()
             .filter(|record| is_concrete_env_file_name(&record.file.name))
             .collect::<Vec<_>>();
-        let contract_keys = collect_contract_keys(&concrete_records);
-        let contract_groups =
-            collect_contract_groups(&project.root_dir, &concrete_records, &contract_keys);
+        let sync_target_keys = collect_sync_target_keys(&concrete_records);
+        let sync_target_groups =
+            collect_contract_groups(&project.root_dir, &concrete_records, &sync_target_keys);
 
         let gitignore_sources =
             read_ancestor_gitignore_sources(&gitignore_traversal_root, &directory.dir)?;
@@ -164,7 +164,7 @@ pub fn run_env_check_with_options(
             }));
         }
 
-        if !contract_keys.is_empty() && example_record.is_none() {
+        if !sync_target_keys.is_empty() && example_record.is_none() {
             let output_path = directory.dir.join(".env.example");
 
             findings.push(make_finding(FindingInput {
@@ -196,14 +196,14 @@ pub fn run_env_check_with_options(
                 planned_fixes.push(plan_create_env_example_with_groups(
                     &project.root_dir,
                     &directory.dir,
-                    contract_groups.clone(),
+                    sync_target_groups.clone(),
                     options.template_render.clone(),
                 ));
             } else {
                 planned_fixes.push(plan_create_env_example(
                     &project.root_dir,
                     &directory.dir,
-                    &contract_keys,
+                    &sync_target_keys,
                 ));
             }
         }
@@ -215,7 +215,7 @@ pub fn run_env_check_with_options(
                 .iter()
                 .cloned()
                 .collect::<BTreeSet<_>>();
-            let missing_keys = contract_keys
+            let missing_keys = sync_target_keys
                 .iter()
                 .filter(|key| !example_keys.contains(*key))
                 .cloned()
@@ -450,6 +450,21 @@ fn collect_contract_keys(records: &[&ParsedEnvRecord]) -> Vec<String> {
     }
 
     keys
+}
+
+fn collect_sync_target_keys(records: &[&ParsedEnvRecord]) -> Vec<String> {
+    collect_contract_keys(records)
+        .into_iter()
+        .filter(|key| !is_ambient_platform_env_key(key))
+        .collect()
+}
+
+fn is_ambient_platform_env_key(key: &str) -> bool {
+    key == "NX_DAEMON"
+        || key == "VERCEL"
+        || key == "VERCEL_URL"
+        || key.starts_with("VERCEL_")
+        || key.starts_with("TURBO_")
 }
 
 fn collect_contract_groups(

--- a/crates/maximus-checks/tests/env_checks.rs
+++ b/crates/maximus-checks/tests/env_checks.rs
@@ -540,6 +540,105 @@ fn env_sync_planned_fix_uses_audited_snapshot_text() {
 }
 
 #[test]
+fn env_sync_planned_fix_excludes_ambient_platform_keys_and_keeps_app_keys() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let example_path = fixture.path().join(".env.local.example");
+
+    write(
+        fixture.path().join(".env.local"),
+        "VERCEL=1\nVERCEL_URL=example.vercel.app\nVERCEL_ENV=preview\nTURBO_TOKEN=turbo-token\nTURBO_TEAM=team\nNX_DAEMON=true\nNEXT_PUBLIC_OKTA_CLIENT_ID=okta-client\nGITHUB_TOKEN=github-token\nSUPABASE_URL=https://example.supabase.co\nSUPABASE_ANON_KEY=supabase-anon\nVALIDATION_MODE=strict\n",
+    );
+    write(fixture.path().join(".gitignore"), ".env.local\n");
+    write(&example_path, "EXISTING=\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_env_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!("env-example-sync:{}", fixture.path().to_string_lossy()),
+        Severity::Warn,
+        ".env.local.example is missing keys",
+        "Missing keys: NEXT_PUBLIC_OKTA_CLIENT_ID, GITHUB_TOKEN, SUPABASE_URL, SUPABASE_ANON_KEY, VALIDATION_MODE.",
+        "Run \"maximus fix\" to append the missing keys to .env.local.example.",
+        Some(example_path.clone()),
+        true,
+        &[format!(
+            "env-example:sync:{}",
+            fixture.path().to_string_lossy()
+        )],
+    );
+
+    let planned = outcome
+        .planned_fixes
+        .iter()
+        .find(|fix| {
+            fix.public.id == format!("env-example:sync:{}", fixture.path().to_string_lossy())
+        })
+        .expect("planned sync fix should exist")
+        .clone();
+
+    match &planned.operation {
+        FixOperation::SyncEnvExample { groups, .. } => {
+            assert_eq!(groups.len(), 1);
+            assert_eq!(
+                groups[0].keys,
+                vec![
+                    "NEXT_PUBLIC_OKTA_CLIENT_ID".to_string(),
+                    "GITHUB_TOKEN".to_string(),
+                    "SUPABASE_URL".to_string(),
+                    "SUPABASE_ANON_KEY".to_string(),
+                    "VALIDATION_MODE".to_string(),
+                ]
+            );
+            for ambient_key in [
+                "VERCEL",
+                "VERCEL_URL",
+                "VERCEL_ENV",
+                "TURBO_TOKEN",
+                "TURBO_TEAM",
+                "NX_DAEMON",
+            ] {
+                assert!(
+                    !groups[0].keys.iter().any(|key| key == ambient_key),
+                    "{ambient_key} should not be planned for env example sync"
+                );
+            }
+        }
+        _ => panic!("expected sync env example operation"),
+    }
+
+    apply_fix(&planned).expect("planned fix should apply");
+
+    let output = fs::read_to_string(&example_path).expect("example file should exist");
+    for app_key in [
+        "NEXT_PUBLIC_OKTA_CLIENT_ID",
+        "GITHUB_TOKEN",
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+        "VALIDATION_MODE",
+    ] {
+        assert!(
+            output.contains(&format!("{app_key}=\n")),
+            "{app_key} should be appended to env example"
+        );
+    }
+    for ambient_key in [
+        "VERCEL",
+        "VERCEL_URL",
+        "VERCEL_ENV",
+        "TURBO_TOKEN",
+        "TURBO_TEAM",
+        "NX_DAEMON",
+    ] {
+        assert!(
+            !output.contains(&format!("{ambient_key}=\n")),
+            "{ambient_key} should not be appended to env example"
+        );
+    }
+}
+
+#[test]
 fn env_example_render_helpers_match_js_create_and_sync_semantics() {
     assert_eq!(
         render_created_env_example(["ZETA", "ALPHA", "ALPHA"]),


### PR DESCRIPTION
## 배경

`maximus fix`가 Vercel/Turbo/NX 런타임 주입 키까지 `.env.local.example` sync 대상으로 잡아 불필요한 append 계획을 만들던 문제를 줄입니다.

## 변경 사항

- env sync/create 대상 키를 계산할 때 `VERCEL_*`, `TURBO_*`, `NX_DAEMON`, `VERCEL`, `VERCEL_URL`을 제외했습니다.
- 일반 앱 env 키는 기존처럼 `.env.local.example` sync 대상으로 유지했습니다.
- ambient platform 키는 `planned_fixes`에 포함되지 않고 `NEXT_PUBLIC_OKTA_*`, `GITHUB_TOKEN`, `SUPABASE_*`, `VALIDATION_*` 계열 키는 유지되는 회귀 테스트를 추가했습니다.

## 검증

- `cargo test -p maximus-checks --test env_checks`
- `git diff --check origin/master..HEAD`
- 사전 `$devils-advocate-review-loop`: Critical/High 없음

## 브랜치 / 워크트리

- Branch: `codex/fix-88-platform-env`
- Worktree: `/tmp/maximus-noise-wave1/issue-88-platform-env`
- Base: `master`

## 이슈 연결

Closes #88
