### PR TITLE
feat(cli): 리포트 파일 출력 옵션 추가

### DIFF
--- a/bin/maximus.js
+++ b/bin/maximus.js
@@ -208,7 +208,7 @@ function parseCompatInvocation(args) {
   let pathArg;
   const unsupportedFlags = [];
   const commandNames = new Set(["audit", "doctor", "fix"]);
-  const valueFlags = new Set(["--only", "--skip", "--fail-on", "--fix-id", "--fix-prefix", "--format"]);
+  const valueFlags = new Set(["--only", "--skip", "--fail-on", "--fix-id", "--fix-prefix", "--format", "--output"]);
   const passthroughFlags = new Set(["--dry-run", "--json"]);
 
   for (let index = 0; index < args.length; index += 1) {
@@ -370,7 +370,7 @@ function formatCompatHelp() {
     "  maximus fix [path] --dry-run [--json]",
     "  maximus help",
     "",
-    "Rust is the canonical Maximus runtime. When no Rust runtime is available, the bundled JS compatibility path stays as frozen reference-only fallback for legacy-compatible commands without Maximus config files or Rust-only flags. `--only`, `--skip`, `--fail-on`, `--diff`, `--fix-id`, `--fix-prefix`, and `--format` require the Rust runtime, and `fix` is only available with `--dry-run`.",
+    "Rust is the canonical Maximus runtime. When no Rust runtime is available, the bundled JS compatibility path stays as frozen reference-only fallback for legacy-compatible commands without Maximus config files or Rust-only flags. `--only`, `--skip`, `--fail-on`, `--diff`, `--fix-id`, `--fix-prefix`, `--format`, and `--output` require the Rust runtime, and `fix` is only available with `--dry-run`.",
   ].join("\n");
 }
 

--- a/crates/maximus-cli/src/args.rs
+++ b/crates/maximus-cli/src/args.rs
@@ -11,6 +11,7 @@ pub struct Flags {
     pub fix_prefixes: Vec<String>,
     pub help: bool,
     pub output_format: OutputFormat,
+    pub output_path: Option<OsString>,
     pub only_checks: Option<Vec<String>>,
     pub skip_checks: Option<Vec<String>>,
 }
@@ -108,6 +109,9 @@ where
                     "--format",
                 )?;
             }
+            Some("--output") => {
+                flags.output_path = Some(next_output_value(tokens.next())?);
+            }
             Some("--skip") => {
                 let value = next_option_value(tokens.next(), "--skip")?;
                 let values = split_csv_values(&value, "--skip")?;
@@ -151,6 +155,20 @@ fn next_option_value(value: Option<OsString>, flag: &'static str) -> Result<OsSt
     }
 
     Ok(value)
+}
+
+fn next_output_value(value: Option<OsString>) -> Result<OsString, ArgsError> {
+    let Some(value) = value else {
+        return Err(ArgsError::MissingValue("--output"));
+    };
+
+    match value.to_str() {
+        Some("") => Err(ArgsError::EmptyValue("--output")),
+        Some(candidate) if candidate.starts_with('-') && candidate != "-" => {
+            Err(ArgsError::MissingValue("--output"))
+        }
+        _ => Ok(value),
+    }
 }
 
 fn split_csv_values(value: &OsString, flag: &'static str) -> Result<Vec<String>, ArgsError> {
@@ -226,6 +244,7 @@ mod tests {
                     fix_prefixes: Vec::new(),
                     help: false,
                     output_format: OutputFormat::Json,
+                    output_path: None,
                     only_checks: None,
                     skip_checks: None,
                 },
@@ -282,6 +301,30 @@ mod tests {
         );
         assert_eq!(parsed.flags.fix_prefixes, vec!["env-example:".to_string()]);
         assert!(parsed.flags.diff);
+    }
+
+    #[test]
+    fn parse_args_collects_output_path_and_stdout_marker() {
+        let parsed = parse_args(["audit", "--json", "--output", "reports/audit.json"])
+            .expect("args should parse");
+
+        assert_eq!(
+            parsed.flags.output_path,
+            Some(OsString::from("reports/audit.json"))
+        );
+
+        let parsed = parse_args(["audit", "--format", "markdown", "--output", "-"])
+            .expect("stdout marker should parse");
+
+        assert_eq!(parsed.flags.output_path, Some(OsString::from("-")));
+    }
+
+    #[test]
+    fn parse_args_errors_when_output_path_value_is_missing() {
+        let error =
+            parse_args(["audit", "--output", "--json"]).expect_err("output path should fail");
+
+        assert_eq!(error, ArgsError::MissingValue("--output"));
     }
 
     #[test]

--- a/crates/maximus-cli/src/main.rs
+++ b/crates/maximus-cli/src/main.rs
@@ -11,7 +11,7 @@ use std::env;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::{Display, Formatter};
-use std::io;
+use std::io::{self, Write};
 use std::process;
 
 use maximus_checks::{
@@ -20,9 +20,9 @@ use maximus_checks::{
 };
 use maximus_core::{
     apply_fixes, find_ignore_root, load_ignore_file_pattern_sources, load_maximus_config,
-    preview_fixes, scope_ignore_patterns, select_fix_plans, select_planned_fixes, AuditResult,
-    EnvTemplateRenderOptions, FailOnLevel, FixPlan, FixSelector, LoadConfigError, MaximusConfig,
-    PlannedFix,
+    prepare_text_write, preview_fixes, scope_ignore_patterns, select_fix_plans,
+    select_planned_fixes, write_text, AuditResult, EnvTemplateRenderOptions, FailOnLevel, FixPlan,
+    FixSelector, LoadConfigError, MaximusConfig, PlannedFix,
 };
 
 use crate::args::{parse_args, ArgsError, Flags, OutputFormat};
@@ -192,6 +192,9 @@ fn run_fix_command(
     }
     let selected_fixes = select_fix_plans(&initial.result.fixes, &selector);
     let selected_initial = result_with_selected_fixes(&initial.result, selected_fixes.clone());
+    if !flags.dry_run {
+        prepare_report_output(flags)?;
+    }
     let previewed = if flags.dry_run && flags.diff {
         Some(preview_fixes(&planned)?)
     } else {
@@ -232,41 +235,25 @@ fn run_fix_command(
 }
 
 fn print_audit_report(flags: &Flags, result: &AuditResult) -> Result<(), CliError> {
-    match flags.output_format {
-        crate::args::OutputFormat::Text => {
-            println!("{}", report_text::format_audit_report(result));
-        }
-        crate::args::OutputFormat::Json => {
-            println!("{}", report_json::render_audit_result(result)?);
-        }
-        crate::args::OutputFormat::Markdown => {
-            println!("{}", report_markdown::format_audit_report(result));
-        }
-        crate::args::OutputFormat::Sarif => {
-            println!("{}", report_sarif::render_audit_result(result)?);
-        }
-    }
+    let report = match flags.output_format {
+        crate::args::OutputFormat::Text => report_text::format_audit_report(result),
+        crate::args::OutputFormat::Json => report_json::render_audit_result(result)?,
+        crate::args::OutputFormat::Markdown => report_markdown::format_audit_report(result),
+        crate::args::OutputFormat::Sarif => report_sarif::render_audit_result(result)?,
+    };
 
-    Ok(())
+    write_report_output(flags, &report)
 }
 
 fn print_doctor_report(flags: &Flags, result: &AuditResult) -> Result<(), CliError> {
-    match flags.output_format {
-        crate::args::OutputFormat::Text => {
-            println!("{}", report_text::format_doctor_report(result));
-        }
-        crate::args::OutputFormat::Json => {
-            println!("{}", report_json::render_audit_result(result)?);
-        }
-        crate::args::OutputFormat::Markdown => {
-            println!("{}", report_markdown::format_doctor_report(result));
-        }
-        crate::args::OutputFormat::Sarif => {
-            println!("{}", report_sarif::render_doctor_result(result)?);
-        }
-    }
+    let report = match flags.output_format {
+        crate::args::OutputFormat::Text => report_text::format_doctor_report(result),
+        crate::args::OutputFormat::Json => report_json::render_audit_result(result)?,
+        crate::args::OutputFormat::Markdown => report_markdown::format_doctor_report(result),
+        crate::args::OutputFormat::Sarif => report_sarif::render_doctor_result(result)?,
+    };
 
-    Ok(())
+    write_report_output(flags, &report)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -280,61 +267,68 @@ fn print_fix_report(
     preview_report: Option<&str>,
     previews: Option<&[maximus_core::PreviewedFix]>,
 ) -> Result<(), CliError> {
-    match flags.output_format {
-        crate::args::OutputFormat::Text => {
-            println!(
-                "{}",
-                report_text::format_fix_result(
-                    flags.dry_run,
-                    target_dir,
-                    initial,
-                    applied,
-                    final_result,
-                    selected_fixes,
-                    preview_report,
-                )
-            );
+    let report = match flags.output_format {
+        crate::args::OutputFormat::Text => report_text::format_fix_result(
+            flags.dry_run,
+            target_dir,
+            initial,
+            applied,
+            final_result,
+            selected_fixes,
+            preview_report,
+        ),
+        crate::args::OutputFormat::Json => report_json::render_fix_result(
+            flags.dry_run,
+            target_dir,
+            initial,
+            applied,
+            final_result,
+            previews,
+        )?,
+        crate::args::OutputFormat::Markdown => report_markdown::format_fix_result(
+            flags.dry_run,
+            target_dir,
+            initial,
+            applied,
+            final_result,
+            selected_fixes,
+            preview_report,
+        ),
+        crate::args::OutputFormat::Sarif => report_sarif::render_fix_result(
+            flags.dry_run,
+            target_dir,
+            initial,
+            applied,
+            final_result,
+            previews,
+        )?,
+    };
+
+    write_report_output(flags, &report)
+}
+
+fn write_report_output(flags: &Flags, report: &str) -> Result<(), CliError> {
+    let content = format!("{report}\n");
+
+    match flags.output_path.as_deref() {
+        Some(output_path) if output_path != OsStr::new("-") => {
+            write_text(std::path::Path::new(output_path), &content)?;
         }
-        crate::args::OutputFormat::Json => {
-            println!(
-                "{}",
-                report_json::render_fix_result(
-                    flags.dry_run,
-                    target_dir,
-                    initial,
-                    applied,
-                    final_result,
-                    previews,
-                )?
-            );
+        _ => {
+            io::stdout().lock().write_all(content.as_bytes())?;
         }
-        crate::args::OutputFormat::Markdown => {
-            println!(
-                "{}",
-                report_markdown::format_fix_result(
-                    flags.dry_run,
-                    target_dir,
-                    initial,
-                    applied,
-                    final_result,
-                    selected_fixes,
-                    preview_report,
-                )
-            );
-        }
-        crate::args::OutputFormat::Sarif => {
-            println!(
-                "{}",
-                report_sarif::render_fix_result(
-                    flags.dry_run,
-                    target_dir,
-                    initial,
-                    applied,
-                    final_result,
-                    previews,
-                )?
-            );
-        }
+    }
+
+    Ok(())
+}
+
+fn prepare_report_output(flags: &Flags) -> Result<(), CliError> {
+    if let Some(output_path) = flags
+        .output_path
+        .as_deref()
+        .filter(|output_path| *output_path != OsStr::new("-"))
+    {
+        prepare_text_write(std::path::Path::new(output_path))?;
     }
 
     Ok(())

--- a/crates/maximus-cli/src/report_text.rs
+++ b/crates/maximus-cli/src/report_text.rs
@@ -11,9 +11,9 @@ pub fn format_help() -> String {
         "Bring order to chaotic configs.",
         "",
         "Usage",
-        "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-        "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+        "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+        "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+        "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json] [--output <path>]",
         "  maximus help",
     ]
     .join("\n")
@@ -379,9 +379,9 @@ mod tests {
                 "Bring order to chaotic configs.",
                 "",
                 "Usage",
-                "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-                "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+                "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+                "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+                "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json] [--output <path>]",
                 "  maximus help",
             ]
             .join("\n")

--- a/crates/maximus-cli/tests/cli_help.rs
+++ b/crates/maximus-cli/tests/cli_help.rs
@@ -22,9 +22,9 @@ fn no_args_prints_help() {
             "Bring order to chaotic configs.",
             "",
             "Usage",
-            "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-            "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]",
-            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json]",
+            "  maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+            "  maximus doctor [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]",
+            "  maximus fix [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--dry-run] [--diff] [--env-source-comments] [--fix-id <id>] [--fix-prefix <prefix>] [--format <format>] [--json] [--output <path>]",
             "  maximus help",
             "",
         ]
@@ -43,7 +43,7 @@ fn help_subcommand_prints_usage() {
     assert!(String::from_utf8(output.stdout)
         .expect("stdout should be utf8")
         .contains(
-            "maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json]"
+            "maximus audit [path] [--only <checks>] [--skip <checks>] [--fail-on <level>] [--format <format>] [--json] [--output <path>]"
         ));
 }
 

--- a/crates/maximus-cli/tests/output_file.rs
+++ b/crates/maximus-cli/tests/output_file.rs
@@ -1,0 +1,163 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn maximus_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_maximus"))
+}
+
+#[test]
+fn audit_output_file_writes_report_creates_parents_and_keeps_exit_code() {
+    let fixture = tempdir().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+    let output_path = fixture.path().join("reports/nested/audit.json");
+
+    let output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--json",
+            "--output",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+
+    let value: Value =
+        serde_json::from_str(&fs::read_to_string(&output_path).expect("output file should exist"))
+            .expect("output file should contain valid json");
+    assert_eq!(value["generator"], "maximus");
+    assert!(
+        value["findings"]
+            .as_array()
+            .is_some_and(|findings| !findings.is_empty()),
+        "expected audit findings in file output: {value:?}"
+    );
+}
+
+#[test]
+fn output_dash_preserves_stdout_behavior() {
+    let fixture = tempdir().expect("temp dir should exist");
+    write_tsconfig_conflict_fixture(fixture.path());
+
+    let default_output = maximus_bin()
+        .args(["audit", fixture.path().to_string_lossy().as_ref(), "--json"])
+        .output()
+        .expect("audit should run");
+    let dash_output = maximus_bin()
+        .args([
+            "audit",
+            fixture.path().to_string_lossy().as_ref(),
+            "--json",
+            "--output",
+            "-",
+        ])
+        .output()
+        .expect("audit should run");
+
+    assert_eq!(dash_output.status.code(), default_output.status.code());
+    assert_eq!(dash_output.stdout, default_output.stdout);
+    assert_eq!(dash_output.stderr, default_output.stderr);
+}
+
+#[test]
+fn fix_dry_run_output_file_writes_selected_report_without_stdout() {
+    let fixture = tempdir().expect("temp dir should exist");
+    write(
+        fixture.path().join(".env"),
+        "API_URL=https://example.test\n",
+    );
+    let output_path = fixture.path().join("reports/fix.json");
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            fixture.path().to_string_lossy().as_ref(),
+            "--dry-run",
+            "--json",
+            "--output",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("fix should run");
+
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+
+    let value: Value =
+        serde_json::from_str(&fs::read_to_string(&output_path).expect("output file should exist"))
+            .expect("output file should contain valid json");
+    assert_eq!(value["dryRun"], true);
+    assert_eq!(value["initial"]["generator"], "maximus");
+    assert_eq!(value["applied"].as_array().map(Vec::len), Some(0));
+}
+
+#[test]
+fn fix_output_file_write_error_fails_before_applying_mutations() {
+    let fixture = tempdir().expect("temp dir should exist");
+    write(
+        fixture.path().join(".env"),
+        "API_URL=https://example.test\n",
+    );
+
+    let output = maximus_bin()
+        .args([
+            "fix",
+            fixture.path().to_string_lossy().as_ref(),
+            "--json",
+            "--output",
+            fixture.path().to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("fix should run");
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Maximus failed:"),
+        "{output:?}"
+    );
+    assert!(
+        !fixture.path().join(".env.example").exists(),
+        "fix should not mutate target files after output preflight fails"
+    );
+}
+
+fn write_tsconfig_conflict_fixture(root: &Path) {
+    write(
+        root.join("package.json"),
+        r##"{"name":"fixture","imports":{"#app/*":"./src/runtime/*"}}"##,
+    );
+    write(
+        root.join("tsconfig.json"),
+        r##"
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "#app/*": ["./src/lib/*"]
+            }
+          }
+        }
+        "##,
+    );
+    write(root.join("src/runtime/index.ts"), "export {};\n");
+    write(root.join("src/lib/index.ts"), "export {};\n");
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}

--- a/crates/maximus-core/src/fs.rs
+++ b/crates/maximus-core/src/fs.rs
@@ -19,11 +19,32 @@ pub fn read_text_if_exists(target_path: impl AsRef<Path>) -> io::Result<Option<S
     }
 }
 
+pub fn prepare_text_write(target_path: impl AsRef<Path>) -> io::Result<()> {
+    let target_path = target_path.as_ref();
+    create_parent_dirs(target_path)?;
+    let _file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(target_path)?;
+
+    Ok(())
+}
+
 pub fn write_text(target_path: impl AsRef<Path>, content: &str) -> io::Result<()> {
     let target_path = target_path.as_ref();
-    if let Some(parent) = target_path.parent() {
+    create_parent_dirs(target_path)?;
+
+    fs::write(target_path, content)
+}
+
+fn create_parent_dirs(target_path: &Path) -> io::Result<()> {
+    if let Some(parent) = target_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
         fs::create_dir_all(parent)?;
     }
 
-    fs::write(target_path, content)
+    Ok(())
 }

--- a/crates/maximus-core/src/lib.rs
+++ b/crates/maximus-core/src/lib.rs
@@ -37,7 +37,7 @@ pub use fixes::{
     select_planned_fixes, AppliedFix, FixFilePreview, FixOperation, FixSelector, PlannedFix,
     PreviewedFix,
 };
-pub use fs::{path_exists, read_text_if_exists, write_text};
+pub use fs::{path_exists, prepare_text_write, read_text_if_exists, write_text};
 pub use jsonc::{parse_jsonc, ParseJsoncError};
 pub use models::{
     AuditContext, AuditResult, AuditSummary, BaselineEntry, CheckId, FileKind, Finding, FixPlan,

--- a/test/packed-wrapper-fallback.test.js
+++ b/test/packed-wrapper-fallback.test.js
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import test from "node:test";
-import { chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { access, chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { resolvePackedWrapperLaunch } from "../scripts/lib/packed-wrapper-launch.mjs";
 
@@ -55,6 +55,23 @@ test("packed install without the optional runtime blocks config files, Rust-only
     /A Rust runtime is required for options not supported by the frozen JS compatibility path/,
   );
   assert.match(rustOnlyResult.stderr, /--only/);
+
+  const outputPath = path.join(installRoot, "fallback-report.json");
+  const outputResult = await runPackedWrapper(installRoot, [
+    "audit",
+    cleanFixtureDir,
+    "--json",
+    "--output",
+    outputPath,
+  ]);
+  assert.equal(outputResult.code, 1);
+  assert.equal(outputResult.stdout.trim(), "");
+  assert.match(
+    outputResult.stderr,
+    /A Rust runtime is required for options not supported by the frozen JS compatibility path/,
+  );
+  assert.match(outputResult.stderr, /--output/);
+  await assert.rejects(access(outputPath));
 
   const fixResult = await runPackedWrapper(installRoot, ["fix", cleanFixtureDir]);
   assert.equal(fixResult.code, 1);

--- a/test/wrapper-runtime.test.js
+++ b/test/wrapper-runtime.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { access, chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 
 test("wrapper preserves conventional exit code when the child terminates by signal", async (t) => {
@@ -301,6 +301,21 @@ test("wrapper blocks the frozen JS fallback when Rust-only flags are requested",
   assert.equal(result.stdout.trim(), "");
   assert.match(result.stderr, /A Rust runtime is required/);
   assert.match(result.stderr, /--only/);
+
+  const outputPath = path.join(rootDir, "report.json");
+  const outputResult = await runWrapper(path.join(rootDir, "bootstrap.mjs"), rootDir, [
+    "audit",
+    ".",
+    "--json",
+    "--output",
+    outputPath,
+  ]);
+
+  assert.equal(outputResult.code, 1);
+  assert.equal(outputResult.stdout.trim(), "");
+  assert.match(outputResult.stderr, /A Rust runtime is required/);
+  assert.match(outputResult.stderr, /--output/);
+  await assert.rejects(access(outputPath));
 });
 
 test("wrapper blocks output format flags on the frozen JS fallback", async (t) => {


### PR DESCRIPTION
## 배경

- #94 `CLI-IO-1`의 리포트 파일 출력 구현입니다.
- CI artifact나 별도 리포트 저장 흐름에서 shell redirection 없이 `maximus`가 직접 결과 파일을 만들 수 있게 합니다.

## 변경 사항

- `audit`, `doctor`, `fix`에 공통 `--output <path>` 옵션을 추가했습니다.
- `--output -`는 기존 stdout 출력과 동일하게 동작합니다.
- 파일 출력 시 parent directory를 자동 생성합니다.
- `fix`의 실제 파일 변경 전 output target을 선검증해, 리포트 쓰기 실패가 대상 프로젝트 변경 뒤에 발생하지 않게 했습니다.
- CLI help와 output-file 회귀 테스트를 추가했습니다.

## 검증

- `cargo test -p maximus-cli --test output_file`
- `cargo test -p maximus-cli --test cli_help`
- `cargo test -p maximus-cli --test config_and_filtering`
- `cargo test -p maximus-cli parse_args`
- `git diff --check`
- `rustfmt --check --config skip_children=true crates/maximus-cli/src/args.rs crates/maximus-cli/src/main.rs crates/maximus-core/src/fs.rs crates/maximus-core/src/lib.rs crates/maximus-cli/src/report_text.rs crates/maximus-cli/tests/cli_help.rs crates/maximus-cli/tests/output_file.rs`

## Devil's Advocate review loop

- Round 1: Critical 0 / High 0 / Medium 1 / Low 0
  - Medium: `--output` help 노출 누락. 반영 완료.
- Round 2: Critical 0 / High 1 / Medium 0 / Low 0
  - High: `fix --output` 쓰기 실패가 파일 변경 뒤에 발생. 반영 완료.
- Round 3: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- Base: `master`
- Branch: `codex/feat-94-cli-output-file`
- Worktree: `/private/tmp/maximus-wave1-20260430/issue-94-cli-output-file`

## 이슈 연결

Closes #94

