### PR TITLE
feat(checks): publish drift 검사 추가

### DIFF
--- a/crates/maximus-checks/src/ignore_file_drift.rs
+++ b/crates/maximus-checks/src/ignore_file_drift.rs
@@ -1,0 +1,319 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use maximus_core::{
+    is_ignored_project_path_from_root, make_finding, FindingInput, ProjectSnapshot, Severity,
+};
+
+use crate::check_outcome::CheckOutcome;
+
+const IGNORED_DIRECTORIES: &[&str] = &[
+    ".git",
+    ".hg",
+    ".idea",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".pnpm-store",
+    ".svelte-kit",
+    ".turbo",
+    ".vercel",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+    "tmp",
+];
+
+const ARTIFACT_PATTERNS: &[ArtifactPattern] = &[
+    ArtifactPattern {
+        canonical: "node_modules",
+        aliases: &["node_modules"],
+    },
+    ArtifactPattern {
+        canonical: "coverage",
+        aliases: &["coverage"],
+    },
+    ArtifactPattern {
+        canonical: "dist",
+        aliases: &["dist"],
+    },
+    ArtifactPattern {
+        canonical: "build",
+        aliases: &["build"],
+    },
+    ArtifactPattern {
+        canonical: "out",
+        aliases: &["out"],
+    },
+    ArtifactPattern {
+        canonical: "target",
+        aliases: &["target"],
+    },
+    ArtifactPattern {
+        canonical: "tmp",
+        aliases: &["tmp", ".tmp"],
+    },
+    ArtifactPattern {
+        canonical: "*.tgz",
+        aliases: &["*.tgz"],
+    },
+];
+
+struct ArtifactPattern {
+    canonical: &'static str,
+    aliases: &'static [&'static str],
+}
+
+#[derive(Debug, Default)]
+struct DirectoryIgnoreFiles {
+    gitignore: Option<ParsedIgnoreFile>,
+    maximusignore: Option<ParsedIgnoreFile>,
+}
+
+#[derive(Debug)]
+struct ParsedIgnoreFile {
+    path: PathBuf,
+    patterns: BTreeSet<String>,
+}
+
+pub fn run_ignore_file_drift_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_ignore_file_drift_check_with_ignore_root(project, &[], &project.root_dir)
+}
+
+pub(crate) fn run_ignore_file_drift_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+    let mut ignore_files = BTreeMap::new();
+    collect_ignore_files(
+        &project.root_dir,
+        ignored_patterns,
+        ignore_root,
+        &mut ignore_files,
+    )?;
+
+    for (directory, files) in ignore_files {
+        let (Some(gitignore), Some(maximusignore)) = (files.gitignore, files.maximusignore) else {
+            continue;
+        };
+
+        let all_patterns = gitignore
+            .patterns
+            .union(&maximusignore.patterns)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        for pattern in all_patterns {
+            let in_gitignore = gitignore.patterns.contains(&pattern);
+            let in_maximusignore = maximusignore.patterns.contains(&pattern);
+            if in_gitignore == in_maximusignore {
+                continue;
+            }
+
+            let (source, missing_file, consequence) = if in_gitignore {
+                (
+                    &gitignore,
+                    ".maximusignore",
+                    "Maximus may still scan generated or packaged artifacts that git ignores.",
+                )
+            } else {
+                (
+                    &maximusignore,
+                    ".gitignore",
+                    "Generated or packaged artifacts may still be committed because git does not ignore them.",
+                )
+            };
+
+            findings.push(make_finding(FindingInput {
+                id: format!(
+                    "ignore-drift:{}:{}:{}",
+                    directory.to_string_lossy(),
+                    pattern,
+                    missing_file
+                ),
+                title: "Ignore files disagree on generated artifact coverage".to_string(),
+                category: Some("ignore-drift".to_string()),
+                detail: Some(format!(
+                    "{} is ignored in {}, but not in {} for {}. {}",
+                    pattern,
+                    source
+                        .path
+                        .file_name()
+                        .map(|name| name.to_string_lossy())
+                        .unwrap_or_default(),
+                    missing_file,
+                    relative_display_dir(&project.root_dir, &directory),
+                    consequence
+                )),
+                file: Some(source.path.clone()),
+                fix_ids: Vec::new(),
+                fixable: false,
+                hint: Some(
+                    "Keep generated-artifact ignore entries aligned across .gitignore and .maximusignore, or remove the redundant local ignore file."
+                        .to_string(),
+                ),
+                severity: Some(Severity::Warn),
+            }));
+        }
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+fn collect_ignore_files(
+    root_dir: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+    ignore_files: &mut BTreeMap<PathBuf, DirectoryIgnoreFiles>,
+) -> io::Result<()> {
+    if is_ignored_project_path_from_root(ignore_root, root_dir, ignored_patterns) {
+        return Ok(());
+    }
+
+    let mut child_directories = Vec::new();
+    let entries = match fs::read_dir(root_dir) {
+        Ok(entries) => entries,
+        Err(error) if should_skip_traversal_error(&error) => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let path = entry.path();
+
+        if file_type.is_dir() {
+            if !should_ignore_directory(&entry.file_name())
+                && !is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns)
+            {
+                child_directories.push(path);
+            }
+            continue;
+        }
+
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if file_name != ".gitignore" && file_name != ".maximusignore" {
+            continue;
+        }
+        if is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns) {
+            continue;
+        }
+
+        let Some(text) = maximus_core::read_text_if_exists(&path)? else {
+            continue;
+        };
+        let parsed = ParsedIgnoreFile {
+            path: path.clone(),
+            patterns: parse_artifact_patterns(&text),
+        };
+        let directory = path.parent().unwrap_or(root_dir).to_path_buf();
+        let files = ignore_files.entry(directory).or_default();
+        if file_name == ".gitignore" {
+            files.gitignore = Some(parsed);
+        } else {
+            files.maximusignore = Some(parsed);
+        }
+    }
+
+    child_directories.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+    for child_directory in child_directories {
+        collect_ignore_files(
+            &child_directory,
+            ignored_patterns,
+            ignore_root,
+            ignore_files,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn parse_artifact_patterns(text: &str) -> BTreeSet<String> {
+    text.lines()
+        .filter_map(normalize_ignore_line)
+        .filter_map(|pattern| canonical_artifact_pattern(&pattern).map(ToOwned::to_owned))
+        .collect()
+}
+
+fn normalize_ignore_line(line: &str) -> Option<String> {
+    let mut value = line.trim_end().to_string();
+    if value.is_empty() || value.starts_with('#') || value.starts_with('!') {
+        return None;
+    }
+    if value.starts_with("\\!") {
+        value.replace_range(..2, "!");
+    } else if value.starts_with("\\#") {
+        value.replace_range(..2, "#");
+    }
+
+    let normalized = value
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string();
+    if normalized.is_empty() || normalized.contains('/') {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn canonical_artifact_pattern(pattern: &str) -> Option<&'static str> {
+    ARTIFACT_PATTERNS
+        .iter()
+        .find(|artifact| artifact.aliases.contains(&pattern))
+        .map(|artifact| artifact.canonical)
+}
+
+fn should_ignore_directory(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .map(|value| IGNORED_DIRECTORIES.contains(&value))
+        .unwrap_or(false)
+}
+
+fn relative_display_dir(root_dir: &Path, directory: &Path) -> String {
+    directory
+        .strip_prefix(root_dir)
+        .map(|relative| {
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            if relative.is_empty() {
+                ".".to_string()
+            } else {
+                relative
+            }
+        })
+        .unwrap_or_else(|_| directory.to_string_lossy().to_string())
+}
+
+fn should_skip_traversal_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+    )
+}

--- a/crates/maximus-checks/src/lib.rs
+++ b/crates/maximus-checks/src/lib.rs
@@ -5,10 +5,13 @@ mod config_duplicates;
 mod editorconfig_prettier;
 mod env;
 mod eslint_prettier;
+mod ignore_file_drift;
 mod jsx_config;
 pub mod lockfiles;
 mod module_system;
 mod monorepo_tsconfig;
+mod node_matrix;
+mod npmignore_files;
 pub mod package_entrypoints;
 pub mod registry;
 pub mod structure;
@@ -26,9 +29,12 @@ pub use env::{
     EnvCheckOptions,
 };
 pub use eslint_prettier::run_eslint_prettier_check;
+pub use ignore_file_drift::run_ignore_file_drift_check;
 pub use jsx_config::run_jsx_config_check;
 pub use module_system::run_module_system_check;
 pub use monorepo_tsconfig::run_monorepo_tsconfig_check;
+pub use node_matrix::run_node_matrix_check;
+pub use npmignore_files::run_npmignore_files_check;
 pub use registry::{
     audit_project, audit_project_with_config, audit_project_with_config_root, registered_check_ids,
     run_env_check_with_config_root_and_options, run_registered_checks,

--- a/crates/maximus-checks/src/node_matrix.rs
+++ b/crates/maximus-checks/src/node_matrix.rs
@@ -1,0 +1,458 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use maximus_core::{
+    get_files, is_ignored_project_path_from_root, make_finding, parse_jsonc, read_text_if_exists,
+    FileKind, FindingInput, ProjectSnapshot, Severity,
+};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+
+pub fn run_node_matrix_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_node_matrix_check_with_ignore_root(project, &[], &project.root_dir)
+}
+
+pub(crate) fn run_node_matrix_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let workflow =
+        collect_workflow_node_versions(&project.root_dir, ignored_patterns, ignore_root)?;
+    if workflow.workflow_files == 0 {
+        return Ok(CheckOutcome::default());
+    }
+
+    let mut findings = Vec::new();
+    for package_file in get_files(project, FileKind::Package) {
+        if is_ignored_project_path_from_root(ignore_root, &package_file.path, ignored_patterns) {
+            continue;
+        }
+        let Some(engine) = read_node_engine(&package_file.path)? else {
+            continue;
+        };
+        let Some(detail) = node_matrix_detail(&engine, &workflow.node_versions) else {
+            continue;
+        };
+
+        findings.push(make_finding(FindingInput {
+            id: format!("node-matrix:{}", package_file.path.to_string_lossy()),
+            title: "Node engine support and GitHub Actions matrix are out of sync".to_string(),
+            category: Some("node-matrix".to_string()),
+            detail: Some(detail),
+            file: Some(package_file.path.clone()),
+            fix_ids: Vec::new(),
+            fixable: false,
+            hint: Some(
+                "Update package.json engines.node and the GitHub Actions Node matrix together so CI exercises the supported runtime floor."
+                    .to_string(),
+            ),
+            severity: Some(Severity::Warn),
+        }));
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+#[derive(Default)]
+struct WorkflowNodeVersions {
+    workflow_files: usize,
+    node_versions: BTreeSet<u32>,
+}
+
+fn collect_workflow_node_versions(
+    root_dir: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<WorkflowNodeVersions> {
+    let workflows_dir = root_dir.join(".github").join("workflows");
+    if !workflows_dir.is_dir() {
+        return Ok(WorkflowNodeVersions::default());
+    }
+    if is_ignored_project_path_from_root(ignore_root, &workflows_dir, ignored_patterns) {
+        return Ok(WorkflowNodeVersions::default());
+    }
+
+    let mut workflow_files = 0;
+    let mut node_versions = BTreeSet::new();
+    let mut entries = fs::read_dir(workflows_dir)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+
+    for path in entries {
+        if !is_workflow_file(&path) {
+            continue;
+        }
+        if is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns) {
+            continue;
+        }
+        workflow_files += 1;
+        let Some(text) = read_text_if_exists(&path)? else {
+            continue;
+        };
+        node_versions.extend(parse_workflow_node_versions(&text));
+    }
+
+    Ok(WorkflowNodeVersions {
+        workflow_files,
+        node_versions,
+    })
+}
+
+fn read_node_engine(package_path: &Path) -> io::Result<Option<String>> {
+    let Some(text) = read_text_if_exists(package_path)? else {
+        return Ok(None);
+    };
+    let Ok(package_json) = parse_jsonc::<Value>(&text, &package_path.to_string_lossy()) else {
+        return Ok(None);
+    };
+
+    Ok(package_json
+        .get("engines")
+        .and_then(Value::as_object)
+        .and_then(|engines| engines.get("node"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned))
+}
+
+fn node_matrix_detail(engine: &str, workflow_versions: &BTreeSet<u32>) -> Option<String> {
+    if workflow_versions.is_empty() {
+        return Some(format!(
+            "package.json engines.node is {engine:?}, but no concrete GitHub Actions Node versions were found."
+        ));
+    }
+
+    let Some(requirement) = parse_engine_requirement(engine) else {
+        return None;
+    };
+    let mut problems = Vec::new();
+
+    let required_majors = requirement.required_majors();
+    let missing = required_majors
+        .difference(workflow_versions)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if !missing.is_empty() {
+        problems.push(format!(
+            "the Actions matrix does not include supported {}",
+            render_node_majors(&missing)
+        ));
+    }
+
+    let unsupported = workflow_versions
+        .iter()
+        .copied()
+        .filter(|version| !requirement.supports(*version))
+        .collect::<BTreeSet<_>>();
+    if !unsupported.is_empty() {
+        problems.push(format!(
+            "the Actions matrix includes unsupported {}",
+            render_node_majors(&unsupported)
+        ));
+    }
+
+    if problems.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "package.json engines.node is {engine:?}, while GitHub Actions declares {}: {}.",
+        render_node_majors(workflow_versions),
+        problems.join("; ")
+    ))
+}
+
+struct EngineRequirement {
+    ranges: Vec<EngineRange>,
+}
+
+impl EngineRequirement {
+    fn supports(&self, major: u32) -> bool {
+        self.ranges.iter().any(|range| range.supports(major))
+    }
+
+    fn required_majors(&self) -> BTreeSet<u32> {
+        self.ranges
+            .iter()
+            .filter_map(|range| range.min_major)
+            .collect()
+    }
+}
+
+#[derive(Default)]
+struct EngineRange {
+    min_major: Option<u32>,
+    max_major: Option<u32>,
+}
+
+impl EngineRange {
+    fn supports(&self, major: u32) -> bool {
+        if self.min_major.is_some_and(|min_major| major < min_major) {
+            return false;
+        }
+        if self.max_major.is_some_and(|max_major| major > max_major) {
+            return false;
+        }
+
+        true
+    }
+}
+
+fn parse_engine_requirement(engine: &str) -> Option<EngineRequirement> {
+    let ranges = engine
+        .split("||")
+        .filter_map(|group| parse_engine_range(group.trim()))
+        .collect::<Vec<_>>();
+
+    if ranges.is_empty() {
+        None
+    } else {
+        Some(EngineRequirement { ranges })
+    }
+}
+
+fn parse_engine_range(group: &str) -> Option<EngineRange> {
+    let mut range = EngineRange::default();
+    let mut recognized = false;
+
+    for token in engine_range_tokens(group) {
+        let token = token.trim_matches(',');
+        if let Some(major) = comparator_major(token, ">=") {
+            range.min_major = Some(range.min_major.map_or(major, |current| current.max(major)));
+            recognized = true;
+            continue;
+        }
+        if let Some(major) = comparator_major(token, ">") {
+            let min_major = major.saturating_add(1);
+            range.min_major = Some(
+                range
+                    .min_major
+                    .map_or(min_major, |current| current.max(min_major)),
+            );
+            recognized = true;
+            continue;
+        }
+        if let Some(major) = comparator_major(token, "<=") {
+            range.max_major = Some(range.max_major.map_or(major, |current| current.min(major)));
+            recognized = true;
+            continue;
+        }
+        if let Some(major) = comparator_major(token, "<") {
+            let Some(max_major) = major.checked_sub(1) else {
+                continue;
+            };
+            range.max_major = Some(
+                range
+                    .max_major
+                    .map_or(max_major, |current| current.min(max_major)),
+            );
+            recognized = true;
+            continue;
+        }
+        if token.starts_with('>') || token.starts_with('<') {
+            continue;
+        }
+        if let Some(major) = major_at_start(
+            token
+                .trim_start_matches('=')
+                .trim_start_matches('^')
+                .trim_start_matches('~'),
+        ) {
+            range.min_major = Some(range.min_major.map_or(major, |current| current.max(major)));
+            range.max_major = Some(range.max_major.map_or(major, |current| current.min(major)));
+            recognized = true;
+        }
+    }
+
+    if !recognized
+        || range
+            .min_major
+            .zip(range.max_major)
+            .is_some_and(|(min, max)| min > max)
+    {
+        None
+    } else {
+        Some(range)
+    }
+}
+
+fn engine_range_tokens(group: &str) -> Vec<String> {
+    let raw_tokens = group
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < raw_tokens.len() {
+        let token = raw_tokens[index].trim_matches(',');
+        if is_standalone_comparator(token) && index + 1 < raw_tokens.len() {
+            tokens.push(format!(
+                "{}{}",
+                token,
+                raw_tokens[index + 1].trim_matches(',')
+            ));
+            index += 2;
+            continue;
+        }
+
+        tokens.push(token.to_string());
+        index += 1;
+    }
+
+    tokens
+}
+
+fn is_standalone_comparator(token: &str) -> bool {
+    matches!(token, ">=" | ">" | "<=" | "<" | "=")
+}
+
+fn comparator_major(token: &str, comparator: &str) -> Option<u32> {
+    token
+        .strip_prefix(comparator)
+        .and_then(|value| major_at_start(value.trim_start_matches('v')))
+}
+
+fn major_at_start(value: &str) -> Option<u32> {
+    let mut digits = String::new();
+    for character in value.chars() {
+        if character.is_ascii_digit() {
+            digits.push(character);
+            continue;
+        }
+        break;
+    }
+
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+fn parse_workflow_node_versions(text: &str) -> BTreeSet<u32> {
+    let mut versions = BTreeSet::new();
+    let mut active_sequence_indent = None;
+
+    for line in text.lines() {
+        let stripped = strip_yaml_comment(line);
+        let trimmed = stripped.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let indent = line
+            .chars()
+            .take_while(|character| character.is_whitespace())
+            .count();
+        if let Some(sequence_indent) = active_sequence_indent {
+            if indent > sequence_indent && trimmed.starts_with('-') {
+                collect_node_versions(trimmed.trim_start_matches('-').trim(), &mut versions);
+                continue;
+            }
+            if indent <= sequence_indent {
+                active_sequence_indent = None;
+            }
+        }
+
+        let mapping_line = normalize_yaml_sequence_mapping(trimmed);
+        let Some((key, value)) = split_yaml_key_value(mapping_line) else {
+            continue;
+        };
+        if key != "node" && key != "node-version" {
+            continue;
+        }
+
+        if value.is_empty() {
+            active_sequence_indent = Some(indent);
+        } else {
+            collect_node_versions(value, &mut versions);
+        }
+    }
+
+    versions
+}
+
+fn split_yaml_key_value(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(':')?;
+    Some((key.trim(), value.trim()))
+}
+
+fn normalize_yaml_sequence_mapping(line: &str) -> &str {
+    line.strip_prefix("- ").map(str::trim_start).unwrap_or(line)
+}
+
+fn collect_node_versions(value: &str, versions: &mut BTreeSet<u32>) {
+    for token in value.split(|character: char| {
+        character == '['
+            || character == ']'
+            || character == ','
+            || character == '"'
+            || character == '\''
+            || character.is_whitespace()
+    }) {
+        let token = token.trim_start_matches('v');
+        if let Some(version) = major_at_start(token) {
+            versions.insert(version);
+        }
+    }
+}
+
+fn strip_yaml_comment(line: &str) -> String {
+    let mut output = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in line.chars() {
+        if escaped {
+            output.push(character);
+            escaped = false;
+            continue;
+        }
+        if character == '\\' {
+            output.push(character);
+            escaped = true;
+            continue;
+        }
+        if quote == Some(character) {
+            quote = None;
+            output.push(character);
+            continue;
+        }
+        if quote.is_none() && (character == '"' || character == '\'') {
+            quote = Some(character);
+            output.push(character);
+            continue;
+        }
+        if quote.is_none() && character == '#' {
+            break;
+        }
+        output.push(character);
+    }
+
+    output
+}
+
+fn is_workflow_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension == "yml" || extension == "yaml")
+        .unwrap_or(false)
+}
+
+fn render_node_majors(versions: &BTreeSet<u32>) -> String {
+    versions
+        .iter()
+        .map(|version| format!("Node {version}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/crates/maximus-checks/src/npmignore_files.rs
+++ b/crates/maximus-checks/src/npmignore_files.rs
@@ -1,0 +1,723 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use maximus_core::{
+    get_files, is_ignored_project_path_from_root, make_finding, parse_jsonc, read_text_if_exists,
+    FileKind, FindingInput, ProjectSnapshot, Severity,
+};
+use serde_json::Value;
+
+use crate::check_outcome::CheckOutcome;
+
+pub fn run_npmignore_files_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome> {
+    run_npmignore_files_check_with_ignore_root(project, &[], &project.root_dir)
+}
+
+pub(crate) fn run_npmignore_files_check_with_ignore_root(
+    project: &ProjectSnapshot,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let mut findings = Vec::new();
+
+    for package_file in get_files(project, FileKind::Package) {
+        if is_ignored_project_path_from_root(ignore_root, &package_file.path, ignored_patterns) {
+            continue;
+        }
+        let Some(files_entries) = read_package_files_entries(&package_file.path)? else {
+            continue;
+        };
+        if files_entries.is_empty() {
+            continue;
+        }
+
+        let package_dir = package_file
+            .path
+            .parent()
+            .unwrap_or(project.root_dir.as_path());
+        let mut seen_finding_ids = BTreeSet::new();
+
+        for files_entry in files_entries {
+            let Some(normalized_entry) = normalize_files_entry(&files_entry) else {
+                continue;
+            };
+            collect_nested_npmignore_findings(
+                &mut findings,
+                &mut seen_finding_ids,
+                &package_file.path,
+                package_dir,
+                &files_entry,
+                &normalized_entry,
+                ignored_patterns,
+                ignore_root,
+            )?;
+        }
+    }
+
+    Ok(CheckOutcome {
+        findings,
+        fixes: Vec::new(),
+        planned_fixes: Vec::new(),
+    })
+}
+
+#[derive(Debug)]
+struct NpmignorePattern {
+    raw: String,
+    normalized: String,
+    negated: bool,
+    directory_only: bool,
+    anchored: bool,
+}
+
+fn collect_nested_npmignore_findings(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    normalized_entry: &str,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    let included_path = if normalized_entry == "." {
+        package_dir.to_path_buf()
+    } else {
+        package_dir.join(normalized_entry)
+    };
+    if contains_glob(normalized_entry) {
+        collect_glob_nested_npmignore_findings(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            normalized_entry,
+            ignored_patterns,
+            ignore_root,
+        )?;
+        return Ok(());
+    }
+
+    if is_ignored_project_path_from_root(ignore_root, &included_path, ignored_patterns) {
+        return Ok(());
+    }
+
+    if included_path.is_file() {
+        collect_file_nested_npmignore_findings(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &included_path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+        return Ok(());
+    }
+
+    if included_path.is_dir() {
+        collect_directory_nested_npmignore_findings(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &included_path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_glob_nested_npmignore_findings(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    normalized_entry: &str,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    let mut candidate_files = Vec::new();
+    collect_candidate_files(package_dir, &mut candidate_files)?;
+
+    for file_path in candidate_files {
+        if is_ignored_project_path_from_root(ignore_root, &file_path, ignored_patterns) {
+            continue;
+        }
+        let Some(relative_to_package) = relative_path(package_dir, &file_path) else {
+            continue;
+        };
+        if !files_entry_includes_file(normalized_entry, &relative_to_package) {
+            continue;
+        }
+
+        collect_file_nested_npmignore_findings(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &file_path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_file_nested_npmignore_findings(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    file_path: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    if is_ignored_project_path_from_root(ignore_root, file_path, ignored_patterns) {
+        return Ok(());
+    }
+
+    let mut directories = Vec::new();
+    let mut current = file_path.parent();
+    while let Some(directory) = current {
+        if directory == package_dir {
+            break;
+        }
+        directories.push(directory.to_path_buf());
+        current = directory.parent();
+    }
+    directories.reverse();
+
+    for directory in directories {
+        let npmignore_path = directory.join(".npmignore");
+        collect_npmignore_findings_for_file(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &npmignore_path,
+            file_path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_directory_nested_npmignore_findings(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    directory: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if should_skip_traversal_error(&error) => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let mut child_directories = Vec::new();
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let path = entry.path();
+
+        if is_ignored_project_path_from_root(ignore_root, &path, ignored_patterns) {
+            continue;
+        }
+
+        if file_type.is_dir() {
+            child_directories.push(path);
+            continue;
+        }
+
+        if !file_type.is_file()
+            || path.file_name().and_then(|name| name.to_str()) != Some(".npmignore")
+        {
+            continue;
+        }
+        if path.parent() == Some(package_dir) {
+            continue;
+        }
+
+        collect_npmignore_findings_for_directory(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    child_directories.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+    for child_directory in child_directories {
+        collect_directory_nested_npmignore_findings(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            &child_directory,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_npmignore_findings_for_directory(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    npmignore_path: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    let Some(npmignore_dir) = npmignore_path.parent() else {
+        return Ok(());
+    };
+    let mut candidate_files = Vec::new();
+    collect_candidate_files(npmignore_dir, &mut candidate_files)?;
+    for file_path in candidate_files {
+        if is_ignored_project_path_from_root(ignore_root, &file_path, ignored_patterns) {
+            continue;
+        }
+        collect_npmignore_findings_for_file(
+            findings,
+            seen_finding_ids,
+            package_path,
+            package_dir,
+            files_entry,
+            npmignore_path,
+            &file_path,
+            ignored_patterns,
+            ignore_root,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_npmignore_findings_for_file(
+    findings: &mut Vec<maximus_core::Finding>,
+    seen_finding_ids: &mut BTreeSet<String>,
+    package_path: &Path,
+    package_dir: &Path,
+    files_entry: &str,
+    npmignore_path: &Path,
+    file_path: &Path,
+    ignored_patterns: &[String],
+    ignore_root: &Path,
+) -> io::Result<()> {
+    if !npmignore_path.is_file() {
+        return Ok(());
+    }
+    if is_ignored_project_path_from_root(ignore_root, file_path, ignored_patterns) {
+        return Ok(());
+    }
+    if file_path.file_name().and_then(|name| name.to_str()) == Some(".npmignore") {
+        return Ok(());
+    }
+
+    let Some(npmignore_dir) = npmignore_path.parent() else {
+        return Ok(());
+    };
+    let Some(relative_to_npmignore) = relative_path(npmignore_dir, file_path) else {
+        return Ok(());
+    };
+    let Some(relative_to_package) = relative_path(package_dir, file_path) else {
+        return Ok(());
+    };
+    let Some(npmignore_text) = read_text_if_exists(npmignore_path)? else {
+        return Ok(());
+    };
+    let patterns = parse_npmignore_patterns(&npmignore_text);
+    let Some(pattern) = final_ignoring_pattern(&relative_to_npmignore, &patterns) else {
+        return Ok(());
+    };
+
+    let id = format!(
+        "npmignore-files:{}:{}",
+        package_path.to_string_lossy(),
+        relative_to_package
+    );
+    if !seen_finding_ids.insert(id.clone()) {
+        return Ok(());
+    }
+
+    findings.push(make_finding(FindingInput {
+        id,
+        title: "package.json files entry is excluded by nested .npmignore".to_string(),
+        category: Some("npmignore-files".to_string()),
+        detail: Some(format!(
+            "package.json files includes {files_entry:?}, but nested .npmignore pattern {:?} excludes {:?}.",
+            pattern.raw, relative_to_package
+        )),
+        file: Some(npmignore_path.to_path_buf()),
+        fix_ids: Vec::new(),
+        fixable: false,
+        hint: Some(
+            "Remove the nested .npmignore rule or adjust package.json files so publish intent is unambiguous."
+                .to_string(),
+        ),
+        severity: Some(Severity::Warn),
+    }));
+
+    Ok(())
+}
+
+fn collect_candidate_files(
+    directory: &Path,
+    candidate_files: &mut Vec<std::path::PathBuf>,
+) -> io::Result<()> {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if should_skip_traversal_error(&error) => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let mut child_directories = Vec::new();
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if should_skip_traversal_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let path = entry.path();
+
+        if file_type.is_file() {
+            candidate_files.push(path);
+        } else if file_type.is_dir() {
+            child_directories.push(path);
+        }
+    }
+
+    child_directories.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+    for child_directory in child_directories {
+        collect_candidate_files(&child_directory, candidate_files)?;
+    }
+
+    Ok(())
+}
+
+fn relative_path(base: &Path, path: &Path) -> Option<String> {
+    Some(
+        path.strip_prefix(base)
+            .ok()?
+            .to_string_lossy()
+            .replace('\\', "/"),
+    )
+}
+
+fn should_skip_traversal_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+    )
+}
+
+fn read_package_files_entries(package_path: &Path) -> io::Result<Option<Vec<String>>> {
+    let Some(text) = read_text_if_exists(package_path)? else {
+        return Ok(None);
+    };
+    let Ok(package_json) = parse_jsonc::<Value>(&text, &package_path.to_string_lossy()) else {
+        return Ok(None);
+    };
+    let Some(files) = package_json.get("files").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        files
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect(),
+    ))
+}
+
+fn parse_npmignore_patterns(text: &str) -> Vec<NpmignorePattern> {
+    text.lines()
+        .filter_map(|line| {
+            let mut value = line.trim_end().to_string();
+            if value.is_empty() || value.starts_with('#') {
+                return None;
+            }
+
+            let negated = if value.starts_with("\\!") {
+                value.replace_range(..2, "!");
+                false
+            } else if value.starts_with("\\#") {
+                value.replace_range(..2, "#");
+                false
+            } else if value.starts_with('!') {
+                value.remove(0);
+                true
+            } else {
+                false
+            };
+
+            let directory_only = value.ends_with('/');
+            let anchored = value.starts_with('/');
+            let normalized = value
+                .replace('\\', "/")
+                .trim_start_matches("./")
+                .trim_start_matches('/')
+                .trim_end_matches('/')
+                .to_string();
+            if normalized.is_empty() {
+                return None;
+            }
+
+            Some(NpmignorePattern {
+                raw: line.trim_end().to_string(),
+                normalized,
+                negated,
+                directory_only,
+                anchored,
+            })
+        })
+        .collect()
+}
+
+fn final_ignoring_pattern<'a>(
+    files_entry: &str,
+    patterns: &'a [NpmignorePattern],
+) -> Option<&'a NpmignorePattern> {
+    let mut ignored_by = None;
+    for pattern in patterns {
+        if pattern_matches_files_entry(pattern, files_entry) {
+            if pattern.negated {
+                ignored_by = None;
+            } else {
+                ignored_by = Some(pattern);
+            }
+        }
+    }
+
+    ignored_by
+}
+
+fn pattern_matches_files_entry(pattern: &NpmignorePattern, files_entry: &str) -> bool {
+    let pattern_value = pattern.normalized.as_str();
+    if pattern.directory_only {
+        return directory_only_pattern_matches(pattern_value, files_entry, pattern.anchored);
+    }
+    if pattern_value == files_entry {
+        return true;
+    }
+    if !pattern_value.contains('/') {
+        if pattern.anchored {
+            return glob_matches(pattern_value, files_entry)
+                || ancestor_directory_paths(files_entry)
+                    .iter()
+                    .any(|ancestor| glob_matches(pattern_value, ancestor));
+        }
+        return path_component_matches(files_entry, pattern_value);
+    }
+    if !pattern_value.contains('*') && path_starts_with(files_entry, pattern_value) {
+        return true;
+    }
+
+    glob_matches(pattern_value, files_entry)
+}
+
+fn directory_only_pattern_matches(pattern: &str, file_path: &str, anchored: bool) -> bool {
+    let ancestors = ancestor_directory_paths(file_path);
+    if anchored {
+        return ancestors
+            .iter()
+            .any(|ancestor| glob_matches(pattern, ancestor));
+    }
+    if !pattern.contains('/') {
+        return ancestors.iter().any(|ancestor| {
+            ancestor
+                .rsplit('/')
+                .next()
+                .is_some_and(|component| segment_glob_matches(pattern, component))
+        });
+    }
+
+    ancestors
+        .iter()
+        .any(|ancestor| glob_matches(pattern, ancestor))
+}
+
+fn normalize_files_entry(value: &str) -> Option<String> {
+    let normalized = value
+        .trim()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string();
+
+    if normalized.is_empty() || normalized.starts_with('!') {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+fn path_starts_with(path: &str, prefix: &str) -> bool {
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
+
+fn path_component_matches(path: &str, pattern: &str) -> bool {
+    path.split('/')
+        .any(|component| segment_glob_matches(pattern, component))
+}
+
+fn ancestor_directory_paths(path: &str) -> Vec<String> {
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    if segments.len() <= 1 {
+        return Vec::new();
+    }
+
+    let mut ancestors = Vec::new();
+    let mut current = String::new();
+    for segment in &segments[..segments.len() - 1] {
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(segment);
+        ancestors.push(current.clone());
+    }
+
+    ancestors
+}
+
+fn contains_glob(value: &str) -> bool {
+    value.contains('*') || value.contains('?')
+}
+
+fn files_entry_includes_file(pattern: &str, path: &str) -> bool {
+    if contains_glob(pattern) {
+        glob_matches(pattern, path)
+            || ancestor_directory_paths(path)
+                .iter()
+                .any(|ancestor| glob_matches(pattern, ancestor))
+    } else {
+        path_starts_with(path, pattern)
+    }
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    let pattern_segments = pattern
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    let path_segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    glob_segments_match(&pattern_segments, &path_segments)
+}
+
+fn glob_segments_match(pattern_segments: &[&str], path_segments: &[&str]) -> bool {
+    let Some((pattern_head, remaining_patterns)) = pattern_segments.split_first() else {
+        return path_segments.is_empty();
+    };
+
+    if *pattern_head == "**" {
+        if glob_segments_match(remaining_patterns, path_segments) {
+            return true;
+        }
+        return path_segments
+            .split_first()
+            .is_some_and(|(_, remaining_paths)| {
+                glob_segments_match(pattern_segments, remaining_paths)
+            });
+    }
+
+    let Some((path_head, remaining_paths)) = path_segments.split_first() else {
+        return false;
+    };
+    if !segment_glob_matches(pattern_head, path_head) {
+        return false;
+    }
+
+    glob_segments_match(remaining_patterns, remaining_paths)
+}
+
+fn segment_glob_matches(pattern: &str, value: &str) -> bool {
+    if !contains_glob(pattern) {
+        return pattern == value;
+    }
+
+    fn matches(
+        pattern_index: usize,
+        value_index: usize,
+        pattern: &[char],
+        value: &[char],
+        memo: &mut [Vec<Option<bool>>],
+    ) -> bool {
+        if let Some(result) = memo[pattern_index][value_index] {
+            return result;
+        }
+
+        let result = if pattern_index == pattern.len() {
+            value_index == value.len()
+        } else if pattern[pattern_index] == '*' {
+            (value_index..=value.len()).any(|next_value_index| {
+                matches(pattern_index + 1, next_value_index, pattern, value, memo)
+            })
+        } else if pattern[pattern_index] == '?' {
+            value_index < value.len()
+                && matches(pattern_index + 1, value_index + 1, pattern, value, memo)
+        } else {
+            value_index < value.len()
+                && pattern[pattern_index] == value[value_index]
+                && matches(pattern_index + 1, value_index + 1, pattern, value, memo)
+        };
+
+        memo[pattern_index][value_index] = Some(result);
+        result
+    }
+
+    let pattern_chars = pattern.chars().collect::<Vec<_>>();
+    let value_chars = value.chars().collect::<Vec<_>>();
+    let mut memo = vec![vec![None; value_chars.len() + 1]; pattern_chars.len() + 1];
+
+    matches(0, 0, &pattern_chars, &value_chars, &mut memo)
+}

--- a/crates/maximus-checks/src/registry.rs
+++ b/crates/maximus-checks/src/registry.rs
@@ -15,10 +15,13 @@ use serde_json::{Map, Value};
 
 use crate::check_outcome::CheckOutcome;
 use crate::editorconfig_prettier::run_editorconfig_prettier_check_with_ignore_root;
+use crate::ignore_file_drift::run_ignore_file_drift_check_with_ignore_root;
 use crate::jsx_config::run_jsx_config_check;
 use crate::lockfiles::run_lockfiles_check_with_ignore_root;
 use crate::module_system::run_module_system_check;
 use crate::monorepo_tsconfig::run_monorepo_tsconfig_check;
+use crate::node_matrix::run_node_matrix_check_with_ignore_root;
+use crate::npmignore_files::run_npmignore_files_check_with_ignore_root;
 use crate::package_entrypoints::run_package_entrypoints_check;
 use crate::test_runner_config::run_test_runner_config_check_with_ignore_root;
 use crate::vite_tsconfig_alias::run_vite_tsconfig_alias_check;
@@ -95,6 +98,18 @@ const REGISTERED_CHECKS: &[RegisteredCheck] = &[
         id: "editorconfig-prettier",
         run: run_editorconfig_prettier_check_registered,
     },
+    RegisteredCheck {
+        id: "ignore-drift",
+        run: run_ignore_file_drift_check_registered,
+    },
+    RegisteredCheck {
+        id: "node-matrix",
+        run: run_node_matrix_check_registered,
+    },
+    RegisteredCheck {
+        id: "npmignore-files",
+        run: run_npmignore_files_check_registered,
+    },
 ];
 
 pub fn registered_check_ids() -> &'static [&'static str] {
@@ -112,6 +127,9 @@ pub fn registered_check_ids() -> &'static [&'static str] {
         "workspace-config",
         "test-runner-config",
         "editorconfig-prettier",
+        "ignore-drift",
+        "node-matrix",
+        "npmignore-files",
     ]
 }
 
@@ -444,6 +462,33 @@ pub fn run_env_check_with_config_root_and_options(
     }
 
     run_env_check_with_options(project, options)
+}
+
+fn run_ignore_file_drift_check_registered(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let ignored_patterns = config.effective_ignore_patterns();
+    run_ignore_file_drift_check_with_ignore_root(project, &ignored_patterns, ignore_root)
+}
+
+fn run_node_matrix_check_registered(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let ignored_patterns = config.effective_ignore_patterns();
+    run_node_matrix_check_with_ignore_root(project, &ignored_patterns, ignore_root)
+}
+
+fn run_npmignore_files_check_registered(
+    project: &ProjectSnapshot,
+    config: &MaximusConfig,
+    ignore_root: &Path,
+) -> io::Result<CheckOutcome> {
+    let ignored_patterns = config.non_git_ignore_patterns();
+    run_npmignore_files_check_with_ignore_root(project, &ignored_patterns, ignore_root)
 }
 
 fn env_rediscovery_ignore_patterns(config: &MaximusConfig) -> Vec<String> {

--- a/crates/maximus-checks/tests/ignore_file_drift_checks.rs
+++ b/crates/maximus-checks/tests/ignore_file_drift_checks.rs
@@ -1,0 +1,155 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::{
+    audit_project, run_ignore_file_drift_check, run_registered_checks_with_config_root,
+};
+use maximus_core::{
+    discover_project, discover_project_with_ignore_root, CheckFilterConfig, MaximusConfig, Severity,
+};
+use tempfile::TempDir;
+
+#[test]
+fn ignore_file_drift_check_keeps_aligned_ignore_files_quiet() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join(".gitignore"),
+        "node_modules\ndist/\n.tmp\n*.tgz\n",
+    );
+    write(
+        fixture.path().join(".maximusignore"),
+        "node_modules/\n/dist\ntmp\n*.tgz\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_ignore_file_drift_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "aligned artifact ignore patterns should stay quiet"
+    );
+}
+
+#[test]
+fn ignore_file_drift_check_keeps_escaped_artifact_literals_quiet() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(fixture.path().join(".gitignore"), "\\!dist\n\\#coverage\n");
+    write(fixture.path().join(".maximusignore"), "");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_ignore_file_drift_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "escaped artifact-looking literals should not count as generated artifact ignores: {:?}",
+        outcome.findings
+    );
+}
+
+#[test]
+fn ignore_file_drift_check_reports_generated_artifact_patterns_missing_from_gitignore() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join(".gitignore"),
+        "node_modules\ncoverage\n",
+    );
+    write(
+        fixture.path().join(".maximusignore"),
+        "node_modules\ncoverage\ndist\n",
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_ignore_file_drift_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "ignore-drift:{}:dist:.gitignore",
+            fixture.path().to_string_lossy()
+        ),
+        Severity::Warn,
+        "Ignore files disagree on generated artifact coverage",
+        Some(fixture.path().join(".maximusignore")),
+    );
+}
+
+#[test]
+fn audit_project_runs_ignore_file_drift_check() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(fixture.path().join(".gitignore"), "node_modules\n");
+    write(
+        fixture.path().join(".maximusignore"),
+        "node_modules\ntarget\n",
+    );
+
+    let audited = audit_project(fixture.path()).expect("audit should run");
+
+    assert!(
+        audited.result.findings.iter().any(|finding| finding.id
+            == format!(
+                "ignore-drift:{}:target:.gitignore",
+                fixture.path().to_string_lossy()
+            )),
+        "registered audit path should include ignore-drift findings"
+    );
+}
+
+#[test]
+fn registered_ignore_file_drift_check_respects_config_ignore_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("fixtures/bad/.gitignore"),
+        "node_modules\n",
+    );
+    write(
+        fixture.path().join("fixtures/bad/.maximusignore"),
+        "node_modules\ndist\n",
+    );
+    let config = MaximusConfig {
+        checks: CheckFilterConfig {
+            only: vec!["ignore-drift".to_string()],
+            ..CheckFilterConfig::default()
+        },
+        ignore_patterns: vec!["fixtures/bad".to_string()],
+        ..MaximusConfig::default()
+    };
+    let ignored_patterns = config.effective_ignore_patterns();
+    let project =
+        discover_project_with_ignore_root(fixture.path(), &ignored_patterns, fixture.path())
+            .expect("project should discover");
+
+    let outcome = run_registered_checks_with_config_root(&project, &config, fixture.path())
+        .expect("registry should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "ignored ignore-file directories should not produce findings: {:?}",
+        outcome.findings
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.file, file);
+}

--- a/crates/maximus-checks/tests/node_matrix_checks.rs
+++ b/crates/maximus-checks/tests/node_matrix_checks.rs
@@ -1,0 +1,301 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::{
+    run_node_matrix_check, run_registered_checks, run_registered_checks_with_config_root,
+};
+use maximus_core::{
+    discover_project, discover_project_with_ignore_root, CheckFilterConfig, MaximusConfig, Severity,
+};
+use tempfile::TempDir;
+
+#[test]
+fn node_matrix_check_keeps_matching_engine_floor_and_actions_matrix_quiet() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [20, 22, 24]
+            steps:
+              - uses: actions/setup-node@v4
+                with:
+                  node-version: ${{ matrix.node }}
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "matrix that includes the engines.node floor should stay quiet"
+    );
+}
+
+#[test]
+fn node_matrix_check_parses_sequence_mapping_node_versions() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                include:
+                  - node: 20
+                  - node-version: 22
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "sequence mapping entries should contribute concrete Node matrix versions"
+    );
+}
+
+#[test]
+fn node_matrix_check_reports_missing_engine_floor_and_unsupported_matrix_version() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [18, 22]
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "node-matrix:{}",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Node engine support and GitHub Actions matrix are out of sync",
+        Some(fixture.path().join("package.json")),
+    );
+    let detail = &outcome.findings[0].detail;
+    assert!(detail.contains("does not include supported Node 20"));
+    assert!(detail.contains("unsupported Node 18"));
+}
+
+#[test]
+fn node_matrix_check_reports_versions_above_inclusive_upper_bound() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20 <=22" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [20, 22, 24]
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "node-matrix:{}",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Node engine support and GitHub Actions matrix are out of sync",
+        Some(fixture.path().join("package.json")),
+    );
+    assert!(outcome.findings[0].detail.contains("unsupported Node 24"));
+}
+
+#[test]
+fn node_matrix_check_reports_spaced_comparator_ranges() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">= 20 < 23" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [20, 22, 24]
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "node-matrix:{}",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "Node engine support and GitHub Actions matrix are out of sync",
+        Some(fixture.path().join("package.json")),
+    );
+    assert!(outcome.findings[0].detail.contains("unsupported Node 24"));
+}
+
+#[test]
+fn node_matrix_check_keeps_disjoint_comparator_ranges_quiet() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20 <21 || >=22 <23" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [20, 22]
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_node_matrix_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "matrix matching disjoint comparator ranges should stay quiet: {:?}",
+        outcome.findings
+    );
+}
+
+#[test]
+fn registered_node_matrix_check_respects_ignored_workflow_files() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": ">=20" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/legacy.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node: [18]
+        "#,
+    );
+    let config = MaximusConfig {
+        checks: CheckFilterConfig {
+            only: vec!["node-matrix".to_string()],
+            ..CheckFilterConfig::default()
+        },
+        ignore_patterns: vec![".github/workflows/legacy.yml".to_string()],
+        ..MaximusConfig::default()
+    };
+    let ignored_patterns = config.effective_ignore_patterns();
+    let project =
+        discover_project_with_ignore_root(fixture.path(), &ignored_patterns, fixture.path())
+            .expect("project should discover");
+
+    let outcome = run_registered_checks_with_config_root(&project, &config, fixture.path())
+        .expect("registry should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "ignored workflow files should not affect node-matrix findings: {:?}",
+        outcome.findings
+    );
+}
+
+#[test]
+fn registered_checks_include_node_matrix_findings() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "engines": { "node": "^20 || ^22" } }"#,
+    );
+    write(
+        fixture.path().join(".github/workflows/ci.yml"),
+        r#"
+        jobs:
+          test:
+            strategy:
+              matrix:
+                node:
+                  - 20
+                  - 24
+        "#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_registered_checks(&project).expect("registry should run");
+
+    assert!(
+        outcome.findings.iter().any(|finding| finding.id
+            == format!(
+                "node-matrix:{}",
+                fixture.path().join("package.json").to_string_lossy()
+            )),
+        "registry should include node-matrix findings"
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.file, file);
+}

--- a/crates/maximus-checks/tests/npmignore_files_checks.rs
+++ b/crates/maximus-checks/tests/npmignore_files_checks.rs
@@ -1,0 +1,467 @@
+use std::fs;
+use std::path::Path;
+
+use maximus_checks::{audit_project, audit_project_with_config, run_npmignore_files_check};
+use maximus_core::{discover_project, MaximusConfig, Severity};
+use tempfile::TempDir;
+
+#[test]
+fn npmignore_files_check_keeps_non_overlapping_publish_surface_quiet() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist", "README.md"] }"#,
+    );
+    write(fixture.path().join(".npmignore"), "coverage\n*.log\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "non-overlapping package files and .npmignore should stay quiet"
+    );
+}
+
+#[test]
+fn npmignore_files_check_ignores_root_npmignore_when_files_lists_directory() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join(".npmignore"), "dist/\n");
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "root .npmignore should not override package.json files entries"
+    );
+}
+
+#[test]
+fn npmignore_files_check_reports_nested_npmignore_excluding_included_file() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_expands_files_globs_before_nested_npmignore() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist/**/*.js"] }"#,
+    );
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_matches_nested_globstar_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(
+        fixture.path().join("dist/components/index.js"),
+        "export {}\n",
+    );
+    write(fixture.path().join("dist/.npmignore"), "**/*.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/components/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_respects_anchored_nested_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(
+        fixture.path().join("dist/components/index.js"),
+        "export {}\n",
+    );
+    write(fixture.path().join("dist/.npmignore"), "/index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_eq!(
+        outcome.findings.len(),
+        1,
+        "anchored nested .npmignore pattern should match only the nested ignore root"
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_matches_multi_star_segment_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/foo.test.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "*.test.*\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/foo.test.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_expands_files_globs_that_match_directories() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist/*"] }"#,
+    );
+    write(fixture.path().join("dist/foo/index.js"), "export {}\n");
+    write(fixture.path().join("dist/foo/.npmignore"), "index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/foo/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/foo/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_expands_question_mark_files_globs() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist/index.?s"] }"#,
+    );
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_matches_nested_basename_directory_patterns() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(
+        fixture.path().join("dist/components/__tests__/fixture.js"),
+        "export {}\n",
+    );
+    write(fixture.path().join("dist/.npmignore"), "__tests__\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/components/__tests__/fixture.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_does_not_match_directory_only_pattern_to_same_named_file() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/foo"), "published file\n");
+    write(fixture.path().join("dist/.npmignore"), "foo/\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "directory-only nested .npmignore pattern should not exclude a same-named file"
+    );
+}
+
+#[test]
+fn npmignore_files_check_still_matches_directory_only_pattern_contents() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/foo/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "foo/\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/foo/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_matches_anchored_basename_pattern_contents() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/foo/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "/foo\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "npmignore-files:{}:dist/foo/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn npmignore_files_check_does_not_unescape_bang_as_negation_prefix() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/secret.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "\\!secret.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "escaped bang pattern should match literal !secret.js, not secret.js"
+    );
+}
+
+#[test]
+fn npmignore_files_check_respects_later_nested_negation() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "*.js\n!index.js\n");
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_npmignore_files_check(&project).expect("check should run");
+
+    assert!(
+        outcome.findings.is_empty(),
+        "later negated nested .npmignore pattern should keep explicit files entry quiet"
+    );
+}
+
+#[test]
+fn audit_project_runs_npmignore_files_check_for_gitignored_package_files_entries() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["dist"] }"#,
+    );
+    write(fixture.path().join(".gitignore"), "dist/\n");
+    write(fixture.path().join("dist/index.js"), "export {}\n");
+    write(fixture.path().join("dist/.npmignore"), "index.js\n");
+
+    let mut config = MaximusConfig::default();
+    config.gitignore_patterns = vec!["dist/".to_string()];
+    config.checks.only = vec!["npmignore-files".to_string()];
+
+    let audited =
+        audit_project_with_config(fixture.path(), &config).expect("audit should run with config");
+
+    assert_has_finding(
+        &audited.result.findings,
+        &format!(
+            "npmignore-files:{}:dist/index.js",
+            fixture.path().join("package.json").to_string_lossy()
+        ),
+        Severity::Warn,
+        "package.json files entry is excluded by nested .npmignore",
+        Some(fixture.path().join("dist/.npmignore")),
+    );
+}
+
+#[test]
+fn audit_project_npmignore_files_check_respects_config_ignored_files_entries() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["ignored"] }"#,
+    );
+    write(fixture.path().join("ignored/index.js"), "export {}\n");
+    write(fixture.path().join("ignored/.npmignore"), "index.js\n");
+
+    let mut config = MaximusConfig::default();
+    config.ignore_patterns = vec!["ignored".to_string()];
+    config.checks.only = vec!["npmignore-files".to_string()];
+
+    let audited =
+        audit_project_with_config(fixture.path(), &config).expect("audit should run with config");
+
+    assert!(
+        audited.result.findings.is_empty(),
+        "config ignored package files entries should not produce npmignore-files findings: {:?}",
+        audited.result.findings
+    );
+}
+
+#[test]
+fn audit_project_runs_npmignore_files_check() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    write(
+        fixture.path().join("package.json"),
+        r#"{ "files": ["bin"] }"#,
+    );
+    write(fixture.path().join("bin/cli.js"), "#!/usr/bin/env node\n");
+    write(fixture.path().join("bin/.npmignore"), "cli.js\n");
+
+    let audited = audit_project(fixture.path()).expect("audit should run");
+
+    assert!(
+        audited.result.findings.iter().any(|finding| finding.id
+            == format!(
+                "npmignore-files:{}:bin/cli.js",
+                fixture.path().join("package.json").to_string_lossy()
+            )),
+        "registered audit path should include npmignore-files findings"
+    );
+}
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir should exist");
+    }
+
+    fs::write(path, content).expect("fixture file should write");
+}
+
+fn assert_has_finding(
+    findings: &[maximus_core::Finding],
+    id: &str,
+    severity: Severity,
+    title: &str,
+    file: Option<std::path::PathBuf>,
+) {
+    let finding = findings
+        .iter()
+        .find(|finding| finding.id == id)
+        .unwrap_or_else(|| panic!("missing finding {id}"));
+
+    assert_eq!(finding.severity, severity);
+    assert_eq!(finding.title, title);
+    assert_eq!(finding.file, file);
+}


### PR DESCRIPTION
## 요약
- `ignore-drift`, `node-matrix`, `npmignore-files` registered check를 추가했습니다.
- 세 check 모두 `maximus.config.json`의 effective ignore pattern과 ignore root를 통과하도록 registry wrapper에 연결했습니다.
- `node-matrix`는 engines.node와 GitHub Actions Node matrix drift를 비교하고, 공백 comparator/range set/sequence mapping 형태를 회귀 테스트로 고정했습니다.
- `npmignore-files`는 `package.json#files`와 nested `.npmignore` 충돌을 실제 publish 의미에 맞춰 점검하고, root `.npmignore` 오해와 glob/basename directory false negative를 회귀 테스트로 고정했습니다.

## 검증
- `cargo test -p maximus-checks --test node_matrix_checks`
- `cargo test -p maximus-checks --test npmignore_files_checks`
- `cargo test -p maximus-checks --test ignore_file_drift_checks`
- `cargo test -p maximus-checks`
- `rustfmt --check --config skip_children=true crates/maximus-checks/src/lib.rs crates/maximus-checks/src/registry.rs crates/maximus-checks/src/ignore_file_drift.rs crates/maximus-checks/src/node_matrix.rs crates/maximus-checks/src/npmignore_files.rs crates/maximus-checks/tests/ignore_file_drift_checks.rs crates/maximus-checks/tests/node_matrix_checks.rs crates/maximus-checks/tests/npmignore_files_checks.rs`
- `git diff --check`

## 리뷰 루프
- Devil R1: Critical 0 / High 1 / Medium 1 / Low 0. config ignore 우회와 node range parser 문제 수정.
- Devil R2: Critical 0 / High 1 / Medium 1 / Low 0. npm publish 의미와 workflow sequence mapping 문제 수정.
- Devil R3: Critical 0 / High 3 / Medium 0 / Low 0. spaced semver comparator, `files` glob, nested basename directory ignore 문제 수정.
- R3 후 검증: targeted tests/full `maximus-checks`/rustfmt/diff check 통과. `devils-advocate-review-loop`의 fresh review 3회 한도에 도달해 추가 Devil round는 실행하지 않았고, PR 생성 후 independent PR review를 별도로 실행합니다.

Closes #95
