### PR TITLE
fix(tsconfig): Next 생성 타입 include 경고 완화

### DIFF
--- a/crates/maximus-checks/src/tsconfig.rs
+++ b/crates/maximus-checks/src/tsconfig.rs
@@ -134,7 +134,13 @@ pub fn run_tsconfig_check(project: &ProjectSnapshot) -> io::Result<CheckOutcome>
 
         collect_deprecated_option_findings(&mut findings, &file.path, compiler_options);
         collect_project_reference_findings(&mut findings, &file.path, &file.dir, references)?;
-        collect_include_exclude_pattern_findings(&mut findings, &file.path, &file.dir, &config)?;
+        collect_include_exclude_pattern_findings(
+            &mut findings,
+            project,
+            &file.path,
+            &file.dir,
+            &config,
+        )?;
         collect_output_path_overlap_findings(
             &mut findings,
             &project.root_dir,
@@ -1038,12 +1044,14 @@ fn parse_type_roots_option(
 
 fn collect_include_exclude_pattern_findings(
     findings: &mut Vec<Finding>,
+    project: &ProjectSnapshot,
     file_path: &Path,
     config_dir: &Path,
     config: &Value,
 ) -> io::Result<()> {
     let base_dir = normalize_path(config_dir);
     let effective_pattern_config = resolve_effective_pattern_config(file_path, config)?;
+    let has_next_dependency = nearest_package_has_next_dependency(project, config_dir)?;
 
     for issue in &effective_pattern_config.issues {
         findings.push(make_finding(FindingInput {
@@ -1107,6 +1115,19 @@ fn collect_include_exclude_pattern_findings(
                 &default_excluded_dirs,
             )?;
             if matches.is_empty() {
+                let is_next_generated_types_pattern =
+                    has_next_dependency && is_next_generated_types_pattern(pattern);
+                let (severity, hint) = if is_next_generated_types_pattern {
+                    (
+                        Severity::Info,
+                        "Next.js generates .next/types during development or build, so this include can be empty before .next exists.",
+                    )
+                } else {
+                    (
+                        Severity::Warn,
+                        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+                    )
+                };
                 findings.push(make_finding(FindingInput {
                     id: format!(
                         "tsconfig-patterns:{}:include:{pattern}",
@@ -1121,11 +1142,8 @@ fn collect_include_exclude_pattern_findings(
                     file: Some(file_path.to_path_buf()),
                     fix_ids: Vec::new(),
                     fixable: false,
-                    hint: Some(
-                        "Fix or remove empty include patterns before TypeScript silently skips expected inputs."
-                            .to_string(),
-                    ),
-                    severity: Some(Severity::Warn),
+                    hint: Some(hint.to_string()),
+                    severity: Some(severity),
                 }));
                 continue;
             }
@@ -1191,6 +1209,41 @@ fn collect_include_exclude_pattern_findings(
     }
 
     Ok(())
+}
+
+fn nearest_package_has_next_dependency(
+    project: &ProjectSnapshot,
+    config_dir: &Path,
+) -> io::Result<bool> {
+    let Some(package_file) = find_nearest_package_file(project, config_dir) else {
+        return Ok(false);
+    };
+    let Some(package_text) = read_text_if_exists(&package_file.path)? else {
+        return Ok(false);
+    };
+    let Ok(package_json) =
+        parse_jsonc::<Value>(&package_text, &package_file.path.to_string_lossy())
+    else {
+        return Ok(false);
+    };
+
+    Ok(
+        package_has_dependency(&package_json, "dependencies", "next")
+            || package_has_dependency(&package_json, "devDependencies", "next")
+            || package_has_dependency(&package_json, "peerDependencies", "next")
+            || package_has_dependency(&package_json, "optionalDependencies", "next"),
+    )
+}
+
+fn package_has_dependency(package_json: &Value, field_name: &str, dependency_name: &str) -> bool {
+    package_json
+        .get(field_name)
+        .and_then(Value::as_object)
+        .is_some_and(|dependencies| dependencies.contains_key(dependency_name))
+}
+
+fn is_next_generated_types_pattern(pattern: &str) -> bool {
+    pattern == ".next/types/**/*.ts" || pattern == "./.next/types/**/*.ts"
 }
 
 fn collect_output_path_overlap_findings(

--- a/crates/maximus-checks/tests/tsconfig_checks.rs
+++ b/crates/maximus-checks/tests/tsconfig_checks.rs
@@ -867,7 +867,9 @@ fn tsconfig_pattern_severity_contract_keeps_noop_excludes_non_blocking() {
     );
 
     write(
-        fixture.path().join("noop-node-modules-exclude/tsconfig.json"),
+        fixture
+            .path()
+            .join("noop-node-modules-exclude/tsconfig.json"),
         r#"
         {
           "include": ["src/**/*.ts"],
@@ -942,6 +944,91 @@ fn tsconfig_pattern_severity_contract_keeps_noop_excludes_non_blocking() {
         &StructureReport {
             is_monorepo: false,
             package_count: 0,
+            env_directories: 0,
+            config_files: 1,
+            recommendations: Vec::new(),
+        },
+    );
+
+    assert_eq!(summary.status, "clean");
+    assert_eq!(summary.blocking_findings, 0);
+    assert_eq!(summary.warning_findings, 0);
+    assert_eq!(summary.info_findings, 1);
+}
+
+#[test]
+fn tsconfig_check_downgrades_missing_next_generated_types_include_for_next_packages() {
+    let fixture = TempDir::new().expect("temp dir should exist");
+    let next_hint = "Next.js generates .next/types during development or build, so this include can be empty before .next exists.";
+    let generic_hint =
+        "Fix or remove empty include patterns before TypeScript silently skips expected inputs.";
+
+    write(
+        fixture.path().join("next-app/package.json"),
+        r#"{ "devDependencies": { "next": "15.0.0" } }"#,
+    );
+    write(
+        fixture.path().join("next-app/tsconfig.json"),
+        r#"{ "include": ["./.next/types/**/*.ts"] }"#,
+    );
+
+    write(
+        fixture.path().join("plain-app/package.json"),
+        r#"{ "devDependencies": { "react": "19.0.0" } }"#,
+    );
+    write(
+        fixture.path().join("plain-app/tsconfig.json"),
+        r#"{ "include": [".next/types/**/*.ts"] }"#,
+    );
+
+    let project = discover_project(fixture.path()).expect("project should discover");
+    let outcome = run_tsconfig_check(&project).expect("check should run");
+    let next_tsconfig = fixture.path().join("next-app/tsconfig.json");
+    let plain_tsconfig = fixture.path().join("plain-app/tsconfig.json");
+
+    let next_id = format!(
+        "tsconfig-patterns:{}:include:./.next/types/**/*.ts",
+        next_tsconfig.to_string_lossy()
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &next_id,
+        Severity::Info,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \"./.next/types/**/*.ts\" matched 0 files under base dir {}.",
+            fixture.path().join("next-app").to_string_lossy()
+        ),
+        next_hint,
+        Some(next_tsconfig.clone()),
+    );
+    assert_has_finding(
+        &outcome.findings,
+        &format!(
+            "tsconfig-patterns:{}:include:.next/types/**/*.ts",
+            plain_tsconfig.to_string_lossy()
+        ),
+        Severity::Warn,
+        "Include pattern does not match any files",
+        &format!(
+            "include pattern \".next/types/**/*.ts\" matched 0 files under base dir {}.",
+            fixture.path().join("plain-app").to_string_lossy()
+        ),
+        generic_hint,
+        Some(plain_tsconfig),
+    );
+
+    let next_finding = outcome
+        .findings
+        .iter()
+        .find(|finding| finding.id == next_id)
+        .expect("Next generated types finding should exist");
+    let summary = summarize_findings(
+        std::slice::from_ref(next_finding),
+        &outcome.fixes,
+        &StructureReport {
+            is_monorepo: false,
+            package_count: 1,
             env_directories: 0,
             config_files: 1,
             recommendations: Vec::new(),

--- a/test/tsconfig-patterns-cli.test.js
+++ b/test/tsconfig-patterns-cli.test.js
@@ -488,6 +488,66 @@ test("CLI audit inherits top-level pattern fields and reports invalid pattern en
   assert.ok(invalidFilesMissing.stdout.includes("declares files[0] as src/missing.ts"));
 });
 
+test("CLI audit treats missing Next generated types include as info-only", async (t) => {
+  if (!(await shouldRunRustCliAssertions(t))) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "maximus-tsconfig-next-types-"));
+  t.after(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  await mkdir(path.join(rootDir, "next-app"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "next-app", "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "next-app", "tsconfig.json"),
+    JSON.stringify({ include: [".next/types/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+
+  await mkdir(path.join(rootDir, "plain-app"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "plain-app", "package.json"),
+    JSON.stringify({ dependencies: { react: "19.0.0" } }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "plain-app", "tsconfig.json"),
+    JSON.stringify({ include: [".next/types/**/*.ts"] }, null, 2),
+    "utf8",
+  );
+
+  const nextResult = runAudit(path.join(rootDir, "next-app"));
+  assert.equal(nextResult.status, 0, nextResult.stderr);
+  assert.ok(nextResult.stdout.includes("Include pattern does not match any files"));
+  assert.ok(nextResult.stdout.includes('include pattern ".next/types/**/*.ts" matched 0 files'));
+  assert.ok(
+    nextResult.stdout.includes("Next.js generates .next/types during development or build"),
+  );
+  assert.ok(
+    !nextResult.stdout.includes(
+      "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+    ),
+  );
+
+  const plainResult = runAudit(path.join(rootDir, "plain-app"));
+  assert.equal(plainResult.status, 1, plainResult.stderr);
+  assert.ok(plainResult.stdout.includes("Include pattern does not match any files"));
+  assert.ok(
+    plainResult.stdout.includes(
+      "Fix or remove empty include patterns before TypeScript silently skips expected inputs.",
+    ),
+  );
+  assert.ok(
+    !plainResult.stdout.includes("Next.js generates .next/types during development or build"),
+  );
+});
+
 function runAudit(target) {
   return spawnSync(process.execPath, ["./bin/maximus.js", "audit", target], {
     cwd: repoRoot,


### PR DESCRIPTION
## 배경

Next.js 프로젝트의 기본 `tsconfig.json`에는 `.next/types/**/*.ts` include가 들어갈 수 있습니다. clean checkout이나 build 전 상태에서는 `.next`가 아직 없어 Maximus가 warning을 내고 exit status를 1로 만들 수 있었습니다.

## 변경 사항

- Next 패키지의 `.next/types/**/*.ts` / `./.next/types/**/*.ts` 빈 include를 `Info`로 낮췄습니다.
- 가장 가까운 `package.json`의 `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`에서 `next` 존재 여부를 확인합니다.
- Next가 아닌 프로젝트의 동일 패턴은 기존처럼 `Warn`과 generic hint를 유지합니다.
- noop exclude의 기존 `Info` 계약은 변경하지 않았습니다.
- Rust check 테스트와 CLI 회귀 테스트를 추가했습니다.

## 검증

- `rustfmt --check crates/maximus-checks/src/tsconfig.rs crates/maximus-checks/tests/tsconfig_checks.rs`
- `cargo test -p maximus-checks --test tsconfig_checks`
- `node --test test/tsconfig-patterns-cli.test.js`
- `node --test test/reference-parity.test.js`
- `git diff --check`
- `cargo test --workspace`
- `npm test` 두 번 연속 통과

첫 `npm test` 전체 실행에서 기존 allowJs assertion이 한 번 transient 실패했지만, 같은 파일 단독 재실행과 이후 전체 `npm test` 2회가 모두 통과했습니다.

## 브랜치 / 워크트리

- branch: `codex/fix-100-next-types-info`
- worktree: `/private/tmp/maximus-pr100-next-types-info`
- base: `master`

## 이슈 연결

Closes #100
